### PR TITLE
8353664: [lworld] missing code for fix for JDK-8334484

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LocalProxyVarsGen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LocalProxyVarsGen.java
@@ -255,10 +255,8 @@ public class LocalProxyVarsGen extends TreeTranslator {
 
         @Override
         public void visitApply(JCTree.JCMethodInvocation tree) {
-            Name methName = TreeInfo.name(tree.meth);
-            boolean isConstructorCall = methName == names._this || methName == names._super;
             super.visitApply(tree);
-            if (isConstructorCall) {
+            if (TreeInfo.isConstructorCall(tree)) {
                 ctorPrologue = false;
             }
         }


### PR DESCRIPTION
just minor refactoring that was not integrated with fix for JDK-8334484

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353664](https://bugs.openjdk.org/browse/JDK-8353664): [lworld] missing code for fix for JDK-8334484 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1415/head:pull/1415` \
`$ git checkout pull/1415`

Update a local copy of the PR: \
`$ git checkout pull/1415` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1415`

View PR using the GUI difftool: \
`$ git pr show -t 1415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1415.diff">https://git.openjdk.org/valhalla/pull/1415.diff</a>

</details>
