### PR TITLE
8352750: More encapsulation of JImage file. Too much?

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -253,9 +253,10 @@ Symbol* ClassLoader::package_from_class_name(const Symbol* name, bool* bad_class
 // The following jimage_xxx static functions encapsulate all JImage_file and JImage_mode access.
 // This is done to make it easy to reason about the JImage file state (exists vs initialized etc.).
 
-// Opens the named JImage file.
+// Opens the named JImage file and sets the JImage file reference.
+// Returns true if opening the JImage file was successful (see also jimage_exists()).
 static bool jimage_open(const char* modules_path) {
-  // Current 'error' is not set to anything useful so ignore it here.
+  // Currently 'error' is not set to anything useful, so ignore it here.
   jint error;
   JImage_file = (*JImageOpen)(modules_path, &error);
   return JImage_file != nullptr;

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -249,6 +249,73 @@ Symbol* ClassLoader::package_from_class_name(const Symbol* name, bool* bad_class
   return SymbolTable::new_symbol(name, pointer_delta_as_int(start, base), pointer_delta_as_int(end, base));
 }
 
+// --------------------------------
+// The following jimage_xxx static functions encapsulate all JImage_file and JImage_mode access.
+// This is done to make it easy to reason about the JImage file state (exists vs initialized etc.).
+
+// Opens the named JImage file.
+static bool jimage_open(const char* modules_path) {
+  // Current 'error' is not set to anything useful so ignore it here.
+  jint error;
+  JImage_file = (*JImageOpen)(modules_path, &error);
+  return JImage_file != nullptr;
+}
+
+// Closes and clears the JImage file reference (this will only be called during shutdown).
+static void jimage_close() {
+  if (JImage_file != nullptr) {
+    (*JImageClose)(JImage_file);
+    JImage_file = nullptr;
+  }
+}
+
+// Returns whether a JImage file was opened (but NOT whether it was initialized yet).
+static bool jimage_exists() {
+  return JImage_file != nullptr;
+}
+
+// Returns the JImage file reference (which may or may not be initialized).
+static JImageFile* jimage_non_null() {
+  assert(jimage_exists(), "should have been opened by ClassLoader::lookup_vm_options "
+                          "and remained throughout normal JVM lifetime");
+  return JImage_file;
+}
+
+// Called once to set the access mode for resource (i.e. preview or non-preview) before
+// general resource lookup can occur.
+static void jimage_init(bool enable_preview) {
+  assert(JImage_mode == JIMAGE_MODE_UNINITIALIZED, "jimage_init must not be called twice");
+  JImage_mode = enable_preview ? JIMAGE_MODE_ENABLE_PREVIEW : JIMAGE_MODE_DEFAULT;
+}
+
+// Returns true if jimage_init() has been called. Once the JImage file is initialized,
+// jimage_is_preview_enabled() can be called to correctly determine the access mode.
+static bool jimage_is_initialized() {
+  return jimage_exists() && JImage_mode != JIMAGE_MODE_UNINITIALIZED;
+}
+
+// Returns the access mode for an initialized JImage file (reflects --enable-preview).
+static bool jimage_is_preview_enabled() {
+  assert(jimage_is_initialized(), "jimage is not initialized");
+  return JImage_mode == JIMAGE_MODE_ENABLE_PREVIEW;
+}
+
+// Looks up the location of a named JImage resource. This "raw" lookup function allows
+// the preview mode to be manually specified, so must not be accessible outside this
+// class. ClassPathImageEntry manages all calls for resources after startup is complete.
+static JImageLocationRef jimage_find_resource(const char* module_name,
+                                              const char* file_name,
+                                              bool is_preview,
+                                              jlong *size) {
+  return ((*JImageFindResource)(jimage_non_null(),
+                                module_name,
+                                get_jimage_version_string(),
+                                file_name,
+                                is_preview,
+                                size));
+}
+// --------------------------------
+
 // Given a fully qualified package name, find its defining package in the class loader's
 // package entry table.
 PackageEntry* ClassLoader::get_package_entry(Symbol* pkg_name, ClassLoaderData* loader_data) {
@@ -376,30 +443,14 @@ ClassFileStream* ClassPathZipEntry::open_stream(JavaThread* current, const char*
 
 DEBUG_ONLY(ClassPathImageEntry* ClassPathImageEntry::_singleton = nullptr;)
 
-JImageFile* ClassPathImageEntry::jimage_non_null() const {
-  assert(ClassLoader::has_jrt_entry(), "must be");
-  assert(JImage_file != nullptr, "should have been opened by ClassLoader::lookup_vm_options "
-                           "and remained throughout normal JVM lifetime");
-  return JImage_file;
-}
-
-bool ClassPathImageEntry::is_preview_enabled() const {
-  assert(JImage_mode != JIMAGE_MODE_UNINITIALIZED, "uninitialized JImage reference");
-  return JImage_mode == JIMAGE_MODE_ENABLE_PREVIEW;
-}
-
 void ClassPathImageEntry::close_jimage() {
-  if (JImage_file != nullptr) {
-    (*JImageClose)(JImage_file);
-    JImage_file = nullptr;
-  }
+  jimage_close();
 }
 
-ClassPathImageEntry::ClassPathImageEntry(JImageFile* jimage, const char* name) :
+ClassPathImageEntry::ClassPathImageEntry(const char* name) :
   ClassPathEntry() {
-  guarantee(jimage != nullptr, "jimage file is null");
+  guarantee(jimage_is_initialized(), "jimage is not initialized");
   guarantee(name != nullptr, "jimage file name is null");
-  guarantee(JImage_mode != JIMAGE_MODE_UNINITIALIZED, "jimage is uninitialized");
 
   assert(_singleton == nullptr, "VM supports only one jimage");
   DEBUG_ONLY(_singleton = this);
@@ -419,11 +470,10 @@ ClassFileStream* ClassPathImageEntry::open_stream(JavaThread* current, const cha
 //     2. A package is in at most one module in the jimage file.
 //
 ClassFileStream* ClassPathImageEntry::open_stream_for_loader(JavaThread* current, const char* name, ClassLoaderData* loader_data) {
-  JImageFile* jimage = this->jimage_non_null();
-  bool is_preview = this->is_preview_enabled();
+  bool is_preview = jimage_is_preview_enabled();
 
   jlong size;
-  JImageLocationRef location = (*JImageFindResource)(jimage, "", get_jimage_version_string(), name, &size);
+  JImageLocationRef location = jimage_find_resource("", name, is_preview, &size);
 
   if (location == 0) {
     TempNewSymbol class_name = SymbolTable::new_symbol(name);
@@ -431,7 +481,7 @@ ClassFileStream* ClassPathImageEntry::open_stream_for_loader(JavaThread* current
 
     if (pkg_name != nullptr) {
       if (!Universe::is_module_initialized()) {
-        location = (*JImageFindResource)(jimage, JAVA_BASE_NAME, get_jimage_version_string(), name, &size);
+        location = jimage_find_resource(JAVA_BASE_NAME, name, is_preview, &size);
       } else {
         PackageEntry* package_entry = ClassLoader::get_package_entry(pkg_name, loader_data);
         if (package_entry != nullptr) {
@@ -442,7 +492,7 @@ ClassFileStream* ClassPathImageEntry::open_stream_for_loader(JavaThread* current
           assert(module->is_named(), "Boot classLoader package is in unnamed module");
           const char* module_name = module->name()->as_C_string();
           if (module_name != nullptr) {
-            location = (*JImageFindResource)(jimage, module_name, get_jimage_version_string(), name, &size);
+            location = jimage_find_resource(module_name, name, is_preview, &size);
           }
         }
       }
@@ -453,7 +503,7 @@ ClassFileStream* ClassPathImageEntry::open_stream_for_loader(JavaThread* current
       ClassLoader::perf_sys_classfile_bytes_read()->inc(size);
     }
     char* data = NEW_RESOURCE_ARRAY(char, size);
-    (*JImageGetResource)(jimage, location, data, size);
+    (*JImageGetResource)(jimage_non_null(), location, data, size);
     // Resource allocated
     assert(this == ClassLoader::get_jrt_entry(), "must be");
     return new ClassFileStream((u1*)data,
@@ -463,13 +513,6 @@ ClassFileStream* ClassPathImageEntry::open_stream_for_loader(JavaThread* current
   }
 
   return nullptr;
-}
-
-JImageLocationRef ClassLoader::jimage_find_resource(JImageFile* jf,
-                                                    const char* module_name,
-                                                    const char* file_name,
-                                                    jlong &size) {
-  return ((*JImageFindResource)(jf, module_name, get_jimage_version_string(), file_name, &size));
 }
 
 bool ClassPathImageEntry::is_modules_image() const {
@@ -688,15 +731,14 @@ void ClassLoader::setup_bootstrap_search_path_impl(JavaThread* current, const ch
       struct stat st;
       if (os::stat(path, &st) == 0) {
         // Directory found
-        if (JImage_file != nullptr) {
+        if (jimage_exists()) {
           assert(Arguments::has_jimage(), "sanity check");
           const char* canonical_path = get_canonical_path(path, current);
           assert(canonical_path != nullptr, "canonical_path issue");
 
-          // Hand over lifecycle control of JImage_file to the _jrt_entry singleton (see
-          // ClassPathImageEntry::close_jimage). The image must be initialized by now.
-          assert(JImage_mode != JIMAGE_MODE_UNINITIALIZED, "init_jimage() must be called before here");
-          _jrt_entry = new ClassPathImageEntry(JImage_file, canonical_path);
+          // Hand over lifecycle control of the JImage file to the _jrt_entry singleton
+          // (see ClassPathImageEntry::close_jimage). The image must be initialized by now.
+          _jrt_entry = new ClassPathImageEntry(canonical_path);
           assert(_jrt_entry != nullptr && _jrt_entry->is_modules_image(), "No java runtime image present");
         } // else it's an exploded build.
       } else {
@@ -1537,20 +1579,8 @@ void ClassLoader::initialize(TRAPS) {
   setup_bootstrap_search_path(THREAD);
 }
 
-static char* lookup_vm_resource(JImageFile *jimage, const char *jimage_version, const char *path) {
-  jlong size;
-  JImageLocationRef location = (*JImageFindResource)(jimage, "java.base", jimage_version, path, &size);
-  if (location == 0)
-    return nullptr;
-  char *val = NEW_C_HEAP_ARRAY(char, size+1, mtClass);
-  (*JImageGetResource)(jimage, location, val, size);
-  val[size] = '\0';
-  return val;
-}
-
 // Lookup VM options embedded in the modules jimage file
 char* ClassLoader::lookup_vm_options() {
-  jint error;
   char modules_path[JVM_MAXPATHLEN];
   const char* fileSep = os::file_separator();
 
@@ -1558,36 +1588,42 @@ char* ClassLoader::lookup_vm_options() {
   load_jimage_library();
 
   jio_snprintf(modules_path, JVM_MAXPATHLEN, "%s%slib%smodules", Arguments::get_java_home(), fileSep, fileSep);
-  JImage_file =(*JImageOpen)(modules_path, &error);
-  if (JImage_file == nullptr) {
-    return nullptr;
+  if (jimage_open(modules_path)) {
+    // Special case where we lookup the options string *before* calling jimage_init().
+    // Since VM arguments have not been parsed, and the ClassPathImageEntry singleton
+    // has not been created yet, we access the JImage file directly in non-preview mode.
+    jlong size;
+    JImageLocationRef location =
+            jimage_find_resource(JAVA_BASE_NAME, "jdk/internal/vm/options", /* is_preview */ false, &size);
+    if (location != 0) {
+      char *options = NEW_C_HEAP_ARRAY(char, size+1, mtClass);
+      (*JImageGetResource)(jimage_non_null(), location, options, size);
+      options[size] = '\0';
+      return options;
+    }
   }
-
-  const char *jimage_version = get_jimage_version_string();
-  char *options = lookup_vm_resource(JImage_file, jimage_version, "jdk/internal/vm/options");
-  return options;
+  return nullptr;
 }
 
 // Finishes initializing the JImageFile (if present) by setting the access mode.
 void ClassLoader::init_jimage(bool enable_preview) {
-  if (JImage_file != nullptr) {
-    assert(JImage_mode == JIMAGE_MODE_UNINITIALIZED, "init_jimage() must not be called twice");
-    JImage_mode = enable_preview ? JIMAGE_MODE_ENABLE_PREVIEW : JIMAGE_MODE_DEFAULT;
+  if (jimage_exists()) {
+    jimage_init(enable_preview);
   }
 }
 
 bool ClassLoader::is_module_observable(const char* module_name) {
   assert(JImageOpen != nullptr, "jimage library should have been opened");
-  if (JImage_file == nullptr) {
+  if (!jimage_exists()) {
     struct stat st;
     const char *path = get_exploded_module_path(module_name, true);
     bool res = os::stat(path, &st) == 0;
     FREE_C_HEAP_ARRAY(char, path);
     return res;
   }
+  // We don't expect preview mode (i.e. --enable-preview) to affect module visibility.
   jlong size;
-  const char *jimage_version = get_jimage_version_string();
-  return (*JImageFindResource)(JImage_file, module_name, jimage_version, "module-info.class", &size) != 0;
+  return jimage_find_resource(module_name, "module-info.class", /* is_preview */ false, &size) != 0;
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -63,8 +63,6 @@ public:
   // Is this entry created from the "Class-path" attribute from a JAR Manifest?
   virtual bool from_class_path_attr() const { return false; }
   virtual const char* name() const = 0;
-  virtual JImageFile* jimage() const { return nullptr; }
-  virtual void close_jimage() {}
   // Constructor
   ClassPathEntry() : _next(nullptr) {}
   // Attempt to locate file_name through this class path entry.
@@ -107,19 +105,29 @@ class ClassPathZipEntry: public ClassPathEntry {
 };
 
 
-// For java image files
+// A singleton path entry which takes ownership of the initialized JImageFile
+// reference. Not used for exploded builds.
 class ClassPathImageEntry: public ClassPathEntry {
 private:
   const char* _name;
   DEBUG_ONLY(static ClassPathImageEntry* _singleton;)
+
+  // Private to guarantee only ClassPathImageEntry can access the JImage structure,
+  // and ensure we completely control the behaviour around '--enable-preview'.
+  //
+  // Returns the non-null, initialized JImage file reference.
+  JImageFile* jimage_non_null() const;
+  // Returns whether the JImage file will return resources suitable for a preview JVM.
+  bool is_preview_enabled() const;
 public:
   bool is_modules_image() const;
   const char* name() const { return _name == nullptr ? "" : _name; }
-  JImageFile* jimage() const;
-  JImageFile* jimage_non_null() const;
+  // Called to closes the JImage during os::abort (normally not called).
   void close_jimage();
+  // Takes ownership of the given (initialized) static JImageFile pointer.
   ClassPathImageEntry(JImageFile* jimage, const char* name);
   virtual ~ClassPathImageEntry() { ShouldNotReachHere(); }
+
   ClassFileStream* open_stream(JavaThread* current, const char* name);
   ClassFileStream* open_stream_for_loader(JavaThread* current, const char* name, ClassLoaderData* loader_data);
 };
@@ -208,10 +216,10 @@ class ClassLoader: AllStatic {
   static GrowableArray<ModuleClassPathList*>* _patch_mod_entries;
 
   // 2. the base piece
-  //    Contains the ClassPathEntry of the modular java runtime image.
+  //    Contains the ClassPathImageEntry of the modular java runtime image.
   //    If no java runtime image is present, this indicates a
   //    build with exploded modules is being used instead.
-  static ClassPathEntry* _jrt_entry;
+  static ClassPathImageEntry* _jrt_entry;
   static GrowableArray<ModuleClassPathList*>* _exploded_entries;
   enum { EXPLODED_ENTRY_SIZE = 80 }; // Initial number of exploded modules
 
@@ -331,7 +339,7 @@ class ClassLoader: AllStatic {
 
   // Modular java runtime image is present vs. a build with exploded modules
   static bool has_jrt_entry() { return (_jrt_entry != nullptr); }
-  static ClassPathEntry* get_jrt_entry() { return _jrt_entry; }
+  static ClassPathImageEntry* get_jrt_entry() { return _jrt_entry; }
   static void close_jrt_image();
 
   // Add a module's exploded directory to the boot loader's exploded module build list
@@ -395,7 +403,15 @@ class ClassLoader: AllStatic {
   static void record_hidden_class(InstanceKlass* ik);
 #endif
 
+  // Retrieves additional VM options prior to flags processing. Options held
+  // in the JImage file are retrieved without fully initializing it. (this is
+  // the only JImage lookup which can succeed before init_jimage() is called).
   static char* lookup_vm_options();
+
+  // Called once, after all flags are processed, to finish initializing the
+  // JImage file. Until this is called, jimage_find_resource(), and any other
+  // JImage resource lookups or access will fail.
+  static void init_jimage(bool enable_preview);
 
   // Determines if the named module is present in the
   // modules jimage file or in the exploded modules directory.

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -111,21 +111,13 @@ class ClassPathImageEntry: public ClassPathEntry {
 private:
   const char* _name;
   DEBUG_ONLY(static ClassPathImageEntry* _singleton;)
-
-  // Private to guarantee only ClassPathImageEntry can access the JImage structure,
-  // and ensure we completely control the behaviour around '--enable-preview'.
-  //
-  // Returns the non-null, initialized JImage file reference.
-  JImageFile* jimage_non_null() const;
-  // Returns whether the JImage file will return resources suitable for a preview JVM.
-  bool is_preview_enabled() const;
 public:
   bool is_modules_image() const;
   const char* name() const { return _name == nullptr ? "" : _name; }
   // Called to closes the JImage during os::abort (normally not called).
   void close_jimage();
-  // Takes ownership of the given (initialized) static JImageFile pointer.
-  ClassPathImageEntry(JImageFile* jimage, const char* name);
+  // Takes effective ownership of the static JImageFile pointer.
+  ClassPathImageEntry(const char* name);
   virtual ~ClassPathImageEntry() { ShouldNotReachHere(); }
 
   ClassFileStream* open_stream(JavaThread* current, const char* name);
@@ -339,7 +331,7 @@ class ClassLoader: AllStatic {
 
   // Modular java runtime image is present vs. a build with exploded modules
   static bool has_jrt_entry() { return (_jrt_entry != nullptr); }
-  static ClassPathImageEntry* get_jrt_entry() { return _jrt_entry; }
+  static ClassPathEntry* get_jrt_entry() { return _jrt_entry; }
   static void close_jrt_image();
 
   // Add a module's exploded directory to the boot loader's exploded module build list
@@ -416,9 +408,6 @@ class ClassLoader: AllStatic {
   // Determines if the named module is present in the
   // modules jimage file or in the exploded modules directory.
   static bool is_module_observable(const char* module_name);
-
-  static JImageLocationRef jimage_find_resource(JImageFile* jf, const char* module_name,
-                                                const char* file_name, jlong &size);
 
   static void  trace_class_path(const char* msg, const char* name = nullptr);
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3556,8 +3556,8 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
 
   // Parse the options in the /java.base/jdk/internal/vm/options resource, if present.
   // This opens the JImage file for lookup of the options, but a subsequent call to
-  // ClassLoader::enable_preview(bool) MUST be made before other resources can be
-  // read (see finalize_patch_module()).
+  // ClassLoader::init_jimage(bool) MUST be made before other resources can be read
+  // (see finalize_patch_module()).
   char *vmoptions = ClassLoader::lookup_vm_options();
   if (vmoptions != nullptr) {
     code = parse_options_buffer("vm options resource", vmoptions, strlen(vmoptions), &initial_vm_options_args);

--- a/src/java.base/share/native/libjimage/jimage.cpp
+++ b/src/java.base/share/native/libjimage/jimage.cpp
@@ -109,17 +109,18 @@ JIMAGE_PackageToModule(JImageFile* image, const char* package_name) {
  * information describing the resource and its size. If no resource is found, the
  * function returns JIMAGE_NOT_FOUND and the value of size is undefined.
  * The version number should be "9.0" and is not used in locating the resource.
+ * 'is_preview' reflects whether the VM was instantiated with --enable-preview.
  * The resulting location does/should not have to be released.
  * All strings are utf-8, zero byte terminated.
  *
  *  Ex.
  *   jlong size;
- *   JImageLocationRef location = (*JImageFindResource)(image,
- *                                 "java.base", "9.0", "java/lang/String.class", &size);
+ *   JImageLocationRef location =(*JImageFindResource)(image,
+ *           "java.base", "9.0", "java/lang/String.class", false, &size);
  */
 extern "C" JNIEXPORT JImageLocationRef
 JIMAGE_FindResource(JImageFile* image,
-        const char* module_name, const char* version, const char* name,
+        const char* module_name, const char* version, const char* name, bool is_preview,
         jlong* size) {
     // Concatenate to get full path
     char fullpath[IMAGE_MAX_PATH];

--- a/src/java.base/share/native/libjimage/jimage.hpp
+++ b/src/java.base/share/native/libjimage/jimage.hpp
@@ -118,20 +118,21 @@ typedef const char* (*JImagePackageToModule_t)(JImageFile* jimage, const char* p
  * information describing the resource and its size. If no resource is found, the
  * function returns JIMAGE_NOT_FOUND and the value of size is undefined.
  * The version number should be "9.0" and is not used in locating the resource.
+ * 'is_preview' reflects whether the VM was instantiated with --enable-preview.
  * The resulting location does/should not have to be released.
  * All strings are utf-8, zero byte terminated.
  *
  *  Ex.
  *   jlong size;
- *   JImageLocationRef location = (*JImageFindResource)(image,
- *                                "java.base", "9.0", "java/lang/String.class", &size);
+ *   JImageLocationRef location =(*JImageFindResource)(image,
+ *           "java.base", "9.0", "java/lang/String.class", false, &size);
  */
 extern "C" JNIEXPORT JImageLocationRef JIMAGE_FindResource(JImageFile* jimage,
-        const char* module_name, const char* version, const char* name,
+        const char* module_name, const char* version, const char* name, bool is_preview,
         jlong* size);
 
 typedef JImageLocationRef(*JImageFindResource_t)(JImageFile* jimage,
-        const char* module_name, const char* version, const char* name,
+        const char* module_name, const char* version, const char* name, bool is_preview,
         jlong* size);
 
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8352750](https://bugs.openjdk.org/browse/JDK-8352750)

### Issue
 * [JDK-8352750](https://bugs.openjdk.org/browse/JDK-8352750): [lworld] Use jimage for preview enabled value classes (**Enhancement** - P3) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1411/head:pull/1411` \
`$ git checkout pull/1411`

Update a local copy of the PR: \
`$ git checkout pull/1411` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1411`

View PR using the GUI difftool: \
`$ git pr show -t 1411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1411.diff">https://git.openjdk.org/valhalla/pull/1411.diff</a>

</details>
