### PR TITLE
8352613: [lworld] New Unsafe API for special array creation needed by VarHandle

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -259,6 +259,9 @@ public final class Unsafe {
 
     private native int fieldLayout0(Object o);
 
+    public native Object[] newSpecialArray(Class<?> componentType,
+                                                  int length, int layoutKind);
+
     /**
      * Returns true if the given class is a flattened array.
      */


### PR DESCRIPTION
New Unsafe API to help the implementation of VarHandle's CAS operations on flat values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8352613](https://bugs.openjdk.org/browse/JDK-8352613): [lworld] New Unsafe API for special array creation needed by VarHandle (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1404/head:pull/1404` \
`$ git checkout pull/1404`

Update a local copy of the PR: \
`$ git checkout pull/1404` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1404`

View PR using the GUI difftool: \
`$ git pr show -t 1404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1404.diff">https://git.openjdk.org/valhalla/pull/1404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1404#issuecomment-2743560549)
</details>
