### PR TITLE
Adding flattening of strict final fields

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5490,7 +5490,8 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
     vk->set_non_atomic_size_in_bytes(_layout_info->_non_atomic_size_in_bytes);
     vk->set_non_atomic_alignment(_layout_info->_non_atomic_alignment);
     vk->set_atomic_size_in_bytes(_layout_info->_atomic_layout_size_in_bytes);
-    vk->set_nullable_size_in_bytes(_layout_info->_nullable_layout_size_in_bytes);
+    vk->set_nullable_atomic_size_in_bytes(_layout_info->_nullable_atomic_layout_size_in_bytes);
+    vk->set_nullable_non_atomic_size_in_bytes(_layout_info->_nullable_non_atomic_layout_size_in_bytes);
     vk->set_null_marker_offset(_layout_info->_null_marker_offset);
     vk->set_default_value_offset(_layout_info->_default_value_offset);
     vk->set_null_reset_value_offset(_layout_info->_null_reset_value_offset);

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -80,7 +80,8 @@ class FieldLayoutInfo : public ResourceObj {
   int _non_atomic_size_in_bytes;
   int _non_atomic_alignment;
   int _atomic_layout_size_in_bytes;
-  int _nullable_layout_size_in_bytes;
+  int _nullable_atomic_layout_size_in_bytes;
+  int _nullable_non_atomic_layout_size_in_bytes;
   int _null_marker_offset;
   int _default_value_offset;
   int _null_reset_value_offset;

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -297,7 +297,8 @@ class FieldLayoutBuilder : public ResourceObj {
   int _non_atomic_layout_size_in_bytes;
   int _non_atomic_layout_alignment;
   int _atomic_layout_size_in_bytes;
-  int _nullable_layout_size_in_bytes;
+  int _nullable_atomic_layout_size_in_bytes;
+  int _nullable_non_atomic_layout_size_in_bytes;
   int _fields_size_sum;
   int _declared_non_static_fields_count;
   bool _has_non_naturally_atomic_fields;
@@ -318,7 +319,7 @@ class FieldLayoutBuilder : public ResourceObj {
                      GrowableArray<FieldInfo>* field_info, bool is_contended, bool is_inline_type, bool is_abstract_value,
                      bool must_be_atomic, FieldLayoutInfo* info, Array<InlineLayoutInfo>* inline_layout_info_array);
 
-  int payload_offset() const               { assert(_payload_offset != -1, "Uninitialized"); return _payload_offset; }
+  int  payload_offset() const                  { assert(_payload_offset != -1, "Uninitialized"); return _payload_offset; }
   int  payload_layout_size_in_bytes() const    { return _payload_size_in_bytes; }
   int  payload_layout_alignment() const        { assert(_payload_alignment != -1, "Uninitialized"); return _payload_alignment; }
   bool has_non_atomic_flat_layout() const      { return _non_atomic_layout_size_in_bytes != -1; }
@@ -326,8 +327,10 @@ class FieldLayoutBuilder : public ResourceObj {
   int  non_atomic_layout_alignment() const     { return _non_atomic_layout_alignment; }
   bool has_atomic_layout() const               { return _atomic_layout_size_in_bytes != -1; }
   int  atomic_layout_size_in_bytes() const     { return _atomic_layout_size_in_bytes; }
-  bool has_nullable_atomic_layout() const      { return _nullable_layout_size_in_bytes != -1; }
-  int  nullable_layout_size_in_bytes() const   { return _nullable_layout_size_in_bytes; }
+  bool has_nullable_atomic_layout() const      { return _nullable_atomic_layout_size_in_bytes != -1; }
+  int  nullable_layout_size_in_bytes() const   { return _nullable_atomic_layout_size_in_bytes; }
+  bool has_nullable_non_atomic_layout() const  { return _nullable_non_atomic_layout_size_in_bytes != -1; }
+  int  nullable_non_atomic_layout_size_in_bytes() const { return _nullable_non_atomic_layout_size_in_bytes; }
   int  null_marker_offset() const              { return _null_marker_offset; }
   bool is_empty_inline_class() const           { return _is_empty_inline_class; }
 

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -56,6 +56,7 @@
 
 FlatArrayKlass::FlatArrayKlass(Klass* element_klass, Symbol* name, LayoutKind lk) : ArrayKlass(name, Kind, markWord::flat_array_prototype(lk)) {
   assert(element_klass->is_inline_klass(), "Expected Inline");
+  assert(lk != LayoutKind::NULLABLE_NON_ATOMIC_FLAT, "Layout not supported by arrays yet (needs frozen arrays)");
   assert(lk == LayoutKind::NON_ATOMIC_FLAT || lk == LayoutKind::ATOMIC_FLAT || lk == LayoutKind::NULLABLE_ATOMIC_FLAT, "Must be a flat layout");
 
   set_element_klass(InlineKlass::cast(element_klass));
@@ -81,6 +82,8 @@ FlatArrayKlass::FlatArrayKlass(Klass* element_klass, Symbol* name, LayoutKind lk
       assert(!layout_helper_is_null_free(layout_helper()), "Must be");
       assert(!prototype_header().is_null_free_array(), "Must be");
     break;
+    case LayoutKind::NULLABLE_NON_ATOMIC_FLAT:
+      ShouldNotReachHere();
     default:
       ShouldNotReachHere();
     break;

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -153,7 +153,12 @@ class InlineKlass: public InstanceKlass {
 
   address adr_nullable_atomic_size_in_bytes() const {
     assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
-    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _nullable_size_in_bytes));
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _nullable_atomic_size_in_bytes));
+  }
+
+  address adr_nullable_non_atomic_size_in_bytes() const {
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _nullable_non_atomic_size_in_bytes));
   }
 
   address adr_null_marker_offset() const {
@@ -192,23 +197,26 @@ class InlineKlass: public InstanceKlass {
 
   bool has_nullable_atomic_layout() const { return nullable_atomic_size_in_bytes() != -1; }
   int nullable_atomic_size_in_bytes() const { return *(int*)adr_nullable_atomic_size_in_bytes(); }
-  void set_nullable_size_in_bytes(int size) { *(int*)adr_nullable_atomic_size_in_bytes() = size; }
+  void set_nullable_atomic_size_in_bytes(int size) { *(int*)adr_nullable_atomic_size_in_bytes() = size; }
+  bool has_nullable_non_atomic_layout() const { return nullable_non_atomic_size_in_bytes() != -1; }
+  int nullable_non_atomic_size_in_bytes() const { return *(int*)adr_nullable_non_atomic_size_in_bytes(); }
+  void set_nullable_non_atomic_size_in_bytes(int size) { *(int*)adr_nullable_non_atomic_size_in_bytes() = size; }
   int null_marker_offset() const { return *(int*)adr_null_marker_offset(); }
   int null_marker_offset_in_payload() const { return null_marker_offset() - payload_offset(); }
   void set_null_marker_offset(int offset) { *(int*)adr_null_marker_offset() = offset; }
 
   bool is_payload_marked_as_null(address payload) {
-    assert(has_nullable_atomic_layout(), " Must have");
+    assert(has_nullable_atomic_layout() || has_nullable_non_atomic_layout(), " Must have");
     return *((jbyte*)payload + null_marker_offset_in_payload()) == 0;
   }
 
   void mark_payload_as_non_null(address payload) {
-    assert(has_nullable_atomic_layout(), " Must have");
+    assert(has_nullable_atomic_layout() || has_nullable_non_atomic_layout(), " Must have");
     *((jbyte*)payload + null_marker_offset_in_payload()) = 1;
   }
 
   void mark_payload_as_null(address payload) {
-    assert(has_nullable_atomic_layout(), " Must have");
+    assert(has_nullable_atomic_layout() || has_nullable_non_atomic_layout(), " Must have");
     *((jbyte*)payload + null_marker_offset_in_payload()) = 0;
   }
 

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -157,7 +157,8 @@ class InlineKlassFixedBlock {
   int _non_atomic_size_in_bytes; // size of null-free non-atomic flat layout
   int _non_atomic_alignment;    // alignment requirement for null-free non-atomic layout
   int _atomic_size_in_bytes;    // size and alignment requirement for a null-free atomic layout, -1 if no atomic flat layout is possible
-  int _nullable_size_in_bytes;  // size and alignment requirement for a nullable layout (always atomic), -1 if no nullable flat layout is possible
+  int _nullable_atomic_size_in_bytes;  // size and alignment requirement for a nullable atomic layout, -1 if not available
+  int _nullable_non_atomic_size_in_bytes; // size and alignment requirement for a nullable non-atomic layout, -1 if not available
   int _null_marker_offset;      // expressed as an offset from the beginning of the object for a heap buffered value
                                 // payload_offset must be subtracted to get the offset from the beginning of the payload
 

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -109,6 +109,8 @@ markWord markWord::flat_array_prototype(LayoutKind lk) {
     case LayoutKind::NULLABLE_ATOMIC_FLAT:
       return markWord(nullable_flat_array_pattern);
       break;
+    case LayoutKind::NULLABLE_NON_ATOMIC_FLAT:
+      ShouldNotReachHere();
     default:
       ShouldNotReachHere();
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -827,6 +827,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, UseAtomicValueFlattening, false,                            \
           "Allow the JVM to flatten some atomic values")                    \
                                                                             \
+  product(bool, UseNullableNonAtomicValueFlattening, false,                 \
+           "Allow the JVM to flatten some strict final non-static fields")  \
+                                                                            \
   product(intx, FlatArrayElementMaxOops, 4,                                 \
           "Max nof embedded object references in an inline type to flatten, <0 no limit")  \
                                                                             \

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
@@ -80,14 +80,16 @@ public class FieldLayoutAnalyzer {
     NON_FLAT,
     NON_ATOMIC_FLAT,
     ATOMIC_FLAT,
-    NULLABLE_FLAT;
+    NULLABLE_ATOMIC_FLAT,
+    NULLABLE_NON_ATOMIC_FLAT;
 
     static LayoutKind parseLayoutKind(String s) {
       switch(s) {
         case ""                : return NON_FLAT;
         case "NON_ATOMIC_FLAT" : return NON_ATOMIC_FLAT;
         case "ATOMIC_FLAT"     : return ATOMIC_FLAT;
-        case "NULLABLE_ATOMIC_FLAT"   : return NULLABLE_FLAT;
+        case "NULLABLE_ATOMIC_FLAT"   : return NULLABLE_ATOMIC_FLAT;
+        case "NULLABLE_NON_ATOMIC_FLAT" : return NULLABLE_NON_ATOMIC_FLAT;
         default:
           throw new RuntimeException("Unknown layout kind: " + s);
       }
@@ -125,10 +127,6 @@ public class FieldLayoutAnalyzer {
 
     static FieldBlock parseField(String line) {
       String[] fieldLine = line.split("\\s+");
-      // for(String  s : fieldLine) {
-      //   System.out.print("["+s+"]");  // debugging statement to be removed
-      // }
-      // System.out.println();
       int offset = Integer.parseInt(fieldLine[1].substring(1, fieldLine[1].length()));
       BlockType type = BlockType.parseType(fieldLine[2]);
       String[] size_align = fieldLine[3].split("/");
@@ -185,8 +183,10 @@ public class FieldLayoutAnalyzer {
     int nonAtomicLayoutAlignment;    // -1 if no non-nullable layout
     int atomicLayoutSize;            // -1 if no atomic layout
     int atomicLayoutAlignment;       // -1 if no atomic layout
-    int nullableLayoutSize;          // -1 if no nullable layout
-    int nullableLayoutAlignment;     // -1 if no nullable layout
+    int nullableAtomicLayoutSize;          // -1 if no nullable layout
+    int nullableAtomicLayoutAlignment;     // -1 if no nullable layout
+    int nullableNonAtomicLayoutSize;
+    int nullableNonAtomicLayoutAlignment;
     int nullMarkerOffset;            // -1 if no nullable layout
     String[] lines;
     ArrayList<FieldBlock> staticFields;
@@ -199,7 +199,8 @@ public class FieldLayoutAnalyzer {
 
     boolean hasNonAtomicLayout() { return nonAtomicLayoutSize != -1; }
     boolean hasAtomicLayout() { return atomicLayoutSize != -1; }
-    boolean hasNullableLayout() { return nullableLayoutSize != -1; }
+    boolean hasNullableAtomicLayout() { return nullableAtomicLayoutSize != -1; }
+    boolean hasNullableNonAtomicLayout() { return nullableNonAtomicLayoutSize != -1; }
     boolean hasNullMarker() {return nullMarkerOffset != -1; }
 
     int getSize(LayoutKind layoutKind) {
@@ -212,9 +213,12 @@ public class FieldLayoutAnalyzer {
         case ATOMIC_FLAT:
           Asserts.assertTrue(atomicLayoutSize != -1);
           return atomicLayoutSize;
-        case NULLABLE_FLAT:
-          Asserts.assertTrue(nullableLayoutSize != -1);
-          return nullableLayoutSize;
+        case NULLABLE_ATOMIC_FLAT:
+          Asserts.assertTrue(nullableAtomicLayoutSize != -1);
+          return nullableAtomicLayoutSize;
+        case NULLABLE_NON_ATOMIC_FLAT:
+          Asserts.assertTrue(nullableNonAtomicLayoutSize != -1);
+          return nullableNonAtomicLayoutSize;
         default:
           throw new RuntimeException("Unknown LayoutKind " + layoutKind);
       }
@@ -230,9 +234,12 @@ public class FieldLayoutAnalyzer {
         case ATOMIC_FLAT:
           Asserts.assertTrue(atomicLayoutSize != -1);
           return atomicLayoutAlignment;
-        case NULLABLE_FLAT:
-          Asserts.assertTrue(nullableLayoutSize != -1);
-          return nullableLayoutAlignment;
+        case NULLABLE_ATOMIC_FLAT:
+          Asserts.assertTrue(nullableAtomicLayoutSize != -1);
+          return nullableAtomicLayoutAlignment;
+        case NULLABLE_NON_ATOMIC_FLAT:
+          Asserts.assertTrue(nullableNonAtomicLayoutSize != -1);
+          return nullableNonAtomicLayoutAlignment;
         default:
           throw new RuntimeException("Unknown LayoutKind " + layoutKind);
       }
@@ -320,21 +327,34 @@ public class FieldLayoutAnalyzer {
           cl.atomicLayoutAlignment = Integer.parseInt(size_align[1]);
         }
         lo.moveToNextLine();
-        // Nullable flat layout: x/y
-        Asserts.assertTrue(lo.getCurrentLine().startsWith("Nullable flat layout"));
-        String[] nullableLayoutLine = lo.getCurrentLine().split("\\s+");
-        size_align = nullableLayoutLine[3].split("/");
+        // Nullable atomic flat layout: x/y
+        Asserts.assertTrue(lo.getCurrentLine().startsWith("Nullable atomic flat layout"));
+        String[] nullableAtomicLayoutLine = lo.getCurrentLine().split("\\s+");
+        size_align = nullableAtomicLayoutLine[4].split("/");
         if (size_align[0].contentEquals("-")) {
           Asserts.assertTrue(size_align[1].contentEquals("-"), "Size/Alignment mismatch");
-          cl.nullableLayoutSize = -1;
-          cl.nullableLayoutAlignment = -1;
+          cl.nullableAtomicLayoutSize = -1;
+          cl.nullableAtomicLayoutAlignment = -1;
         } else {
-          cl.nullableLayoutSize = Integer.parseInt(size_align[0]);
-          cl.nullableLayoutAlignment = Integer.parseInt(size_align[1]);
+          cl.nullableAtomicLayoutSize = Integer.parseInt(size_align[0]);
+          cl.nullableAtomicLayoutAlignment = Integer.parseInt(size_align[1]);
+        }
+        lo.moveToNextLine();
+        // Nullable non-atomic flat layout: x/y
+        Asserts.assertTrue(lo.getCurrentLine().startsWith("Nullable non-atomic flat layout"));
+        String[] nullableNonAtomicLayoutLine = lo.getCurrentLine().split("\\s+");
+        size_align = nullableNonAtomicLayoutLine[4].split("/");
+        if (size_align[0].contentEquals("-")) {
+          Asserts.assertTrue(size_align[1].contentEquals("-"), "Size/Alignment mismatch");
+          cl.nullableNonAtomicLayoutSize = -1;
+          cl.nullableNonAtomicLayoutAlignment = -1;
+        } else {
+          cl.nullableNonAtomicLayoutSize = Integer.parseInt(size_align[0]);
+          cl.nullableNonAtomicLayoutAlignment = Integer.parseInt(size_align[1]);
         }
         lo.moveToNextLine();
         // Null marker offset = 15 (if class has a nullable flat layout)
-        if (cl.nullableLayoutSize != -1) {
+        if (cl.nullableAtomicLayoutSize != -1 || cl.nullableNonAtomicLayoutSize != -1) {
           Asserts.assertTrue(lo.getCurrentLine().startsWith("Null marker offset"));
           String[] nullMarkerLine = lo.getCurrentLine().split("\\s+");
           cl.nullMarkerOffset = Integer.parseInt(nullMarkerLine[4]);
@@ -345,7 +365,6 @@ public class FieldLayoutAnalyzer {
       } else {
         cl.isValue = false;
       }
-
       Asserts.assertTrue(lo.getCurrentLine().startsWith("---"), lo.getCurrentLine());
       lo.moveToNextLine();
       return cl;
@@ -647,7 +666,7 @@ public class FieldLayoutAnalyzer {
           last_type = block.type;
           if (block.type() == BlockType.NULL_MARKER) {
             Asserts.assertTrue(layout.hasNullMarker());
-            Asserts.assertTrue(layout.hasNullableLayout());
+            Asserts.assertTrue(layout.hasNullableAtomicLayout() || layout.hasNullableNonAtomicLayout());
             Asserts.assertEQ(block.offset(), layout.nullMarkerOffset);
           }
           if (block.type() == BlockType.EMPTY) has_empty_slot = true;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/StrictFinalTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/StrictFinalTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @library /test/lib
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @compile FieldLayoutAnalyzer.java StrictFinalTest.java
+ * @run main/othervm -XX:+UseNullableNonAtomicValueFlattening StrictFinalTest
+ */
+
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jdk.internal.vm.annotation.ImplicitlyConstructible;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class StrictFinalTest {
+
+    static class TestRunner {
+        public static void main(String[] args) throws Exception {
+            Class testClass = Class.forName("StrictFinalTest");
+            Asserts.assertNotNull(testClass);
+            Method[] testMethods = testClass.getMethods();
+            for (Method test : testMethods) {
+                if (test.getName().startsWith("test_")) {
+                    Asserts.assertTrue(Modifier.isStatic(test.getModifiers()));
+                    Asserts.assertTrue(test.getReturnType().equals(Void.TYPE));
+                    System.out.println("Running " + test.getName());
+                    test.invoke(null);
+                }
+            }
+        }
+    }
+
+    @LooselyConsistentValue
+    static value class Value0 {
+        // Just big enough to be bigger than 64 bits with the null marker
+        int i = 0;
+        int j = 0;
+    }
+
+    static value class Container0 {
+        Value0 val0 = new Value0();
+    }
+
+    static public void test_0() {
+        Container0 c = new Container0();
+    }
+
+    static public void check_0(FieldLayoutAnalyzer fla) {
+        FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container0");
+        FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_NON_ATOMIC_FLAT, f.layoutKind());
+    }
+
+    static value class Value1 {
+        // Just big enough to be bigger than 64 bits with the null marker
+        int i = 0;
+        int j = 0;
+    }
+
+    static value class Container1 {
+        Value1 val0 = new Value1();
+    }
+
+    static public void test_1() {
+        Container1 c = new Container1();
+    }
+
+    static public void check_1(FieldLayoutAnalyzer fla) {
+        FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container1");
+        FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+        // Value classes' fields are always strict and final, must be flattened
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_NON_ATOMIC_FLAT, f.layoutKind());
+    }
+
+    static class Container2 {
+        Value1 val0 = new Value1();
+    }
+
+
+    static public void test_2() {
+        Container2 c = new Container2();
+    }
+
+    static public void check_2(FieldLayoutAnalyzer fla) {
+        FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container2");
+        FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+        // Not strict nor final, must not be flattened
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f.layoutKind());
+    }
+
+    // Test temporarily disabled, to be be re-enabled when strict non-final fields are supported
+    //
+    // static class Container3 {
+    //     @Strict
+    //     Value1 val0 = new Value1();
+    // }
+
+
+    // static public void test_3() {
+    //     Container3 c = new Container3();
+    // }
+
+    // static public void check_3(FieldLayoutAnalyzer fla) {
+    //     FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container3");
+    //     FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+    //     // Not final, must not be flattened
+    //     Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f.layoutKind());
+    // }
+
+    static class Container4 {
+        final Value1 val0 = new Value1();
+    }
+
+
+    static public void test_4() {
+        Container4 c = new Container4();
+    }
+
+    static public void check_4(FieldLayoutAnalyzer fla) {
+        FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container4");
+        FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+        // Not strict, must not be flattened
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f.layoutKind());
+    }
+
+    static class Container5 {
+        @Strict
+        final Value1 val0 = new Value1();
+    }
+
+    static public void test_5() {
+        Container5 c = new Container5();
+        Asserts.assertNotNull(c.val0);
+    }
+
+    static public void check_5(FieldLayoutAnalyzer fla) {
+        FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container5");
+        FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+        // Strict and final, must be flattened
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_NON_ATOMIC_FLAT, f.layoutKind());
+    }
+
+    static class Container6 {
+        @Strict
+        final Value1 val0 = null;
+    }
+
+    static public void test_6() {
+        Container6 c = new Container6();
+        Asserts.assertNull(c.val0);
+    }
+
+    static public void check_6(FieldLayoutAnalyzer fla) {
+        FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container6");
+        FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+        // Strict and final, must be flattened
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_NON_ATOMIC_FLAT, f.layoutKind());
+    }
+
+    @LooselyConsistentValue
+    static value class Container7 {
+        Value1 val0 = new Value1();
+    }
+
+    static public void test_7() {
+        Container7 c = new Container7();
+        Asserts.assertNotNull(c.val0);
+    }
+
+    static public void check_7(FieldLayoutAnalyzer fla) {
+        FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("StrictFinalTest$Container7");
+        FieldLayoutAnalyzer.FieldBlock f = cl.getFieldFromName("val0", false);
+        // Container is not atomic, must not flattened
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f.layoutKind());
+    }
+
+    static ProcessBuilder exec(String... args) throws Exception {
+        List<String> argsList = new ArrayList<>();
+        Collections.addAll(argsList, "--enable-preview");
+        Collections.addAll(argsList, "-Xint");
+        Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
+        Collections.addAll(argsList, "-XX:+PrintFieldLayout");
+        Collections.addAll(argsList, "-Xshare:off");
+        Collections.addAll(argsList, "-Xmx256m");
+        Collections.addAll(argsList, "-XX:+UseNullableNonAtomicValueFlattening");
+        Collections.addAll(argsList, "-cp", System.getProperty("java.class.path") + System.getProperty("path.separator") + ".");
+        Collections.addAll(argsList, args);
+        return ProcessTools.createTestJavaProcessBuilder(argsList);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        // Generate test classes
+        StrictFinalTest sft = new StrictFinalTest();
+
+        // Execute the test runner in charge of loading all test classes
+        ProcessBuilder pb = exec("StrictFinalTest$TestRunner");
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+
+        if (out.getExitValue() != 0) {
+            System.out.print(out.getOutput());
+        }
+        Asserts.assertEquals(out.getExitValue(), 0, "Something went wrong while running the tests");
+
+        // To help during test development
+        System.out.print(out.getOutput());
+
+        // Get and parse the test output
+        FieldLayoutAnalyzer.LogOutput lo = new FieldLayoutAnalyzer.LogOutput(out.asLines());
+        FieldLayoutAnalyzer fla =  FieldLayoutAnalyzer.createFieldLayoutAnalyzer(lo);
+
+        // Running tests verification method (check that tests produced the right configuration)
+        Class testClass = StrictFinalTest.class;
+        Method[] testMethods = testClass.getMethods();
+        for (Method test : testMethods) {
+            if (test.getName().startsWith("check_")) {
+                Asserts.assertTrue(Modifier.isStatic(test.getModifiers()));
+                Asserts.assertTrue(test.getReturnType().equals(Void.TYPE));
+                test.invoke(null, fla);
+            }
+        }
+
+        // Verify that all layouts are correct
+        fla.check();
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java
@@ -146,7 +146,7 @@ public class TestLayoutFlags {
         FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("TestLayoutFlags$Container0");
         FieldLayoutAnalyzer.FieldBlock f0 = cl.getFieldFromName("val0", false);
         if (useNullableAtomicFlat) {
-            Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_FLAT, f0.layoutKind());
+            Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_ATOMIC_FLAT, f0.layoutKind());
         } else {
             Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f0.layoutKind());
         }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java
@@ -117,7 +117,7 @@ public class ValueCompositionTest {
     }
     FieldLayoutAnalyzer.FieldBlock f1 = cl.getFieldFromName("val1", false);
     if (useNullableAtomicFlat) {
-      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_FLAT, f1.layoutKind());
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_ATOMIC_FLAT, f1.layoutKind());
     } else {
       Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f1.layoutKind());
     }
@@ -144,7 +144,7 @@ public class ValueCompositionTest {
     }
     FieldLayoutAnalyzer.FieldBlock f1 = cl.getFieldFromName("val1", false);
     if (useNullableAtomicFlat) {
-      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_FLAT, f1.layoutKind());
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_ATOMIC_FLAT, f1.layoutKind());
     } else {
       Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f1.layoutKind());
     }
@@ -194,7 +194,7 @@ public class ValueCompositionTest {
     Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_ATOMIC_FLAT, f0.layoutKind());
     FieldLayoutAnalyzer.FieldBlock f1 = cl.getFieldFromName("val1", false);
     if (useNullableAtomicFlat) {
-      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_FLAT, f1.layoutKind());
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_ATOMIC_FLAT, f1.layoutKind());
     } else {
       Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f1.layoutKind());
     }
@@ -217,7 +217,7 @@ public class ValueCompositionTest {
     Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_ATOMIC_FLAT, f0.layoutKind());
     FieldLayoutAnalyzer.FieldBlock f1 = cl.getFieldFromName("val1", false);
     if (useNullableAtomicFlat) {
-      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_FLAT, f1.layoutKind());
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_ATOMIC_FLAT, f1.layoutKind());
     } else {
       Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f1.layoutKind());
     }
@@ -264,7 +264,7 @@ public class ValueCompositionTest {
     Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_ATOMIC_FLAT, f0.layoutKind());
     FieldLayoutAnalyzer.FieldBlock f1 = cl.getFieldFromName("val1", false);
     if (useNullableAtomicFlat) {
-      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_FLAT, f1.layoutKind());
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_ATOMIC_FLAT, f1.layoutKind());
     } else {
       Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f1.layoutKind());
     }
@@ -287,7 +287,7 @@ public class ValueCompositionTest {
     Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_ATOMIC_FLAT, f0.layoutKind());
     FieldLayoutAnalyzer.FieldBlock f1 = cl.getFieldFromName("val1", false);
     if (useNullableAtomicFlat) {
-      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_FLAT, f1.layoutKind());
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_ATOMIC_FLAT, f1.layoutKind());
     } else {
       Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f1.layoutKind());
     }


### PR DESCRIPTION
Strict final instance fields are not subject to concurrent writes during a read access, so they can be flattened even if they are nullable and bigger than 64 bits. The NULLABLE_NON_ATOMIC_FLAT layout is added for this particular case.
