### PR TITLE
8350632: [lworld] Parse::array_store_check() assert introduced by 8348411 fails

### DIFF
--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -251,8 +251,6 @@ Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
   int element_klass_offset = in_bytes(ArrayKlass::element_klass_offset());
   Node* p2 = basic_plus_adr(array_klass, array_klass, element_klass_offset);
   Node* a_e_klass = _gvn.transform(LoadKlassNode::make(_gvn, immutable_memory(), p2, tak));
-  // Disable, fix: 8350632
-  //assert(array_klass->is_Con() == a_e_klass->is_Con() || StressReflectiveCode, "a constant array type must come with a constant element type");
 
   // If we statically know that this is an inline type array, use precise element klass for checkcast
   const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
@@ -263,6 +261,14 @@ Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
     a_e_klass = makecon(TypeKlassPtr::make(elemtype->inline_klass()));
   }
 #ifdef ASSERT
+  if (!StressReflectiveCode && array_klass->is_Con() != a_e_klass->is_Con()) {
+    // When the element type is exact, the array type also needs to be exact. There is one exception, though:
+    // Nullable arrays are not exact because the null-free array is a subtype while the element type being a
+    // concrete value class (i.e. final) is always exact.
+    assert(!array_klass->is_Con() && a_e_klass->is_Con() && elem_ptr->is_inlinetypeptr() && !null_free,
+           "a constant element type either matches a constant array type or a non-constant nullable value class array");
+  }
+
   // If the element type is exact, the array can be null-free (i.e. the element type is NotNull) if:
   //   - The elements are inline types
   //   - The array is from an autobox cache.


### PR DESCRIPTION
The assert introduced with JDK-8348411 is too strong when having value classes around because of the following reason:

https://github.com/openjdk/valhalla/blob/3f6f249bd457538f020d062ffe5b295509b45a4c/src/hotspot/share/opto/parseHelper.cpp#L265-L267

I've updated the assert to make it work with value classes by special casing them.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350632](https://bugs.openjdk.org/browse/JDK-8350632): [lworld] Parse::array_store_check() assert introduced by 8348411 fails (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1410/head:pull/1410` \
`$ git checkout pull/1410`

Update a local copy of the PR: \
`$ git checkout pull/1410` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1410`

View PR using the GUI difftool: \
`$ git pr show -t 1410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1410.diff">https://git.openjdk.org/valhalla/pull/1410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1410#issuecomment-2754119311)
</details>
