### PR TITLE
8353639: [lworld] IGV: Fix broken type info filter with TypeAryPtr::_field_offset

### DIFF
--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/showTypes.filter
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/showTypes.filter
@@ -9,7 +9,7 @@
 //   "[5:]Class"
 function simplify_reference_type(type) {
   // Clean up interface lists in reference types.
-  var m = /(.*)\(.*\)(.*)/.exec(type);
+  var m = /(.*) \([^\)]*\)(.*)/.exec(type);
   if (m != null && typeof m[1] != 'undefined' && typeof m[2] != 'undefined') {
     type = m[1] + m[2];
   }


### PR DESCRIPTION
The `TypeAryPtr::_field_offset` information is dumped inside a pair of braces:
```
                                                         --> HERE <--
flat:narrowoop: V1:NotNull:exact *[int:≥0]:NotNull:exact:flat(+4):null_free[2] * [narrow]
```
The problem is that the type info filter from mainline only expects that interface types are found inside braces and then tries to remove them. This now messes with two pair of braces.

The fix I propose is to match anything but the first closing `)` when finding the first `(` with `\([^\)]*\)` for the interface types instead of matching it with `\(.*\)` which matches up to the field offset.

Without fix:
![Screenshot from 2025-04-03 13-57-20](https://github.com/user-attachments/assets/3baf40df-2ea4-4b7d-a450-6dca200b986f)

With fix:
![Screenshot from 2025-04-03 13-59-20](https://github.com/user-attachments/assets/a5c97f9e-cd70-4f81-af85-5bd8c960f4aa)

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353639](https://bugs.openjdk.org/browse/JDK-8353639): [lworld] IGV: Fix broken type info filter with TypeAryPtr::_field_offset (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1414/head:pull/1414` \
`$ git checkout pull/1414`

Update a local copy of the PR: \
`$ git checkout pull/1414` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1414`

View PR using the GUI difftool: \
`$ git pr show -t 1414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1414.diff">https://git.openjdk.org/valhalla/pull/1414.diff</a>

</details>
