### PR TITLE
8352727: [lworld] Remove or replace obsolete StressInlineTypeReturnedAsFields flag from tests

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -76,8 +76,7 @@ public class InlineTypes {
                          "-XX:-UseArrayLoadStoreProfile",
                          "-XX:+UseFieldFlattening",
                          "-XX:+InlineTypePassFieldsAsArgs",
-                         "-XX:+InlineTypeReturnedAsFields",
-                         "-XX:+StressInlineTypeReturnedAsFields"
+                         "-XX:+InlineTypeReturnedAsFields"
             ),
             new Scenario(3,
                          "--enable-preview",

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
@@ -65,7 +65,7 @@ public class TestCallingConventionC1 {
                              "-XX:TieredStopAtLevel=4",
                              "-XX:+TieredCompilation",
                              "-XX:+IgnoreUnrecognizedVMOptions",
-                             "-XX:+StressInlineTypeReturnedAsFields"),
+                             "-XX:+StressCallingConvention"),
                 // Same as above, but flip all the compLevel=CompLevel.C1_SIMPLE and compLevel=CompLevel.C2, so we test
                 // the compliment of the above scenario.
                 new Scenario(2,


### PR DESCRIPTION
[JDK-8301007](https://bugs.openjdk.org/browse/JDK-8301007) renamed `StressInlineTypeReturnedAsFields` to `StressCallingConvention` and added some more stressing possibilities. However, it was forgotten to update the flag in tests in two locations:

### Use in Default Scenario

One default scenario uses `-XX:+StressInlineTypeReturnedAsFields` for Valhalla IR tests. The tests still succeed because we have `-XX:+IgnoreUnrecognizedVMOptions` in place which ignores the now non-existing flag.

I tried to replace `StressInlineTypeReturnedAsFields` with the updated `StressCallingConvention` flag but it turns out that too many IR rules rely on a predictable calling convention such that we could verify that all allocations are removed. With `StressCallingConvention`, we could now randomly enforce allocations because we cannot pass a value object in scalarized form anymore because there is only a non-scalarized calling convention.

I therefore propose to simply drop `StressInlineTypeReturnedAsFields` from the default scenario without replacement. 

Note that we still have stress jobs in place that run with `StressCallingConvention` enabled to exercise different combinations of calling conventions.


### Use in `TestCallingConventionC1.java`
The second use in `TestCallingConventionC1.java` can be replaced by `StressCallingConvention` because we do not have any IR rules that could be affected.

Thanks,
Christian