### PR TITLE
8353186: [lworld] Disable failing tests after JDK-8351569

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -187,7 +187,8 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateThenAtomic(Inner i) {
         Outer o = new Outer();
         Common.blackhole(o);
@@ -195,23 +196,26 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-// TODO 8329234
-//    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8329234
+    //@IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testLoadThenAtomic(Outer o, Inner i) {
         Common.blackhole(o.field1);
         Common.field1VarHandle.getAndSet​(o, i);
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenAtomicAnotherField(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet​(o, i);
         Common.field2VarHandle.getAndSet​(o, i);
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateArrayThenAtomicAtKnownIndex(Outer o) {
         Outer[] a = new Outer[42];
         Common.blackhole(a);
@@ -219,7 +223,8 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateArrayThenAtomicAtUnknownIndex(Outer o, int index) {
         Outer[] a = new Outer[42];
         Common.blackhole(a);
@@ -227,7 +232,8 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayAtomicThenAtomicAtUnknownIndices(Outer[] a, Outer o, int index1, int index2) {
         Common.outerArrayVarHandle.getAndSet(a, index1, o);
         Common.outerArrayVarHandle.getAndSet(a, index2, o);
@@ -388,14 +394,16 @@ class TestZGCEffectiveBarrierElision {
 
     @Test
     @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testStoreThenAtomic(Outer o, Inner i) {
         o.field1 = i;
         Common.field1VarHandle.getAndSet​(o, i);
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenLoad(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet​(o, i);
@@ -403,7 +411,8 @@ class TestZGCEffectiveBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenStore(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet​(o, i);
@@ -411,16 +420,18 @@ class TestZGCEffectiveBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenAtomic(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet​(o, i);
         Common.field1VarHandle.getAndSet​(o, i);
     }
 
     @Test
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    // TODO: 8353182
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayAtomicThenAtomic(Outer[] a, Outer o) {
         Common.outerArrayVarHandle.getAndSet(a, 0, o);
         Common.outerArrayVarHandle.getAndSet(a, 0, o);

--- a/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
@@ -44,8 +44,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+// TODO: 8353180: Remove requires != Xcomp
+
 /*
  * @test
+ * @requires vm.compMode != "Xcomp"
  * @summary Test atomic access modes on var handles for flattened values
  * @enablePreview
  * @modules java.base/jdk.internal.value java.base/jdk.internal.vm.annotation

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -21,10 +21,12 @@
  * questions.
  */
 
+// TODO: 8353180: Remove requires != Xcomp
 
 /*
  * @test
  * @enablePreview
+ * @requires vm.compMode != "Xcomp"
  * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening NullRestrictedArraysTest
  * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening NullRestrictedArraysTest
  */


### PR DESCRIPTION
[JDK-8351569](https://bugs.openjdk.org/browse/JDK-8351569) triggered some test failures (see [JDK-8353180](https://bugs.openjdk.org/browse/JDK-8353180) and [JDK-8353182](https://bugs.openjdk.org/browse/JDK-8353182)). To reduce noise until these are fixed, I'm disabling the failing tests by either disabling IR rules or preventing certain flag modes.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353186](https://bugs.openjdk.org/browse/JDK-8353186): [lworld] Disable failing tests after JDK-8351569 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1413/head:pull/1413` \
`$ git checkout pull/1413`

Update a local copy of the PR: \
`$ git checkout pull/1413` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1413`

View PR using the GUI difftool: \
`$ git pr show -t 1413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1413.diff">https://git.openjdk.org/valhalla/pull/1413.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1413#issuecomment-2761659693)
</details>
