### PR TITLE
8351569: [lworld] Revisit atomic access modes in flat var handles

### DIFF
--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -49,6 +49,7 @@ define GenerateVarHandle
     $1_ARGS += -KAtomicAdd
     $1_ARGS += -KNonPlainAccess
     $1_ARGS += -KStatic
+    $1_ARGS += -KArray
   endif
 
   ifneq ($$(findstring $$($1_InputType), Byte Short Char Int Long), )
@@ -59,6 +60,7 @@ define GenerateVarHandle
     $1_ARGS += -KBitwise
     $1_ARGS += -KNonPlainAccess
     $1_ARGS += -KStatic
+    $1_ARGS += -KArray
   endif
 
   ifneq ($$(findstring $$($1_InputType), Byte Short Char), )
@@ -69,12 +71,14 @@ define GenerateVarHandle
     $1_ARGS += -KReference
     $1_ARGS += -KNonPlainAccess
     $1_ARGS += -KStatic
+    $1_ARGS += -KArray
   endif
 
   ifeq ($$($1_InputType), NonAtomicReference)
       $1_ARGS += -KReference
       $1_ARGS += -KStatic
       $1_Type := Reference
+      $1_ARGS += -KArray
   endif
 
   ifeq ($$($1_InputType), FlatValue)

--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -40,19 +40,14 @@ VARHANDLES_SRC_DIR := $(MODULE_SRC)/share/classes/java/lang/invoke
 define GenerateVarHandle
 
   $1_Type := $2
-  $1_TypeAtomic := $2
 
   $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandle$$($1_Type)s.java
 
   $1_ARGS += -KCAS
 
-  ifneq ($$(findstring $$($1_Type), Boolean Byte Short Char Int Long Float Double Reference), )
-      $1_ARGS += -KNonPlain
-      $1_ARGS += -KStatic
-  endif
-
   ifneq ($$(findstring $$($1_Type), Byte Short Char Int Long Float Double), )
     $1_ARGS += -KAtomicAdd
+    $1_ARGS += -KNonPlainAccess
   endif
 
   ifneq ($$(findstring $$($1_Type), Boolean Byte Short Char Int Long), )
@@ -65,24 +60,35 @@ define GenerateVarHandle
 
   ifeq ($$($1_Type), Reference)
     $1_ARGS += -KReference
+    $1_ARGS += -KNonPlainAccess
+    $1_ARGS += -KCovariantArrayArg
   endif
 
-  ifeq ($$($1_Type), FlatValue)
+  ifeq ($$($1_Type), FlatAtomicValue)
     $1_ARGS += -KFlatValue
-    $1_TypeAtomic := Reference
+    $1_ARGS += -KFlatAtomicValue
+    $1_ARGS += -KNonPlainAccess
+    $1_ARGS += -KCovariantArrayArg
+  endif
+
+  ifeq ($$($1_Type), FlatNonAtomicValue)
+    $1_ARGS += -KFlatValue
+    $1_ARGS += -KFlatNonAtomicValue
   endif
 
   $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandle.java.template $(BUILD_TOOLS_JDK)
         ifeq ($$($1_Type), Reference)
 	  $$(eval $1_type := Object)
-        else ifeq ($$($1_Type), FlatValue)
+        else ifeq ($$($1_Type), FlatAtomicValue)
+	  $$(eval $1_type := Object)
+        else ifeq ($$($1_Type), FlatNonAtomicValue)
 	  $$(eval $1_type := Object)
         else
 	  $$(eval $1_type := $$$$(shell $(TR) '[:upper:]' '[:lower:]' <<< $$$$($1_Type)))
         endif
 	$$(call MakeDir, $$(@D))
 	$(RM) $$@
-	$(TOOL_SPP) -nel -K$$($1_type) -Dtype=$$($1_type) -DType=$$($1_Type) -DTypeAtomic=$$($1_TypeAtomic) \
+	$(TOOL_SPP) -nel -K$$($1_type) -Dtype=$$($1_type) -DType=$$($1_Type) \
 	    $$($1_ARGS) -i$$< -o$$@
 
   GENSRC_VARHANDLES += $$($1_FILENAME)
@@ -301,7 +307,7 @@ endef
 ################################################################################
 
 # List the types to generate source for, with capitalized first letter
-VARHANDLES_TYPES := Boolean Byte Short Char Int Long Float Double Reference FlatValue
+VARHANDLES_TYPES := Boolean Byte Short Char Int Long Float Double Reference FlatAtomicValue FlatNonAtomicValue
 $(foreach t, $(VARHANDLES_TYPES), \
   $(eval $(call GenerateVarHandle,VAR_HANDLE_$t,$t)))
 

--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -40,10 +40,16 @@ VARHANDLES_SRC_DIR := $(MODULE_SRC)/share/classes/java/lang/invoke
 define GenerateVarHandle
 
   $1_Type := $2
+  $1_TypeAtomic := $2
 
   $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandle$$($1_Type)s.java
 
   $1_ARGS += -KCAS
+
+  ifneq ($$(findstring $$($1_Type), Boolean Byte Short Char Int Long Float Double Reference), )
+      $1_ARGS += -KNonPlain
+      $1_ARGS += -KStatic
+  endif
 
   ifneq ($$(findstring $$($1_Type), Byte Short Char Int Long Float Double), )
     $1_ARGS += -KAtomicAdd
@@ -63,6 +69,7 @@ define GenerateVarHandle
 
   ifeq ($$($1_Type), FlatValue)
     $1_ARGS += -KFlatValue
+    $1_TypeAtomic := Reference
   endif
 
   $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandle.java.template $(BUILD_TOOLS_JDK)
@@ -75,7 +82,7 @@ define GenerateVarHandle
         endif
 	$$(call MakeDir, $$(@D))
 	$(RM) $$@
-	$(TOOL_SPP) -nel -K$$($1_type) -Dtype=$$($1_type) -DType=$$($1_Type) \
+	$(TOOL_SPP) -nel -K$$($1_type) -Dtype=$$($1_type) -DType=$$($1_Type) -DTypeAtomic=$$($1_TypeAtomic) \
 	    $$($1_ARGS) -i$$< -o$$@
 
   GENSRC_VARHANDLES += $$($1_FILENAME)

--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -39,56 +39,73 @@ VARHANDLES_SRC_DIR := $(MODULE_SRC)/share/classes/java/lang/invoke
 # Param 2 - Type with first letter capitalized
 define GenerateVarHandle
 
-  $1_Type := $2
+  $1_InputType := $2
 
-  $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandle$$($1_Type)s.java
+  $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandle$$($1_InputType)s.java
 
   $1_ARGS += -KCAS
 
-  ifneq ($$(findstring $$($1_Type), Byte Short Char Int Long Float Double), )
+  ifneq ($$(findstring $$($1_InputType), Byte Short Char Int Long Float Double), )
     $1_ARGS += -KAtomicAdd
     $1_ARGS += -KNonPlainAccess
+    $1_ARGS += -KStatic
   endif
 
-  ifneq ($$(findstring $$($1_Type), Boolean Byte Short Char Int Long), )
+  ifneq ($$(findstring $$($1_InputType), Byte Short Char Int Long), )
     $1_ARGS += -KBitwise
   endif
 
-  ifneq ($$(findstring $$($1_Type), Byte Short Char), )
+  ifeq ($$($1_InputType), Boolean)
+    $1_ARGS += -KBitwise
+    $1_ARGS += -KNonPlainAccess
+    $1_ARGS += -KStatic
+  endif
+
+  ifneq ($$(findstring $$($1_InputType), Byte Short Char), )
     $1_ARGS += -KShorterThanInt
   endif
 
-  ifeq ($$($1_Type), Reference)
+  ifeq ($$($1_InputType), Reference)
     $1_ARGS += -KReference
     $1_ARGS += -KNonPlainAccess
-    $1_ARGS += -KCovariantArrayArg
+    $1_ARGS += -KStatic
   endif
 
-  ifeq ($$($1_Type), FlatAtomicValue)
+  ifeq ($$($1_InputType), NonAtomicReference)
+      $1_ARGS += -KReference
+      $1_ARGS += -KStatic
+      $1_Type := Reference
+  endif
+
+  ifeq ($$($1_InputType), FlatValue)
     $1_ARGS += -KFlatValue
-    $1_ARGS += -KFlatAtomicValue
     $1_ARGS += -KNonPlainAccess
-    $1_ARGS += -KCovariantArrayArg
   endif
 
-  ifeq ($$($1_Type), FlatNonAtomicValue)
+  ifeq ($$($1_InputType), NonAtomicFlatValue)
     $1_ARGS += -KFlatValue
-    $1_ARGS += -KFlatNonAtomicValue
   endif
 
   $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandle.java.template $(BUILD_TOOLS_JDK)
-        ifeq ($$($1_Type), Reference)
+        ifeq ($$($1_InputType), Reference)
 	  $$(eval $1_type := Object)
-        else ifeq ($$($1_Type), FlatAtomicValue)
+	  $$(eval $1_Type := Reference)
+        else ifeq ($$($1_InputType), NonAtomicReference)
 	  $$(eval $1_type := Object)
-        else ifeq ($$($1_Type), FlatNonAtomicValue)
+	  $$(eval $1_Type := Reference)
+        else ifeq ($$($1_InputType), FlatValue)
 	  $$(eval $1_type := Object)
+	  $$(eval $1_Type := FlatValue)
+        else ifeq ($$($1_InputType), NonAtomicFlatValue)
+	  $$(eval $1_type := Object)
+	  $$(eval $1_Type := FlatValue)
         else
-	  $$(eval $1_type := $$$$(shell $(TR) '[:upper:]' '[:lower:]' <<< $$$$($1_Type)))
+	  $$(eval $1_type := $$$$(shell $(TR) '[:upper:]' '[:lower:]' <<< $$$$($1_InputType)))
+	  $$(eval $1_Type := $$$$($1_InputType))
         endif
 	$$(call MakeDir, $$(@D))
 	$(RM) $$@
-	$(TOOL_SPP) -nel -K$$($1_type) -Dtype=$$($1_type) -DType=$$($1_Type) \
+	$(TOOL_SPP) -nel -K$$($1_type) -Dtype=$$($1_type) -DType=$$($1_Type) -DInputType=$$($1_InputType) \
 	    $$($1_ARGS) -i$$< -o$$@
 
   GENSRC_VARHANDLES += $$($1_FILENAME)
@@ -307,7 +324,7 @@ endef
 ################################################################################
 
 # List the types to generate source for, with capitalized first letter
-VARHANDLES_TYPES := Boolean Byte Short Char Int Long Float Double Reference FlatAtomicValue FlatNonAtomicValue
+VARHANDLES_TYPES := Boolean Byte Short Char Int Long Float Double Reference FlatValue NonAtomicReference NonAtomicFlatValue
 $(foreach t, $(VARHANDLES_TYPES), \
   $(eval $(call GenerateVarHandle,VAR_HANDLE_$t,$t)))
 

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -507,8 +507,7 @@ public abstract sealed class VarHandle implements Constable
              VarHandleShorts.FieldInstanceReadOnly,
              VarHandleShorts.FieldStaticReadOnly,
              VarHandleFlatValues.Array,
-             VarHandleFlatValues.FieldInstanceReadOnly,
-             VarHandleFlatValues.FieldStaticReadOnly {
+             VarHandleFlatValues.FieldInstanceReadOnly {
     final VarForm vform;
     final boolean exact;
 

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -506,12 +506,10 @@ public abstract sealed class VarHandle implements Constable
              VarHandleShorts.Array,
              VarHandleShorts.FieldInstanceReadOnly,
              VarHandleShorts.FieldStaticReadOnly,
-             VarHandleFlatValues.Array,
              VarHandleFlatValues.FieldInstanceReadOnly,
              VarHandleNonAtomicReferences.Array,
              VarHandleNonAtomicReferences.FieldInstanceReadOnly,
              VarHandleNonAtomicReferences.FieldStaticReadOnly,
-             VarHandleNonAtomicFlatValues.Array,
              VarHandleNonAtomicFlatValues.FieldInstanceReadOnly {
     final VarForm vform;
     final boolean exact;

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -506,8 +506,12 @@ public abstract sealed class VarHandle implements Constable
              VarHandleShorts.Array,
              VarHandleShorts.FieldInstanceReadOnly,
              VarHandleShorts.FieldStaticReadOnly,
-             VarHandleFlatValues.Array,
-             VarHandleFlatValues.FieldInstanceReadOnly {
+             VarHandleFlatAtomicValues.Array,
+             VarHandleFlatAtomicValues.FieldInstanceReadOnly,
+             VarHandleFlatAtomicValues.FieldStaticReadOnly,
+             VarHandleFlatNonAtomicValues.Array,
+             VarHandleFlatNonAtomicValues.FieldInstanceReadOnly,
+             VarHandleFlatNonAtomicValues.FieldStaticReadOnly {
     final VarForm vform;
     final boolean exact;
 

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -506,12 +506,13 @@ public abstract sealed class VarHandle implements Constable
              VarHandleShorts.Array,
              VarHandleShorts.FieldInstanceReadOnly,
              VarHandleShorts.FieldStaticReadOnly,
-             VarHandleFlatAtomicValues.Array,
-             VarHandleFlatAtomicValues.FieldInstanceReadOnly,
-             VarHandleFlatAtomicValues.FieldStaticReadOnly,
-             VarHandleFlatNonAtomicValues.Array,
-             VarHandleFlatNonAtomicValues.FieldInstanceReadOnly,
-             VarHandleFlatNonAtomicValues.FieldStaticReadOnly {
+             VarHandleFlatValues.Array,
+             VarHandleFlatValues.FieldInstanceReadOnly,
+             VarHandleNonAtomicReferences.Array,
+             VarHandleNonAtomicReferences.FieldInstanceReadOnly,
+             VarHandleNonAtomicReferences.FieldStaticReadOnly,
+             VarHandleNonAtomicFlatValues.Array,
+             VarHandleNonAtomicFlatValues.FieldInstanceReadOnly {
     final VarForm vform;
     final boolean exact;
 

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -119,17 +119,9 @@ final class VarHandles {
         long foffset = MethodHandleNatives.staticFieldOffset(f);
         Class<?> type = f.getFieldType();
         if (!type.isPrimitive()) {
-            if (f.isFlat()) {
-                assert false : ("static field is flat in " + decl + "." + f.getName());
-                int layout = f.getLayout();
-                return f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleFlatValues.FieldStaticReadOnly(decl, base, foffset, type, f.getCheckedFieldType(), layout)
-                        : new VarHandleFlatValues.FieldStaticReadWrite(decl, base, foffset, type, f.getCheckedFieldType(), layout);
-            } else {
-                return f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.getCheckedFieldType())
-                        : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.getCheckedFieldType());
-            }
+            return f.isFinal() && !isWriteAllowedOnFinalFields
+                    ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.getCheckedFieldType())
+                    : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.getCheckedFieldType());
         }
         else if (type == boolean.class) {
             return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -119,6 +119,7 @@ final class VarHandles {
         long foffset = MethodHandleNatives.staticFieldOffset(f);
         Class<?> type = f.getFieldType();
         if (!type.isPrimitive()) {
+            assert !f.isFlat() : ("static field is flat in " + decl + "." + f.getName());
             return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.getCheckedFieldType())
                     : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.getCheckedFieldType());

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -211,7 +211,7 @@ final class VarHandles {
         return hasAtomicAccess && !HAS_OOPS.get(field.getFieldType());
     }
 
-    static boolean isAtomicFlat(Object array) {
+    static boolean isAtomicFlat(Object[] array) {
         Class<?> componentType = array.getClass().componentType();
         boolean hasAtomicAccess = ValueClass.isAtomicArray(array) ||
                 !ValueClass.isNullRestrictedArray(array) ||
@@ -265,7 +265,7 @@ final class VarHandles {
     }
 
     // This is invoked by non-flat array var handle code when attempting to access a flat array
-    public static void checkAtomicFlatArray(Object array) {
+    public static void checkAtomicFlatArray(Object[] array) {
         if (!isAtomicFlat(array)) {
             throw new IllegalArgumentException("Attempt to perform a non-plain access on a non-atomic array");
         }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -820,6 +820,7 @@ final class VarHandle$InputType$s {
     }
 #end[Static]    
 
+#if[Array]
     static final class Array extends VarHandle {
         final int abase;
         final int ashift;
@@ -932,13 +933,18 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.getVolatile(oarray, index);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.getFlatValueVolatile(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType());
             }
 #end[Reference]
             return UNSAFE.get$Type$Volatile(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase);
         }
 
         @ForceInline
@@ -952,9 +958,15 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                vh.setVolatile(oarray, index, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                UNSAFE.putFlatValueVolatile(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         runtimeTypeCheck(handle, array, value));
                 return;
             }
 #end[Reference]
@@ -974,9 +986,14 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.getOpaque(oarray, index);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.getFlatValueOpaque(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType());
             }
 #end[Reference]
             return UNSAFE.get$Type$Opaque(array,
@@ -994,9 +1011,15 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                vh.setOpaque(oarray, index, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                UNSAFE.putFlatValueOpaque(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         runtimeTypeCheck(handle, array, value));
                 return;
             }
 #end[Reference]
@@ -1016,9 +1039,14 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.getAcquire(oarray, index);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.getFlatValueAcquire(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType());
             }
 #end[Reference]
             return UNSAFE.get$Type$Acquire(array,
@@ -1036,9 +1064,15 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                vh.setRelease(oarray, index, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                UNSAFE.putFlatValueRelease(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         runtimeTypeCheck(handle, array, value));
                 return;
             }
 #end[Reference]
@@ -1059,9 +1093,16 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.compareAndSet(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.compareAndSetFlatValue(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.compareAndSet$Type$(array,
@@ -1081,9 +1122,16 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.compareAndExchange(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.compareAndExchangeFlatValue(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.compareAndExchange$Type$(array,
@@ -1103,9 +1151,16 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.compareAndExchangeAcquire(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.compareAndExchangeFlatValueAcquire(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.compareAndExchange$Type$Acquire(array,
@@ -1125,13 +1180,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.compareAndExchangeRelease(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.compareAndExchangeFlatValueRelease(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.compareAndExchange$Type$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1147,13 +1209,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.weakCompareAndSetPlain(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.weakCompareAndSetFlatValuePlain(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Plain(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1169,13 +1238,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.weakCompareAndSet(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.weakCompareAndSetFlatValue(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1191,13 +1267,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.weakCompareAndSetAcquire(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.weakCompareAndSetFlatValueAcquire(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1213,13 +1296,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.weakCompareAndSetRelease(oarray, index, expected, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.weakCompareAndSetFlatValueRelease(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         arrayType.componentType().cast(expected),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1235,14 +1325,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.getAndSet(oarray, index, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.getAndSetFlatValue(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.getAndSet$Type$(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
+                    {#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
         }
 
         @ForceInline
@@ -1256,14 +1352,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.getAndSetAcquire(oarray, index, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.getAndSetFlatValueAcquire(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.getAndSet$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
+                    {#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
         }
 
         @ForceInline
@@ -1277,14 +1379,20 @@ final class VarHandle$InputType$s {
 #if[Reference]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
-                return vh.getAndSetRelease(oarray, index, value);
+                // delegate to flat access primitives
+                VarHandles.checkAtomicFlatArray(oarray);
+                int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
+                int ascale = UNSAFE.arrayIndexScale(arrayType);
+                int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+                int layout = UNSAFE.arrayLayout(arrayType);
+                return UNSAFE.getAndSetFlatValueRelease(array,
+                        (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << ashift) + aoffset, layout, arrayType.componentType(),
+                         runtimeTypeCheck(handle, array, value));
             }
 #end[Reference]
             return UNSAFE.getAndSet$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
+                    {#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
         }
 #end[CAS]
 #if[AtomicAdd]
@@ -1403,4 +1511,5 @@ final class VarHandle$InputType$s {
 
         static final VarForm FORM = new VarForm(Array.class, {#if[Object]?Object[].class:$type$[].class}, {#if[Object]?Object.class:$type$.class}, int.class);
     }
+#end[Array]
 }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -934,7 +934,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -959,7 +959,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -987,7 +987,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1012,7 +1012,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1040,7 +1040,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1065,7 +1065,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1094,7 +1094,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1123,7 +1123,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1152,7 +1152,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1181,7 +1181,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1210,7 +1210,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1239,7 +1239,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1268,7 +1268,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1297,7 +1297,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1326,7 +1326,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1353,7 +1353,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
@@ -1380,7 +1380,7 @@ final class VarHandle$InputType$s {
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to flat access primitives
-                VarHandles.checkAtomicFlatArray(oarray);
+                VarHandles.checkAtomicFlatArray(array);
                 int aoffset = (int) UNSAFE.arrayBaseOffset(arrayType);
                 int ascale = UNSAFE.arrayIndexScale(arrayType);
                 int ashift = 31 - Integer.numberOfLeadingZeros(ascale);

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -33,6 +33,7 @@ import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.lang.invoke.VarHandle.VarHandleDesc;
+import java.lang.reflect.Field;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -116,7 +117,7 @@ final class VarHandle$Type$s {
             return value;
         }
 
-#if[NonPlain]
+#if[NonPlainAccess]
         @ForceInline
         static $type$ getVolatile(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
@@ -155,7 +156,7 @@ final class VarHandle$Type$s {
 #end[Reference]
             return value;
         }
-#end[NonPlain]
+#end[NonPlainAccess]
 
         static final VarForm FORM = new VarForm(FieldInstanceReadOnly.class, Object.class, $type$.class);
     }
@@ -199,7 +200,7 @@ final class VarHandle$Type$s {
                              {#if[Object]?checkCast(handle, value):value});
         }
 
-#if[NonPlain]
+#if[NonPlainAccess]
         @ForceInline
         static void setVolatile(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -301,7 +302,7 @@ final class VarHandle$Type$s {
         static $type$ getAndSet(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
-                                          handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
+                                          handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -309,7 +310,7 @@ final class VarHandle$Type$s {
         static $type$ getAndSetAcquire(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndSet$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
-                                          handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
+                                          handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -317,7 +318,7 @@ final class VarHandle$Type$s {
         static $type$ getAndSetRelease(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndSet$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
-                                          handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
+                                          handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
         }
 #end[CAS]
@@ -422,12 +423,11 @@ final class VarHandle$Type$s {
                                        value);
         }
 #end[Bitwise]
-#end[NonPlain]
+#end[NonPlainAccess]
 
         static final VarForm FORM = new VarForm(FieldInstanceReadWrite.class, Object.class, $type$.class);
     }
 
-#if[Static]
     static sealed class FieldStaticReadOnly extends VarHandle {
         final Class<?> declaringClass;
         final Object base;
@@ -437,7 +437,7 @@ final class VarHandle$Type$s {
         final CheckedType checkedFieldType;
 #end[Object]
 #if[FlatValue]
-        final int layout;
+        final int layout;        
 #end[FlatValue]
 
         FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType}{#if[FlatValue]?, int layout}) {
@@ -506,7 +506,7 @@ final class VarHandle$Type$s {
             return value;
         }
 
-#if[NonPlain]
+#if[NonPlainAccess]
         @ForceInline
         static $type$ getVolatile(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
@@ -545,7 +545,7 @@ final class VarHandle$Type$s {
 #end[Reference]
             return value;
         }
-#end[NonPlain]
+#end[NonPlainAccess]
 
         static final VarForm FORM = new VarForm(FieldStaticReadOnly.class, null, $type$.class);
     }
@@ -590,7 +590,7 @@ final class VarHandle$Type$s {
                              {#if[Object]?checkCast(handle, value):value});
         }
 
-#if[NonPlain]
+#if[NonPlainAccess]
         @ForceInline
         static void setVolatile(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
@@ -693,7 +693,7 @@ final class VarHandle$Type$s {
         static $type$ getAndSet(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
             return UNSAFE.getAndSet$Type$(handle.base,
-                                          handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
+                                          handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -701,7 +701,7 @@ final class VarHandle$Type$s {
         static $type$ getAndSetAcquire(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
             return UNSAFE.getAndSet$Type$Acquire(handle.base,
-                                          handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
+                                          handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -709,7 +709,7 @@ final class VarHandle$Type$s {
         static $type$ getAndSetRelease(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
             return UNSAFE.getAndSet$Type$Release(handle.base,
-                                          handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
+                                          handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
         }
 #end[CAS]
@@ -813,11 +813,10 @@ final class VarHandle$Type$s {
                                        value);
         }
 #end[Bitwise]
-#end[NonPlain]
+#end[NonPlainAccess]
 
         static final VarForm FORM = new VarForm(FieldStaticReadWrite.class, null, $type$.class);
     }
-#end[Static]
 
     static final class Array extends VarHandle {
         final int abase;
@@ -895,13 +894,6 @@ final class VarHandle$Type$s {
                 throw new ArrayStoreException();
             }
         }
-
-        @ForceInline
-        static void checkNonFlat(Object[] oarray) {
-            if (ValueClass.isFlatArray(oarray)) {
-                throw new IllegalArgumentException("Non-plain access mode not supported on flat arrays");
-            }
-        }
 #end[Object]
 
         @ForceInline
@@ -923,18 +915,10 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
-            Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
-                // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
-                vh.set(oarray, index, value);
-                return;
-            }
-#end[Reference]
             array[index] = {#if[Object]?runtimeTypeCheck(handle, array, value):value};
         }
 
+#if[NonPlainAccess]
         @ForceInline
         static $type$ getVolatile(VarHandle ob, Object oarray, int index) {
             Array handle = (Array)ob;
@@ -943,19 +927,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.getVolatile(oarray, index);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.get$TypeAtomic$Volatile(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase);
+#end[CovariantArrayArg]
+            return UNSAFE.get$Type$Volatile(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
         }
 
         @ForceInline
@@ -966,21 +947,18 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 vh.setVolatile(oarray, index, value);
                 return;
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            UNSAFE.put$TypeAtomic$Volatile(array,
+#end[CovariantArrayArg]
+            UNSAFE.put$Type$Volatile(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+                    {#if[FlatValue]?handle.layout, handle.componentType, }{#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
         @ForceInline
@@ -991,19 +969,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.getOpaque(oarray, index);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.get$TypeAtomic$Opaque(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase);
+#end[CovariantArrayArg]
+            return UNSAFE.get$Type$Opaque(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
         }
 
         @ForceInline
@@ -1014,21 +989,18 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 vh.setOpaque(oarray, index, value);
                 return;
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            UNSAFE.put$TypeAtomic$Opaque(array,
+#end[CovariantArrayArg]
+            UNSAFE.put$Type$Opaque(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+                    {#if[FlatValue]?handle.layout, handle.componentType, }{#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
         @ForceInline
@@ -1039,19 +1011,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.getAcquire(oarray, index);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.get$TypeAtomic$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase);
+#end[CovariantArrayArg]
+            return UNSAFE.get$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
         }
 
         @ForceInline
@@ -1062,21 +1031,18 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 vh.setRelease(oarray, index, value);
                 return;
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            UNSAFE.put$TypeAtomic$Release(array,
+#end[CovariantArrayArg]
+            UNSAFE.put$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+                    {#if[FlatValue]?handle.layout, handle.componentType, }{#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 #if[CAS]
 
@@ -1088,19 +1054,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.compareAndSet(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.compareAndSet$TypeAtomic$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.compareAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1113,19 +1076,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.compareAndExchange(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.compareAndExchange$TypeAtomic$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.compareAndExchange$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1138,19 +1098,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.compareAndExchangeAcquire(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.compareAndExchange$TypeAtomic$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.compareAndExchange$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1163,19 +1120,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.compareAndExchangeRelease(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.compareAndExchange$TypeAtomic$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.compareAndExchange$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1188,19 +1142,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.weakCompareAndSetPlain(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.weakCompareAndSet$TypeAtomic$Plain(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.weakCompareAndSet$Type$Plain(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1213,19 +1164,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.weakCompareAndSet(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.weakCompareAndSet$TypeAtomic$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.weakCompareAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1238,19 +1186,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.weakCompareAndSetAcquire(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.weakCompareAndSet$TypeAtomic$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.weakCompareAndSet$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1263,19 +1208,16 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.weakCompareAndSetRelease(oarray, index, expected, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.weakCompareAndSet$TypeAtomic$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
+#end[CovariantArrayArg]
+            return UNSAFE.weakCompareAndSet$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1288,20 +1230,17 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.getAndSet(oarray, index, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.getAndSet$TypeAtomic$(array,
+#end[CovariantArrayArg]
+            return UNSAFE.getAndSet$Type$(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+                    {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
         }
 
         @ForceInline
@@ -1312,20 +1251,17 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.getAndSetAcquire(oarray, index, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.getAndSet$TypeAtomic$Acquire(array,
+#end[CovariantArrayArg]
+            return UNSAFE.getAndSet$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+                    {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
         }
 
         @ForceInline
@@ -1336,20 +1272,17 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[Reference]
+#if[CovariantArrayArg]
             Class<?> arrayType = oarray.getClass();
             if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
                 return vh.getAndSetRelease(oarray, index, value);
             }
-#end[Reference]
-#if[FlatValue]
-            checkNonFlat(array);
-#end[FlatValue]
-            return UNSAFE.getAndSet$TypeAtomic$Release(array,
+#end[CovariantArrayArg]
+            return UNSAFE.getAndSet$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
-                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+                    {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
         }
 #end[CAS]
 #if[AtomicAdd]
@@ -1464,17 +1397,15 @@ final class VarHandle$Type$s {
                                        value);
         }
 #end[Bitwise]
+#end[NonPlainAccess]
+
         static final VarForm FORM = new VarForm(Array.class, {#if[Object]?Object[].class:$type$[].class}, {#if[Object]?Object.class:$type$.class}, int.class);
     }
 #if[FlatValue]
-    static final ClassValue<Array> flatArrayVarHandles = new ClassValue<>() {
-        @Override protected Array computeValue(Class<?> arrayClass) {
+    static final ClassValue<VarHandle> flatArrayVarHandles = new ClassValue<>() {
+        @Override protected VarHandle computeValue(Class<?> arrayClass) {
             assert UNSAFE.isFlatArray(arrayClass);
-            int aoffset = (int) UNSAFE.arrayBaseOffset(arrayClass);
-            int ascale = UNSAFE.arrayIndexScale(arrayClass);
-            int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
-            int layout = UNSAFE.arrayLayout(arrayClass);
-            return new Array(aoffset, ashift, arrayClass, layout);
+            return VarHandles.makeArrayElementHandle(arrayClass);
         }
     };
     static VarHandle flatArrayVarHandle(Class<?> arrayClass) {

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -438,7 +438,7 @@ final class VarHandle$InputType$s {
         final CheckedType checkedFieldType;
 #end[Object]
 #if[FlatValue]
-        final int layout;        
+        final int layout;
 #end[FlatValue]
 
         FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType}{#if[FlatValue]?, int layout}) {

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -116,6 +116,7 @@ final class VarHandle$Type$s {
             return value;
         }
 
+#if[NonPlain]
         @ForceInline
         static $type$ getVolatile(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
@@ -154,6 +155,7 @@ final class VarHandle$Type$s {
 #end[Reference]
             return value;
         }
+#end[NonPlain]
 
         static final VarForm FORM = new VarForm(FieldInstanceReadOnly.class, Object.class, $type$.class);
     }
@@ -197,6 +199,7 @@ final class VarHandle$Type$s {
                              {#if[Object]?checkCast(handle, value):value});
         }
 
+#if[NonPlain]
         @ForceInline
         static void setVolatile(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -419,11 +422,12 @@ final class VarHandle$Type$s {
                                        value);
         }
 #end[Bitwise]
+#end[NonPlain]
 
         static final VarForm FORM = new VarForm(FieldInstanceReadWrite.class, Object.class, $type$.class);
     }
 
-
+#if[Static]
     static sealed class FieldStaticReadOnly extends VarHandle {
         final Class<?> declaringClass;
         final Object base;
@@ -502,6 +506,7 @@ final class VarHandle$Type$s {
             return value;
         }
 
+#if[NonPlain]
         @ForceInline
         static $type$ getVolatile(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
@@ -540,6 +545,7 @@ final class VarHandle$Type$s {
 #end[Reference]
             return value;
         }
+#end[NonPlain]
 
         static final VarForm FORM = new VarForm(FieldStaticReadOnly.class, null, $type$.class);
     }
@@ -584,6 +590,7 @@ final class VarHandle$Type$s {
                              {#if[Object]?checkCast(handle, value):value});
         }
 
+#if[NonPlain]
         @ForceInline
         static void setVolatile(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
@@ -806,9 +813,11 @@ final class VarHandle$Type$s {
                                        value);
         }
 #end[Bitwise]
+#end[NonPlain]
 
         static final VarForm FORM = new VarForm(FieldStaticReadWrite.class, null, $type$.class);
     }
+#end[Static]
 
     static final class Array extends VarHandle {
         final int abase;
@@ -886,6 +895,13 @@ final class VarHandle$Type$s {
                 throw new ArrayStoreException();
             }
         }
+
+        @ForceInline
+        static void checkNonFlat(Object[] oarray) {
+            if (ValueClass.isFlatArray(oarray)) {
+                throw new IllegalArgumentException("Non-plain access mode not supported on flat arrays");
+            }
+        }
 #end[Object]
 
         @ForceInline
@@ -935,8 +951,11 @@ final class VarHandle$Type$s {
                 return vh.getVolatile(oarray, index);
             }
 #end[Reference]
-            return UNSAFE.get$Type$Volatile(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.get$TypeAtomic$Volatile(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase);
         }
 
         @ForceInline
@@ -956,8 +975,11 @@ final class VarHandle$Type$s {
                 return;
             }
 #end[Reference]
-            UNSAFE.put$Type$Volatile(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            UNSAFE.put$TypeAtomic$Volatile(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
@@ -977,8 +999,11 @@ final class VarHandle$Type$s {
                 return vh.getOpaque(oarray, index);
             }
 #end[Reference]
-            return UNSAFE.get$Type$Opaque(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.get$TypeAtomic$Opaque(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase);
         }
 
         @ForceInline
@@ -998,8 +1023,11 @@ final class VarHandle$Type$s {
                 return;
             }
 #end[Reference]
-            UNSAFE.put$Type$Opaque(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            UNSAFE.put$TypeAtomic$Opaque(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
@@ -1019,8 +1047,11 @@ final class VarHandle$Type$s {
                 return vh.getAcquire(oarray, index);
             }
 #end[Reference]
-            return UNSAFE.get$Type$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.get$TypeAtomic$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase);
         }
 
         @ForceInline
@@ -1040,8 +1071,11 @@ final class VarHandle$Type$s {
                 return;
             }
 #end[Reference]
-            UNSAFE.put$Type$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            UNSAFE.put$TypeAtomic$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 #if[CAS]
@@ -1062,8 +1096,11 @@ final class VarHandle$Type$s {
                 return vh.compareAndSet(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.compareAndSet$Type$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.compareAndSet$TypeAtomic$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1084,8 +1121,11 @@ final class VarHandle$Type$s {
                 return vh.compareAndExchange(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.compareAndExchange$Type$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.compareAndExchange$TypeAtomic$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1106,8 +1146,11 @@ final class VarHandle$Type$s {
                 return vh.compareAndExchangeAcquire(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.compareAndExchange$Type$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.compareAndExchange$TypeAtomic$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1128,8 +1171,11 @@ final class VarHandle$Type$s {
                 return vh.compareAndExchangeRelease(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.compareAndExchange$Type$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.compareAndExchange$TypeAtomic$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1150,8 +1196,11 @@ final class VarHandle$Type$s {
                 return vh.weakCompareAndSetPlain(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.weakCompareAndSet$Type$Plain(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.weakCompareAndSet$TypeAtomic$Plain(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1172,8 +1221,11 @@ final class VarHandle$Type$s {
                 return vh.weakCompareAndSet(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.weakCompareAndSet$Type$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.weakCompareAndSet$TypeAtomic$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1194,8 +1246,11 @@ final class VarHandle$Type$s {
                 return vh.weakCompareAndSetAcquire(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.weakCompareAndSet$Type$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.weakCompareAndSet$TypeAtomic$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1216,8 +1271,11 @@ final class VarHandle$Type$s {
                 return vh.weakCompareAndSetRelease(oarray, index, expected, value);
             }
 #end[Reference]
-            return UNSAFE.weakCompareAndSet$Type$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.weakCompareAndSet$TypeAtomic$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
@@ -1238,8 +1296,11 @@ final class VarHandle$Type$s {
                 return vh.getAndSet(oarray, index, value);
             }
 #end[Reference]
-            return UNSAFE.getAndSet$Type$(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.getAndSet$TypeAtomic$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
@@ -1259,8 +1320,11 @@ final class VarHandle$Type$s {
                 return vh.getAndSetAcquire(oarray, index, value);
             }
 #end[Reference]
-            return UNSAFE.getAndSet$Type$Acquire(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.getAndSet$TypeAtomic$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
@@ -1280,8 +1344,11 @@ final class VarHandle$Type$s {
                 return vh.getAndSetRelease(oarray, index, value);
             }
 #end[Reference]
-            return UNSAFE.getAndSet$Type$Release(array,
-                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType},
+#if[FlatValue]
+            checkNonFlat(array);
+#end[FlatValue]
+            return UNSAFE.getAndSet$TypeAtomic$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 #end[CAS]

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -41,7 +41,7 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
 
-final class VarHandle$Type$s {
+final class VarHandle$InputType$s {
 
     static sealed class FieldInstanceReadOnly extends VarHandle {
         final long fieldOffset;
@@ -428,6 +428,7 @@ final class VarHandle$Type$s {
         static final VarForm FORM = new VarForm(FieldInstanceReadWrite.class, Object.class, $type$.class);
     }
 
+#if[Static]
     static sealed class FieldStaticReadOnly extends VarHandle {
         final Class<?> declaringClass;
         final Object base;
@@ -817,6 +818,7 @@ final class VarHandle$Type$s {
 
         static final VarForm FORM = new VarForm(FieldStaticReadWrite.class, null, $type$.class);
     }
+#end[Static]    
 
     static final class Array extends VarHandle {
         final int abase;
@@ -927,14 +929,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.getVolatile(oarray, index);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.get$Type$Volatile(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
         }
@@ -947,15 +949,15 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 vh.setVolatile(oarray, index, value);
                 return;
             }
-#end[CovariantArrayArg]
+#end[Reference]
             UNSAFE.put$Type$Volatile(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[FlatValue]?handle.layout, handle.componentType, }{#if[Object]?runtimeTypeCheck(handle, array, value):value});
@@ -969,14 +971,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.getOpaque(oarray, index);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.get$Type$Opaque(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
         }
@@ -989,15 +991,15 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 vh.setOpaque(oarray, index, value);
                 return;
             }
-#end[CovariantArrayArg]
+#end[Reference]
             UNSAFE.put$Type$Opaque(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[FlatValue]?handle.layout, handle.componentType, }{#if[Object]?runtimeTypeCheck(handle, array, value):value});
@@ -1011,14 +1013,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.getAcquire(oarray, index);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.get$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout, handle.componentType});
         }
@@ -1031,15 +1033,15 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 vh.setRelease(oarray, index, value);
                 return;
             }
-#end[CovariantArrayArg]
+#end[Reference]
             UNSAFE.put$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[FlatValue]?handle.layout, handle.componentType, }{#if[Object]?runtimeTypeCheck(handle, array, value):value});
@@ -1054,14 +1056,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.compareAndSet(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.compareAndSet$Type$(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1076,14 +1078,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.compareAndExchange(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.compareAndExchange$Type$(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1098,14 +1100,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.compareAndExchangeAcquire(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.compareAndExchange$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1120,14 +1122,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.compareAndExchangeRelease(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.compareAndExchange$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1142,14 +1144,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.weakCompareAndSetPlain(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Plain(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1164,14 +1166,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.weakCompareAndSet(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.weakCompareAndSet$Type$(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1186,14 +1188,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.weakCompareAndSetAcquire(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1208,14 +1210,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.weakCompareAndSetRelease(oarray, index, expected, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.componentType},
                     {#if[Object]?handle.componentType.cast(expected):expected},
@@ -1230,14 +1232,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.getAndSet(oarray, index, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.getAndSet$Type$(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
@@ -1251,14 +1253,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.getAndSetAcquire(oarray, index, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.getAndSet$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
@@ -1272,14 +1274,14 @@ final class VarHandle$Type$s {
 #else[Object]
             $type$[] array = ($type$[]) oarray;
 #end[Object]
-#if[CovariantArrayArg]
+#if[Reference]
             Class<?> arrayType = oarray.getClass();
-            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+            if (handle.arrayType != arrayType && ValueClass.isFlatArray(oarray)) {
                 // delegate to VarHandle of flat array
-                VarHandle vh = VarHandleFlatAtomicValues.flatArrayVarHandle(arrayType);
+                VarHandle vh = VarHandles.flatArrayElementHandleFor(oarray);
                 return vh.getAndSetRelease(oarray, index, value);
             }
-#end[CovariantArrayArg]
+#end[Reference]
             return UNSAFE.getAndSet$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, Preconditions.AIOOBE_FORMATTER)) << handle.ashift) + handle.abase,
                     {#if[FlatValue]?handle.layout, }{#if[Object]?handle.componentType, runtimeTypeCheck(handle, array, value):value});
@@ -1401,15 +1403,4 @@ final class VarHandle$Type$s {
 
         static final VarForm FORM = new VarForm(Array.class, {#if[Object]?Object[].class:$type$[].class}, {#if[Object]?Object.class:$type$.class}, int.class);
     }
-#if[FlatValue]
-    static final ClassValue<VarHandle> flatArrayVarHandles = new ClassValue<>() {
-        @Override protected VarHandle computeValue(Class<?> arrayClass) {
-            assert UNSAFE.isFlatArray(arrayClass);
-            return VarHandles.makeArrayElementHandle(arrayClass);
-        }
-    };
-    static VarHandle flatArrayVarHandle(Class<?> arrayClass) {
-        return flatArrayVarHandles.get(arrayClass);
-    }
-#end[FlatValue]
 }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -31,6 +31,7 @@ import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
 
+import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
 import java.security.ProtectionDomain;
 
@@ -2520,6 +2521,7 @@ public final class Unsafe {
     public final <V> void putFlatValueVolatile(Object o, long offset, int layout, Class<?> valueType, V x) {
         // we translate using fences (see: https://gee.cs.oswego.edu/dl/html/j9mm.html)
         putFlatValueRelease(o, offset, layout, valueType, x);
+        fullFence();
     }
 
     /** Volatile version of {@link #getInt(Object, long)}  */

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1655,6 +1655,7 @@ public final class Unsafe {
      * For value type, CAS should do substitutability test as opposed
      * to two pointers comparison.
      */
+    @ForceInline
     public final <V> boolean compareAndSetReference(Object o, long offset,
                                                     Class<?> type,
                                                     V expected,
@@ -1696,6 +1697,7 @@ public final class Unsafe {
                                                            Object expected,
                                                            Object x);
 
+    @ForceInline
     public final <V> Object compareAndExchangeReference(Object o, long offset,
                                                         Class<?> valueType,
                                                         V expected,
@@ -2844,6 +2846,7 @@ public final class Unsafe {
         putDoubleVolatile(o, offset, x);
     }
 
+    @ForceInline
     private boolean compareAndSetFlatValueAsBytes(Object o, long offset, int layout, Class<?> valueType, Object expected, Object x) {
         // try nullable atomic array first
         Object expectedArray = ValueClass.newNullableAtomicArray(valueType, 1);

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -2732,7 +2732,7 @@ public final class Unsafe {
 
     @ForceInline
     public final <V> Object getFlatValueOpaque(Object o, long offset, int layout, Class<?> valueType) {
-        // this is stronger that opaque semantics
+        // this is stronger than opaque semantics
         return getFlatValueAcquire(o, offset, layout, valueType);
     }
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -26,13 +26,11 @@
 package jdk.internal.misc;
 
 import jdk.internal.ref.Cleaner;
-import jdk.internal.value.CheckedType;
 import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
 
-import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
 import java.security.ProtectionDomain;
 
@@ -1676,6 +1674,23 @@ public final class Unsafe {
         }
     }
 
+    @ForceInline
+    public final <V> boolean compareAndSetFlatValue(Object o, long offset,
+                                                int layout,
+                                                Class<?> valueType,
+                                                V expected,
+                                                V x) {
+        while (true) {
+            Object witness = getFlatValueVolatile(o, offset, layout, valueType);
+            if (witness != expected) {
+                return false;
+            }
+            if (compareAndSetFlatValueAsBytes(o, offset, layout, valueType, witness, x)) {
+                return true;
+            }
+        }
+    }
+
     @IntrinsicCandidate
     public final native Object compareAndExchangeReference(Object o, long offset,
                                                            Object expected,
@@ -1700,6 +1715,23 @@ public final class Unsafe {
         }
     }
 
+    @ForceInline
+    public final <V> Object compareAndExchangeFlatValue(Object o, long offset,
+                                                    int layout,
+                                                    Class<?> valueType,
+                                                    V expected,
+                                                    V x) {
+        while (true) {
+            Object witness = getFlatValueVolatile(o, offset, layout, valueType);
+            if (witness != expected) {
+                return witness;
+            }
+            if (compareAndSetFlatValueAsBytes(o, offset, layout, valueType, witness, x)) {
+                return witness;
+            }
+        }
+    }
+
     @IntrinsicCandidate
     public final Object compareAndExchangeReferenceAcquire(Object o, long offset,
                                                            Object expected,
@@ -1714,6 +1746,15 @@ public final class Unsafe {
         return compareAndExchangeReference(o, offset, valueType, expected, x);
     }
 
+    @ForceInline
+    public final <V> Object compareAndExchangeFlatValueAcquire(Object o, long offset,
+                                                           int layout,
+                                                           Class<?> valueType,
+                                                           V expected,
+                                                           V x) {
+        return compareAndExchangeFlatValue(o, offset, layout, valueType, expected, x);
+    }
+
     @IntrinsicCandidate
     public final Object compareAndExchangeReferenceRelease(Object o, long offset,
                                                            Object expected,
@@ -1726,6 +1767,15 @@ public final class Unsafe {
                                                                V expected,
                                                                V x) {
         return compareAndExchangeReference(o, offset, valueType, expected, x);
+    }
+
+    @ForceInline
+    public final <V> Object compareAndExchangeFlatValueRelease(Object o, long offset,
+                                                           int layout,
+                                                           Class<?> valueType,
+                                                           V expected,
+                                                           V x) {
+        return compareAndExchangeFlatValue(o, offset, layout, valueType, expected, x);
     }
 
     @IntrinsicCandidate
@@ -1746,6 +1796,15 @@ public final class Unsafe {
         }
     }
 
+    @ForceInline
+    public final <V> boolean weakCompareAndSetFlatValuePlain(Object o, long offset,
+                                                         int layout,
+                                                         Class<?> valueType,
+                                                         V expected,
+                                                         V x) {
+        return compareAndSetFlatValue(o, offset, layout, valueType, expected, x);
+    }
+
     @IntrinsicCandidate
     public final boolean weakCompareAndSetReferenceAcquire(Object o, long offset,
                                                            Object expected,
@@ -1762,6 +1821,15 @@ public final class Unsafe {
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
         }
+    }
+
+    @ForceInline
+    public final <V> boolean weakCompareAndSetFlatValueAcquire(Object o, long offset,
+                                                           int layout,
+                                                           Class<?> valueType,
+                                                           V expected,
+                                                           V x) {
+        return compareAndSetFlatValue(o, offset, layout, valueType, expected, x);
     }
 
     @IntrinsicCandidate
@@ -1782,6 +1850,15 @@ public final class Unsafe {
         }
     }
 
+    @ForceInline
+    public final <V> boolean weakCompareAndSetFlatValueRelease(Object o, long offset,
+                                                           int layout,
+                                                           Class<?> valueType,
+                                                           V expected,
+                                                           V x) {
+        return compareAndSetFlatValue(o, offset, layout, valueType, expected, x);
+    }
+
     @IntrinsicCandidate
     public final boolean weakCompareAndSetReference(Object o, long offset,
                                                     Object expected,
@@ -1798,6 +1875,15 @@ public final class Unsafe {
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
         }
+    }
+
+    @ForceInline
+    public final <V> boolean weakCompareAndSetFlatValue(Object o, long offset,
+                                                    int layout,
+                                                    Class<?> valueType,
+                                                    V expected,
+                                                    V x) {
+        return compareAndSetFlatValue(o, offset, layout, valueType, expected, x);
     }
 
     /**
@@ -2415,12 +2501,26 @@ public final class Unsafe {
     @IntrinsicCandidate
     public native Object getReferenceVolatile(Object o, long offset);
 
+    @ForceInline
+    public final <V> Object getFlatValueVolatile(Object o, long offset, int layout, Class<?> valueType) {
+        // we translate using fences (see: https://gee.cs.oswego.edu/dl/html/j9mm.html)
+        Object res = getFlatValue(o, offset, layout, valueType);
+        fullFence();
+        return res;
+    }
+
     /**
      * Stores a reference value into a given Java variable, with
      * volatile store semantics. Otherwise identical to {@link #putReference(Object, long, Object)}
      */
     @IntrinsicCandidate
     public native void putReferenceVolatile(Object o, long offset, Object x);
+
+    @ForceInline
+    public final <V> void putFlatValueVolatile(Object o, long offset, int layout, Class<?> valueType, V x) {
+        // we translate using fences (see: https://gee.cs.oswego.edu/dl/html/j9mm.html)
+        putFlatValueRelease(o, offset, layout, valueType, x);
+    }
 
     /** Volatile version of {@link #getInt(Object, long)}  */
     @IntrinsicCandidate
@@ -2494,6 +2594,14 @@ public final class Unsafe {
         return getReferenceVolatile(o, offset);
     }
 
+    @ForceInline
+    public final <V> Object getFlatValueAcquire(Object o, long offset, int layout, Class<?> valueType) {
+        // we translate using fences (see: https://gee.cs.oswego.edu/dl/html/j9mm.html)
+        Object res = getFlatValue(o, offset, layout, valueType);
+        loadFence();
+        return res;
+    }
+
     /** Acquire version of {@link #getBooleanVolatile(Object, long)} */
     @IntrinsicCandidate
     public final boolean getBooleanAcquire(Object o, long offset) {
@@ -2558,6 +2666,13 @@ public final class Unsafe {
         putReferenceVolatile(o, offset, x);
     }
 
+    @ForceInline
+    public final <V> void putFlatValueRelease(Object o, long offset, int layout, Class<?> valueType, V x) {
+        // we translate using fences (see: https://gee.cs.oswego.edu/dl/html/j9mm.html)
+        storeFence();
+        putFlatValue(o, offset, layout, valueType, x);
+    }
+
     /** Release version of {@link #putBooleanVolatile(Object, long, boolean)} */
     @IntrinsicCandidate
     public final void putBooleanRelease(Object o, long offset, boolean x) {
@@ -2614,6 +2729,12 @@ public final class Unsafe {
         return getReferenceVolatile(o, offset);
     }
 
+    @ForceInline
+    public final <V> Object getFlatValueOpaque(Object o, long offset, int layout, Class<?> valueType) {
+        // this is stronger that opaque semantics
+        return getFlatValueAcquire(o, offset, layout, valueType);
+    }
+
     /** Opaque version of {@link #getBooleanVolatile(Object, long)} */
     @IntrinsicCandidate
     public final boolean getBooleanOpaque(Object o, long offset) {
@@ -2668,6 +2789,12 @@ public final class Unsafe {
         putReferenceVolatile(o, offset, x);
     }
 
+    @ForceInline
+    public final <V> void putFlatValueOpaque(Object o, long offset, int layout, Class<?> valueType, V x) {
+        // this is stronger that opaque semantics
+        putFlatValueRelease(o, offset, layout, valueType, x);
+    }
+
     /** Opaque version of {@link #putBooleanVolatile(Object, long, boolean)} */
     @IntrinsicCandidate
     public final void putBooleanOpaque(Object o, long offset, boolean x) {
@@ -2716,124 +2843,14 @@ public final class Unsafe {
         putDoubleVolatile(o, offset, x);
     }
 
-    // flat atomic support (using Doug's translations)
-
-    public Object getFlatAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType) {
-        return getFlatValue(o, offset, layoutKind, valueType);
-    }
-
-    public void putFlatAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType, Object v) {
-        putFlatValue(o, offset, layoutKind, valueType, v);
-    }
-
-    public Object getFlatAtomicValueOpaque(Object o, long offset, int layoutKind, Class<?> valueType) {
-        // @@@: this is stronger that opaque semantics
-        return getFlatAtomicValueAcquire(o, offset, layoutKind, valueType);
-    }
-
-    public void putFlatAtomicValueOpaque(Object o, long offset, int layoutKind, Class<?> valueType, Object v) {
-        // @@@: this is stronger that opaque semantics
-        putFlatAtomicValueRelease(o, offset, layoutKind, valueType, v);
-    }
-
-    public void putFlatAtomicValueRelease(Object o, long offset, int layoutKind, Class<?> valueType, Object v) {
-        storeFence();
-        putFlatValue(o, offset, layoutKind, valueType, v);
-    }
-
-    public Object getFlatAtomicValueAcquire(Object o, long offset, int layoutKind, Class<?> valueType) {
-        Object res = getFlatValue(o, offset, layoutKind, valueType);
-        loadFence();
-        return res;
-    }
-
-    public void putFlatAtomicValueVolatile(Object o, long offset, int layoutKind, Class<?> valueType, Object v) {
-        putFlatAtomicValueRelease(o, offset, layoutKind, valueType, v);
-    }
-
-
-    public Object getFlatAtomicValueVolatile(Object o, long offset, int layoutKind, Class<?> valueType) {
-        Object res = getFlatValue(o, offset, layoutKind, valueType);
-        fullFence();
-        return res;
-    }
-
-    public Object compareAndExchangeFlatAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        while (true) {
-            Object witness = getFlatAtomicValueVolatile(o, offset, layoutKind, valueType);
-            if (witness != expected) {
-                return witness;
-            }
-            if (compareAndSetFlatValueAsBytes(o, offset, layoutKind, valueType, witness, x)) {
-                return witness;
-            }
-        }
-    }
-
-    public boolean compareAndSetFlatAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        while (true) {
-            Object witness = getFlatAtomicValueVolatile(o, offset, layoutKind, valueType);
-            if (witness != expected) {
-                return false;
-            }
-            if (compareAndSetFlatValueAsBytes(o, offset, layoutKind, valueType, witness, x)) {
-                return true;
-            }
-        }
-    }
-
-    public Object getAndSetFlatAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType, Object newValue) {
-        Object v;
-        do {
-            v = getFlatAtomicValueVolatile(o, offset, layoutKind, valueType);
-        } while (!compareAndSetFlatAtomicValue(o, offset, layoutKind, valueType, v, newValue));
-        return v;
-    }
-
-    public Object compareAndExchangeFlatAtomicValueAcquire(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        return compareAndExchangeFlatAtomicValue(o, offset, layoutKind, valueType, expected, x);
-    }
-
-    public Object compareAndExchangeFlatAtomicValueRelease(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        return compareAndExchangeFlatAtomicValue(o, offset, layoutKind, valueType, expected, x);
-    }
-
-    public Object compareAndExchangeFlatAtomicValuePlain(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        return compareAndExchangeFlatAtomicValue(o, offset, layoutKind, valueType, expected, x);
-    }
-
-    public boolean weakCompareAndSetFlatAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        return compareAndSetFlatAtomicValue(o, offset, layoutKind, valueType, expected, x);
-    }
-
-    public boolean weakCompareAndSetFlatAtomicValuePlain(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        return compareAndSetFlatAtomicValue(o, offset, layoutKind, valueType, expected, x);
-    }
-
-    public boolean weakCompareAndSetFlatAtomicValueAcquire(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        return compareAndSetFlatAtomicValue(o, offset, layoutKind, valueType, expected, x);
-    }
-
-    public boolean weakCompareAndSetFlatAtomicValueRelease(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
-        return compareAndSetFlatAtomicValue(o, offset, layoutKind, valueType, expected, x);
-    }
-
-    public Object getAndSetFlatAtomicValueAcquire(Object o, long offset, int layoutKind, Class<?> valueType, Object x) {
-        return getAndSetFlatAtomicValue(o, offset, layoutKind, valueType, x);
-    }
-
-    public Object getAndSetFlatAtomicValueRelease(Object o, long offset, int layoutKind, Class<?> valueType, Object x) {
-        return getAndSetFlatAtomicValue(o, offset, layoutKind, valueType, x);
-    }
-
-    private boolean compareAndSetFlatValueAsBytes(Object o, long offset, int layoutKind, Class<?> valueType, Object expected, Object x) {
+    private boolean compareAndSetFlatValueAsBytes(Object o, long offset, int layout, Class<?> valueType, Object expected, Object x) {
         // we only support nullable flat layouts
         Object expectedArray = ValueClass.newNullableAtomicArray(valueType, 1);
         Object xArray = ValueClass.newNullableAtomicArray(valueType, 1);
         long base = arrayBaseOffset(expectedArray.getClass());
         int scale = arrayIndexScale(expectedArray.getClass());
-        putFlatValue(expectedArray, base, layoutKind, valueType, expected);
-        putFlatValue(xArray, base, layoutKind, valueType, x);
+        putFlatValue(expectedArray, base, layout, valueType, expected);
+        putFlatValue(xArray, base, layout, valueType, x);
         switch (scale) {
             case 1: {
                 byte expectedByte = getByte(expectedArray, base);
@@ -2859,16 +2876,6 @@ public final class Unsafe {
                 throw new UnsupportedOperationException();
             }
         }
-    }
-
-    // flat non-atomic support (only plain access)
-
-    public Object getFlatNonAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType) {
-        return getFlatValue(o, offset, layoutKind, valueType);
-    }
-
-    public void putFlatNonAtomicValue(Object o, long offset, int layoutKind, Class<?> valueType, Object v) {
-        putFlatValue(o, offset, layoutKind, valueType, v);
     }
 
     /**
@@ -3266,6 +3273,14 @@ public final class Unsafe {
         return v;
     }
 
+    public Object getAndSetFlatValue(Object o, long offset, int layoutKind, Class<?> valueType, Object newValue) {
+        Object v;
+        do {
+            v = getFlatValueVolatile(o, offset, layoutKind, valueType);
+        } while (!compareAndSetFlatValue(o, offset, layoutKind, valueType, v, newValue));
+        return v;
+    }
+
     @ForceInline
     public final Object getAndSetReferenceRelease(Object o, long offset, Object newValue) {
         Object v;
@@ -3281,6 +3296,11 @@ public final class Unsafe {
     }
 
     @ForceInline
+    public Object getAndSetFlatValueRelease(Object o, long offset, int layoutKind, Class<?> valueType, Object x) {
+        return getAndSetFlatValue(o, offset, layoutKind, valueType, x);
+    }
+
+    @ForceInline
     public final Object getAndSetReferenceAcquire(Object o, long offset, Object newValue) {
         Object v;
         do {
@@ -3292,6 +3312,11 @@ public final class Unsafe {
     @ForceInline
     public final Object getAndSetReferenceAcquire(Object o, long offset, Class<?> valueType, Object newValue) {
         return getAndSetReference(o, offset, valueType, newValue);
+    }
+
+    @ForceInline
+    public Object getAndSetFlatValueAcquire(Object o, long offset, int layoutKind, Class<?> valueType, Object x) {
+        return getAndSetFlatValue(o, offset, layoutKind, valueType, x);
     }
 
     @IntrinsicCandidate

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -31,7 +31,6 @@ import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
 
-import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
 import java.security.ProtectionDomain;
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -2792,7 +2792,7 @@ public final class Unsafe {
 
     @ForceInline
     public final <V> void putFlatValueOpaque(Object o, long offset, int layout, Class<?> valueType, V x) {
-        // this is stronger that opaque semantics
+        // this is stronger than opaque semantics
         putFlatValueRelease(o, offset, layout, valueType, x);
     }
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -3284,6 +3284,7 @@ public final class Unsafe {
         return v;
     }
 
+    @ForceInline
     public Object getAndSetFlatValue(Object o, long offset, int layoutKind, Class<?> valueType, Object newValue) {
         Object v;
         do {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1204,6 +1204,7 @@ public class TestIntrinsics {
 
     @Run(test = "test63")
     public void test63_verifier() {
+        if (TEST31_VT_FLATTENED) return;
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
         test31_vt = MyValue1.createDefaultInline();
 
@@ -1234,6 +1235,7 @@ public class TestIntrinsics {
 
     @Run(test = "test64")
     public void test64_verifier() {
+        if (TEST33_FLATTENED_ARRAY) return;
         MyValue1[] arr = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 2);
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
 
@@ -1264,6 +1266,7 @@ public class TestIntrinsics {
 
     @Run(test = "test65")
     public void test65_verifier() {
+        if (TEST31_VT_FLATTENED) return;
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
         test31_vt = MyValue1.createDefaultInline();
 
@@ -1288,6 +1291,7 @@ public class TestIntrinsics {
 
     @Run(test = "test66")
     public void test66_verifier() {
+        if (TEST31_VT_FLATTENED) return;
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
         test31_vt = MyValue1.createDefaultInline();
 
@@ -1312,6 +1316,7 @@ public class TestIntrinsics {
 
     @Run(test = "test67")
     public void test67_verifier() {
+        if (TEST31_VT_FLATTENED) return;
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
         MyValue1 oldVal = MyValue1.createDefaultInline();
         test31_vt = oldVal;
@@ -1343,6 +1348,7 @@ public class TestIntrinsics {
 
     @Run(test = "test68")
     public void test68_verifier() {
+        if (TEST33_FLATTENED_ARRAY) return;
         MyValue1[] arr = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 2);
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
 
@@ -1373,6 +1379,7 @@ public class TestIntrinsics {
 
     @Run(test = "test69")
     public void test69_verifier() {
+        if (TEST31_VT_FLATTENED) return;
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
         MyValue1 oldVal = MyValue1.createDefaultInline();
         test31_vt = oldVal;
@@ -1389,25 +1396,27 @@ public class TestIntrinsics {
     // compareAndExchange to flattened field in object, non-inline arguments to compare and set
     @Test
     public Object test70(Object oldVal, Object newVal) {
-        return U.compareAndExchangeReference(this, TEST31_VT_OFFSET, oldVal, newVal);
+        if (TEST31_VT_FLATTENED) {
+            return U.compareAndExchangeFlatValue(this, TEST31_VT_OFFSET, TEST31_VT_LAYOUT, MyValue1.class, oldVal, newVal);
+        } else {
+            return U.compareAndExchangeReference(this, TEST31_VT_OFFSET, oldVal, newVal);
+        }
     }
 
     @Run(test = "test70")
     public void test70_verifier() {
-        if (!TEST31_VT_FLATTENED) {
-            // no cAE for flat fields
-            MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
-            MyValue1 oldVal = MyValue1.createDefaultInline();
-            test31_vt = oldVal;
+        if (TEST31_VT_FLATTENED) return;
+        MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
+        MyValue1 oldVal = MyValue1.createDefaultInline();
+        test31_vt = oldVal;
 
-            Object res = test70(test31_vt, vt);
-            Asserts.assertEQ(res, oldVal);
-            Asserts.assertEQ(test31_vt, vt);
+        Object res = test70(test31_vt, vt);
+        Asserts.assertEQ(res, oldVal);
+        Asserts.assertEQ(test31_vt, vt);
 
-            res = test70(MyValue1.createDefaultInline(), MyValue1.createDefaultInline());
-            Asserts.assertEQ(res, vt);
-            Asserts.assertEQ(test31_vt, vt);
-        }
+        res = test70(MyValue1.createDefaultInline(), MyValue1.createDefaultInline());
+        Asserts.assertEQ(res, vt);
+        Asserts.assertEQ(test31_vt, vt);
     }
 
     // getValue to retrieve flattened field from (nullable) value class

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1389,26 +1389,25 @@ public class TestIntrinsics {
     // compareAndExchange to flattened field in object, non-inline arguments to compare and set
     @Test
     public Object test70(Object oldVal, Object newVal) {
-        if (TEST31_VT_FLATTENED) {
-            return U.compareAndExchangeFlatValue(this, TEST31_VT_OFFSET, TEST31_VT_LAYOUT, MyValue1.class, oldVal, newVal);
-        } else {
-            return U.compareAndExchangeReference(this, TEST31_VT_OFFSET, oldVal, newVal);
-        }
+        return U.compareAndExchangeReference(this, TEST31_VT_OFFSET, oldVal, newVal);
     }
 
     @Run(test = "test70")
     public void test70_verifier() {
-        MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
-        MyValue1 oldVal = MyValue1.createDefaultInline();
-        test31_vt = oldVal;
+        if (!TEST31_VT_FLATTENED) {
+            // no cAE for flat fields
+            MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
+            MyValue1 oldVal = MyValue1.createDefaultInline();
+            test31_vt = oldVal;
 
-        Object res = test70(test31_vt, vt);
-        Asserts.assertEQ(res, oldVal);
-        Asserts.assertEQ(test31_vt, vt);
+            Object res = test70(test31_vt, vt);
+            Asserts.assertEQ(res, oldVal);
+            Asserts.assertEQ(test31_vt, vt);
 
-        res = test70(MyValue1.createDefaultInline(), MyValue1.createDefaultInline());
-        Asserts.assertEQ(res, vt);
-        Asserts.assertEQ(test31_vt, vt);
+            res = test70(MyValue1.createDefaultInline(), MyValue1.createDefaultInline());
+            Asserts.assertEQ(res, vt);
+            Asserts.assertEQ(test31_vt, vt);
+        }
     }
 
     // getValue to retrieve flattened field from (nullable) value class

--- a/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
@@ -25,6 +25,7 @@
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import jdk.internal.misc.Unsafe;
 import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ImplicitlyConstructible;
 import jdk.internal.vm.annotation.LooselyConsistentValue;
@@ -41,53 +42,91 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 
 /*
  * @test
  * @summary Test atomic access modes on var handles for flattened values
  * @enablePreview
- * @modules java.base/jdk.internal.value java.base/jdk.internal.vm.annotation
+ * @modules java.base/jdk.internal.value java.base/jdk.internal.vm.annotation java.base/jdk.internal.misc
  * @run junit/othervm FlatVarHandleTest
  */
 public class FlatVarHandleTest {
+
+    static final Unsafe UNSAFE = Unsafe.getUnsafe();
 
     interface Pointable { }
 
     @ImplicitlyConstructible
     @LooselyConsistentValue
-    static value class Point implements Pointable {
+    static value class WeakPoint implements Pointable {
         int x,y;
-        Point(int i, int j) { x = i; y = j; }
+        long x2 = 0L,y2 = 0L;
+        long x3 = 0L,y3 = 0L;
+        long x4 = 0L,y4 = 0L;
+        long x5 = 0L,y5 = 0L;
+        long x6 = 0L,y6 = 0L;
+        WeakPoint(int i, int j) { x = i; y = j; }
 
-        static Point[] makePoints(int len) {
-            Point[] array = (Point[])ValueClass.newNullRestrictedArray(Point.class, len);
+        static WeakPoint[] makePoints(int len) {
+            WeakPoint[] array = (WeakPoint[])ValueClass.newNullRestrictedArray(WeakPoint.class, len);
             for (int i = 0; i < len; ++i) {
-                array[i] = new Point(i, i);
+                array[i] = new WeakPoint(i, i);
             }
             return array;
         }
     }
 
-    static class PointHolder {
-        Point p_i = new Point(0, 0);
-        static Point p_s = new Point(0, 0);
+    static class WeakPointHolder {
+        WeakPoint p_i = new WeakPoint(0, 0);
+        static WeakPoint p_s = new WeakPoint(0, 0);
         @NullRestricted
-        Point p_i_nr = new Point(0, 0);
+        WeakPoint p_i_nr = new WeakPoint(0, 0);
         @NullRestricted
-        static Point p_s_nr = new Point(0, 0);
+        static WeakPoint p_s_nr = new WeakPoint(0, 0);
+    }
+
+    static value class StrongPoint implements Pointable {
+        short x,y;
+        StrongPoint(short i, short j) { x = i; y = j; }
+
+        static StrongPoint[] makePoints(int len) {
+            StrongPoint[] array = (StrongPoint[])ValueClass.newNullableAtomicArray(StrongPoint.class, len);
+            for (int i = 0; i < len; ++i) {
+                array[i] = new StrongPoint((short)i, (short)i);
+            }
+            return array;
+        }
+    }
+
+    static class StrongPointHolder {
+        StrongPoint p_i = new StrongPoint((short)0, (short)0);
+        static StrongPoint p_s = new StrongPoint((short)0, (short)0);
     }
 
     private static List<Arguments> fieldAccessProvider() {
         try {
             List<Field> fields = List.of(
-                    PointHolder.class.getDeclaredField("p_s"),
-                    PointHolder.class.getDeclaredField("p_i"),
-                    PointHolder.class.getDeclaredField("p_s_nr"),
-                    PointHolder.class.getDeclaredField("p_i_nr"));
+                    WeakPointHolder.class.getDeclaredField("p_s"),
+                    WeakPointHolder.class.getDeclaredField("p_i"),
+                    WeakPointHolder.class.getDeclaredField("p_s_nr"),
+                    WeakPointHolder.class.getDeclaredField("p_i_nr"),
+                    StrongPointHolder.class.getDeclaredField("p_s"),
+                    StrongPointHolder.class.getDeclaredField("p_i"));
             List<Arguments> arguments = new ArrayList<>();
             for (AccessMode accessMode : AccessMode.values()) {
                 for (Field field : fields) {
-                    arguments.add(Arguments.of(accessMode, field));
+                    boolean isStatic = (field.getModifiers() & Modifier.STATIC) != 0;
+                    boolean isWeak = field.getDeclaringClass().equals(WeakPointHolder.class);
+                    Object holder = null;
+                    if (!isStatic) {
+                        holder = isWeak ? new WeakPointHolder() : new StrongPointHolder();
+                    }
+                    BiFunction<Integer, Integer, Object> factory = isWeak ?
+                            (i1, i2) -> new WeakPoint(i1, i2) :
+                            (i1, i2) -> new StrongPoint((short)(int)i1, (short)(int)i2);
+                    boolean supported = !field.getName().equals("p_i_nr");
+                    arguments.add(Arguments.of(accessMode, holder, factory, field, supported));
                 }
             }
             return arguments;
@@ -101,39 +140,43 @@ public class FlatVarHandleTest {
      */
     @ParameterizedTest
     @MethodSource("fieldAccessProvider")
-    public void testFieldAccess(AccessMode accessMode, Field field) throws Throwable {
+    public void testFieldAccess(AccessMode accessMode, Object holder, BiFunction<Integer, Integer, Object> factory, Field field, boolean supported) throws Throwable {
         VarHandle varHandle = MethodHandles.lookup().unreflectVarHandle(field);
-        boolean isStatic = (field.getModifiers() & Modifier.STATIC) != 0;
-        boolean isNullRestricted = (field.isAnnotationPresent(NullRestricted.class));
-        boolean isFlatField = !isStatic && isNullRestricted;
-        boolean supported = (!isFlatField && !isNumeric(accessMode) && !isBitwise(accessMode)) || isPlain(accessMode);
-        if (supported) {
-            assertTrue(varHandle.isAccessModeSupported(accessMode));
+        if (varHandle.isAccessModeSupported(accessMode)) {
+            assertTrue(isPlain(accessMode) || (supported && !isBitwise(accessMode) && !isNumeric(accessMode)));
             MethodHandle methodHandle = varHandle.toMethodHandle(accessMode);
             List<Object> arguments = new ArrayList<>();
-            if (!isStatic) {
-                arguments.add(new PointHolder()); // receiver
+            if (holder != null) {
+                arguments.add(holder); // receiver
             }
-            for (int i = arguments.size() ; i < methodHandle.type().parameterCount() ; i++) {
-                arguments.add(new Point(i, i)); // add extra setter param
+            for (int i = arguments.size(); i < methodHandle.type().parameterCount(); i++) {
+                arguments.add(factory.apply(i, i)); // add extra setter param
             }
             methodHandle.invokeWithArguments(arguments.toArray());
         } else {
-            assertFalse(varHandle.isAccessModeSupported(accessMode));
+            assertTrue(!supported || isBitwise(accessMode) || isNumeric(accessMode));
         }
     }
 
     private static List<Arguments> arrayAccessProvider() {
-        List<Point[]> arrayObjects = List.of(
-                Point.makePoints(10),
-                new Point[10]);
-        List<Class<?>> arrayTypes = List.of(
-                Point[].class, Pointable[].class, Object[].class);
+        List<Object[]> arrayObjects = List.of(
+                WeakPoint.makePoints(10),
+                new WeakPoint[10],
+                StrongPoint.makePoints(10),
+                new StrongPoint[10]);
+
         List<Arguments> arguments = new ArrayList<>();
         for (AccessMode accessMode : AccessMode.values()) {
-            for (Point[] arrayObject : arrayObjects) {
+            for (Object[] arrayObject : arrayObjects) {
+                boolean isWeak = arrayObject.getClass().getComponentType().equals(WeakPoint.class);
+                List<Class<?>> arrayTypes = List.of(
+                        isWeak ? WeakPoint[].class : StrongPoint[].class, Pointable[].class, Object[].class);
                 for (Class<?> arrayType : arrayTypes) {
-                    arguments.add(Arguments.of(accessMode, arrayObject, arrayType));
+                    BiFunction<Integer, Integer, Object> factory = isWeak ?
+                            (i1, i2) -> new WeakPoint(i1, i2) :
+                            (i1, i2) -> new StrongPoint((short)(int)i1, (short)(int)i2);
+                    boolean supported = !ValueClass.isFlatArray(arrayObject) || !isWeak;
+                    arguments.add(Arguments.of(accessMode, arrayObject, factory, arrayType, supported));
                 }
             }
         }
@@ -145,26 +188,24 @@ public class FlatVarHandleTest {
      */
     @ParameterizedTest
     @MethodSource("arrayAccessProvider")
-    public void testArrayAccess(AccessMode accessMode, Point[] arrayObject, Class<?> arrayType) throws Throwable {
+    public void testArrayAccess(AccessMode accessMode, Object[] arrayObject, BiFunction<Integer, Integer, Object> factory, Class<?> arrayType, boolean supported) throws Throwable {
         VarHandle varHandle = MethodHandles.arrayElementVarHandle(arrayType);
-        boolean supported = !isBitwise(accessMode) && !isNumeric(accessMode);
-        if (supported) {
-            assertTrue(varHandle.isAccessModeSupported(accessMode));
+        if (varHandle.isAccessModeSupported(accessMode)) {
+            assertTrue(!isBitwise(accessMode) && !isNumeric(accessMode));
             MethodHandle methodHandle = varHandle.toMethodHandle(accessMode);
             List<Object> arguments = new ArrayList<>();
             arguments.add(arrayObject); // array receiver
             arguments.add(0); // index
-            for (int i = 2 ; i < methodHandle.type().parameterCount() ; i++) {
-                arguments.add(new Point(i, i)); // add extra setter param
+            for (int i = 2; i < methodHandle.type().parameterCount(); i++) {
+                arguments.add(factory.apply(i, i)); // add extra setter param
             }
             try {
                 methodHandle.invokeWithArguments(arguments.toArray());
-                assertTrue(isPlain(accessMode) || !ValueClass.isFlatArray(arrayObject));
-            } catch (IllegalArgumentException ex) {
-                assertTrue(!isPlain(accessMode) && ValueClass.isFlatArray(arrayObject));
+            } catch (UnsupportedOperationException ex) {
+                assertFalse(supported);
             }
         } else {
-            assertFalse(varHandle.isAccessModeSupported(accessMode));
+            assertTrue(isBitwise(accessMode) || isNumeric(accessMode));
         }
     }
 

--- a/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.ImplicitlyConstructible;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.internal.vm.annotation.NullRestricted;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.invoke.VarHandle.AccessMode;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * @test
+ * @summary Test atomic access modes on var handles for flattened values
+ * @enablePreview
+ * @modules java.base/jdk.internal.value java.base/jdk.internal.vm.annotation
+ * @run junit/othervm FlatVarHandleTest
+ */
+public class FlatVarHandleTest {
+
+    interface Pointable { }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class Point implements Pointable {
+        int x,y;
+        Point(int i, int j) { x = i; y = j; }
+
+        static Point[] makePoints(int len) {
+            Point[] array = (Point[])ValueClass.newNullRestrictedArray(Point.class, len);
+            for (int i = 0; i < len; ++i) {
+                array[i] = new Point(i, i);
+            }
+            return array;
+        }
+    }
+
+    static class PointHolder {
+        Point p_i = new Point(0, 0);
+        static Point p_s = new Point(0, 0);
+        @NullRestricted
+        Point p_i_nr = new Point(0, 0);
+        @NullRestricted
+        static Point p_s_nr = new Point(0, 0);
+    }
+
+    private static List<Arguments> fieldAccessProvider() {
+        try {
+            List<Field> fields = List.of(
+                    PointHolder.class.getDeclaredField("p_s"),
+                    PointHolder.class.getDeclaredField("p_i"),
+                    PointHolder.class.getDeclaredField("p_s_nr"),
+                    PointHolder.class.getDeclaredField("p_i_nr"));
+            List<Arguments> arguments = new ArrayList<>();
+            for (AccessMode accessMode : AccessMode.values()) {
+                for (Field field : fields) {
+                    arguments.add(Arguments.of(accessMode, field));
+                }
+            }
+            return arguments;
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /*
+     * Verify that atomic access modes are not supported on flat fields.
+     */
+    @ParameterizedTest
+    @MethodSource("fieldAccessProvider")
+    public void testFieldAccess(AccessMode accessMode, Field field) throws Throwable {
+        VarHandle varHandle = MethodHandles.lookup().unreflectVarHandle(field);
+        boolean isStatic = (field.getModifiers() & Modifier.STATIC) != 0;
+        boolean isNullRestricted = (field.isAnnotationPresent(NullRestricted.class));
+        boolean isFlatField = !isStatic && isNullRestricted;
+        boolean supported = (!isFlatField && !isNumeric(accessMode) && !isBitwise(accessMode)) || isPlain(accessMode);
+        if (supported) {
+            assertTrue(varHandle.isAccessModeSupported(accessMode));
+            MethodHandle methodHandle = varHandle.toMethodHandle(accessMode);
+            List<Object> arguments = new ArrayList<>();
+            if (!isStatic) {
+                arguments.add(new PointHolder()); // receiver
+            }
+            for (int i = arguments.size() ; i < methodHandle.type().parameterCount() ; i++) {
+                arguments.add(new Point(i, i)); // add extra setter param
+            }
+            methodHandle.invokeWithArguments(arguments.toArray());
+        } else {
+            assertFalse(varHandle.isAccessModeSupported(accessMode));
+        }
+    }
+
+    private static List<Arguments> arrayAccessProvider() {
+        List<Point[]> arrayObjects = List.of(
+                Point.makePoints(10),
+                new Point[10]);
+        List<Class<?>> arrayTypes = List.of(
+                Point[].class, Pointable[].class, Object[].class);
+        List<Arguments> arguments = new ArrayList<>();
+        for (AccessMode accessMode : AccessMode.values()) {
+            for (Point[] arrayObject : arrayObjects) {
+                for (Class<?> arrayType : arrayTypes) {
+                    arguments.add(Arguments.of(accessMode, arrayObject, arrayType));
+                }
+            }
+        }
+        return arguments;
+    }
+
+    /*
+     * Verify that atomic access modes are not supported on flat array instances.
+     */
+    @ParameterizedTest
+    @MethodSource("arrayAccessProvider")
+    public void testArrayAccess(AccessMode accessMode, Point[] arrayObject, Class<?> arrayType) throws Throwable {
+        VarHandle varHandle = MethodHandles.arrayElementVarHandle(arrayType);
+        boolean supported = !isBitwise(accessMode) && !isNumeric(accessMode);
+        if (supported) {
+            assertTrue(varHandle.isAccessModeSupported(accessMode));
+            MethodHandle methodHandle = varHandle.toMethodHandle(accessMode);
+            List<Object> arguments = new ArrayList<>();
+            arguments.add(arrayObject); // array receiver
+            arguments.add(0); // index
+            for (int i = 2 ; i < methodHandle.type().parameterCount() ; i++) {
+                arguments.add(new Point(i, i)); // add extra setter param
+            }
+            try {
+                methodHandle.invokeWithArguments(arguments.toArray());
+                assertTrue(isPlain(accessMode) || !ValueClass.isFlatArray(arrayObject));
+            } catch (IllegalArgumentException ex) {
+                assertTrue(!isPlain(accessMode) && ValueClass.isFlatArray(arrayObject));
+            }
+        } else {
+            assertFalse(varHandle.isAccessModeSupported(accessMode));
+        }
+    }
+
+    boolean isBitwise(AccessMode accessMode) {
+        return switch (accessMode) {
+            case GET_AND_BITWISE_AND, GET_AND_BITWISE_AND_ACQUIRE,
+                 GET_AND_BITWISE_AND_RELEASE, GET_AND_BITWISE_OR,
+                 GET_AND_BITWISE_OR_ACQUIRE, GET_AND_BITWISE_OR_RELEASE,
+                 GET_AND_BITWISE_XOR, GET_AND_BITWISE_XOR_ACQUIRE,
+                 GET_AND_BITWISE_XOR_RELEASE -> true;
+            default -> false;
+        };
+    }
+
+    boolean isNumeric(AccessMode accessMode) {
+        return switch (accessMode) {
+            case GET_AND_ADD, GET_AND_ADD_ACQUIRE, GET_AND_ADD_RELEASE -> true;
+            default -> false;
+        };
+    }
+
+    boolean isPlain(AccessMode accessMode) {
+        return switch (accessMode) {
+            case GET, SET -> true;
+            default -> false;
+        };
+    }
+}

--- a/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
@@ -49,8 +49,8 @@ import java.util.function.BiFunction;
  * @summary Test atomic access modes on var handles for flattened values
  * @enablePreview
  * @modules java.base/jdk.internal.value java.base/jdk.internal.vm.annotation
- * @run junit/othervm -XX:-UseNullableValueFlattening FlatVarHandleTest
- * @run junit/othervm -XX:+UseNullableValueFlattening FlatVarHandleTest
+ * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening FlatVarHandleTest
+ * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening FlatVarHandleTest
  */
 public class FlatVarHandleTest {
 

--- a/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
@@ -169,6 +169,7 @@ public class FlatVarHandleTest {
 
         List<Arguments> arguments = new ArrayList<>();
         for (AccessMode accessMode : AccessMode.values()) {
+            if (accessMode.ordinal() != 2) continue;
             for (Object[] arrayObject : arrayObjects) {
                 boolean isWeak = arrayObject.getClass().getComponentType().equals(WeakPoint.class);
                 List<Class<?>> arrayTypes = List.of(
@@ -206,7 +207,7 @@ public class FlatVarHandleTest {
             }
             try {
                 methodHandle.invokeWithArguments(arguments.toArray());
-            } catch (UnsupportedOperationException ex) {
+            } catch (IllegalArgumentException ex) {
                 assertFalse(allowsNonPlainAccess);
             }
         } else {

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -26,7 +26,6 @@
  * @test
  * @enablePreview
  * @run junit/othervm NullRestrictedArraysTest
- * @run junit/othervm -XX:-UseArrayFlattening NullRestrictedArraysTest
  */
 
 import java.lang.invoke.MethodHandles;
@@ -214,22 +213,25 @@ public class NullRestrictedArraysTest {
         Value value = new Value(0);
         Value value1 =  new Value(1);
         assertTrue(vh.get(array, 0) == value);
-        assertTrue(vh.getVolatile(array, 0) == value);
-        assertTrue(vh.getOpaque(array, 0) == value);
-        assertTrue(vh.getAcquire(array, 0) == value);
         assertThrows(NullPointerException.class, () -> vh.set(array, 0, null));
-        assertThrows(NullPointerException.class, () -> vh.setVolatile(array, 0, null));
-        assertThrows(NullPointerException.class, () -> vh.setOpaque(array, 0, null));
-        assertThrows(NullPointerException.class, () -> vh.setRelease(array, 0, null));
 
-        assertThrows(NullPointerException.class, () -> vh.compareAndSet(array, 1, value1, null));
-        assertThrows(NullPointerException.class, () -> vh.compareAndExchange(array, 1, value1, null));
-        assertThrows(NullPointerException.class, () -> vh.compareAndExchangeAcquire(array, 1, value1, null));
-        assertThrows(NullPointerException.class, () -> vh.compareAndExchangeRelease(array, 1, value1, null));
-        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSet(array, 1, value1, null));
-        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSetAcquire(array, 1, value1, null));
-        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSetPlain(array, 1, value1, null));
-        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSetRelease(array, 1, value1, null));
+        // atomic access modes not supported on flat array instances
+
+        assertThrows(IllegalArgumentException.class, () -> vh.getVolatile(array, 0));
+        assertThrows(IllegalArgumentException.class, () -> vh.getOpaque(array, 0));
+        assertThrows(IllegalArgumentException.class, () -> vh.getAcquire(array, 0));
+        assertThrows(IllegalArgumentException.class, () -> vh.setVolatile(array, 0, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.setOpaque(array, 0, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.setRelease(array, 0, null));
+
+        assertThrows(IllegalArgumentException.class, () -> vh.compareAndSet(array, 1, value1, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.compareAndExchange(array, 1, value1, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.compareAndExchangeAcquire(array, 1, value1, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.compareAndExchangeRelease(array, 1, value1, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.weakCompareAndSet(array, 1, value1, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.weakCompareAndSetAcquire(array, 1, value1, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.weakCompareAndSetPlain(array, 1, value1, null));
+        assertThrows(IllegalArgumentException.class, () -> vh.weakCompareAndSetRelease(array, 1, value1, null));
     }
 
 }

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -25,8 +25,8 @@
 /*
  * @test
  * @enablePreview
- * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening FlatVarHandleTest
- * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening FlatVarHandleTest
+ * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening NullRestrictedArraysTest
+ * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening NullRestrictedArraysTest
  */
 
 import java.lang.invoke.MethodHandles;

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -25,7 +25,6 @@
 /*
  * @test
  * @enablePreview
- * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening NullRestrictedArraysTest
  * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening NullRestrictedArraysTest
  */
 
@@ -208,35 +207,35 @@ public class NullRestrictedArraysTest {
             vh.setRelease(array, 0, null);
             assertNull(vh.get(array, 0));
 
-            vh.compareAndSet(array, 1, value1, null);
+            assertTrue(vh.compareAndSet(array, 1, value1, null));
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
 
-            vh.compareAndExchange(array, 1, value1, null);
+            assertEquals(vh.compareAndExchange(array, 1, value1, null), value1);
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
 
-            vh.compareAndExchangeAcquire(array, 1, value1, null);
+            assertEquals(vh.compareAndExchangeAcquire(array, 1, value1, null), value1);
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
 
-            vh.compareAndExchangeRelease(array, 1, value1, null);
+            assertEquals(vh.compareAndExchangeRelease(array, 1, value1, null), value1);
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
 
-            vh.weakCompareAndSet(array, 1, value1, null);
+            assertTrue(vh.weakCompareAndSet(array, 1, value1, null));
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
 
-            vh.weakCompareAndSetAcquire(array, 1, value1, null);
+            assertTrue(vh.weakCompareAndSetAcquire(array, 1, value1, null));
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
 
-            vh.weakCompareAndSetPlain(array, 1, value1, null);
+            assertTrue(vh.weakCompareAndSetPlain(array, 1, value1, null));
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
 
-            vh.weakCompareAndSetRelease(array, 1, value1, null);
+            assertTrue(vh.weakCompareAndSetRelease(array, 1, value1, null));
             assertNull(vh.get(array, 0));
             vh.set(array, 1, value1);
         } else {
@@ -299,5 +298,31 @@ public class NullRestrictedArraysTest {
         assertTrue(vh.weakCompareAndSetRelease(array, 1, value1, value2));
         assertEquals(vh.get(array, 1), value2);
         vh.set(array, 1, value1);
+
+        // test atomic set with null witness
+
+        assertFalse(vh.compareAndSet(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
+
+        assertNotNull(vh.compareAndExchange(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
+
+        assertNotNull(vh.compareAndExchangeAcquire(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
+
+        assertNotNull(vh.compareAndExchangeRelease(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
+
+        assertFalse(vh.weakCompareAndSet(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
+
+        assertFalse(vh.weakCompareAndSetAcquire(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
+
+        assertFalse(vh.weakCompareAndSetPlain(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
+
+        assertFalse(vh.weakCompareAndSetRelease(array, 2, null, value1));
+        assertEquals(vh.get(array, 2), value2);
     }
 }

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -25,6 +25,7 @@
 /*
  * @test
  * @enablePreview
+ * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening NullRestrictedArraysTest
  * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening NullRestrictedArraysTest
  */
 

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -25,8 +25,8 @@
 /*
  * @test
  * @enablePreview
- * @run junit/othervm NullRestrictedArraysTest
- * @run junit/othervm -XX:-UseArrayFlattening NullRestrictedArraysTest
+ * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening FlatVarHandleTest
+ * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening FlatVarHandleTest
  */
 
 import java.lang.invoke.MethodHandles;

--- a/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
@@ -28,7 +28,6 @@
  *          that may be flattened or non-flattened
  * @enablePreview
  * @run junit/othervm NullRestrictedTest
- * @run junit/othervm -XX:-UseFieldFlattening NullRestrictedTest
  */
 
 import java.lang.invoke.MethodHandles;

--- a/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
@@ -28,6 +28,7 @@
  *          that may be flattened or non-flattened
  * @enablePreview
  * @run junit/othervm NullRestrictedTest
+ * @run junit/othervm -XX:-UseFieldFlattening NullRestrictedTest
  */
 
 import java.lang.invoke.MethodHandles;


### PR DESCRIPTION
This PR is an attempt to put var handle support for flat values on a more solid footing. Some more notes in a comment below.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8351569](https://bugs.openjdk.org/browse/JDK-8351569): [lworld] Revisit atomic access modes in flat var handles (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1402/head:pull/1402` \
`$ git checkout pull/1402`

Update a local copy of the PR: \
`$ git checkout pull/1402` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1402`

View PR using the GUI difftool: \
`$ git pr show -t 1402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1402.diff">https://git.openjdk.org/valhalla/pull/1402.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1402#issuecomment-2739950558)
</details>
