### PR TITLE
8353212: [lworld] TestFlatArrayAliasesCardMark.java crashes when run with -XX:+UseAtomicValueFlattening

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -579,7 +579,7 @@ static Node* get_payload_value(PhaseGVN* gvn, Node* payload, BasicType bt, Basic
     value = gvn->transform(new URShiftINode(payload, shift_val));
   }
 
-  if (val_bt == T_INT || val_bt == T_OBJECT) {
+  if (val_bt == T_INT || val_bt == T_OBJECT || val_bt == T_ARRAY) {
     return value;
   } else {
     // Make sure to zero unused bits in the 32-bit value

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayNullMarkers.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayNullMarkers.java
@@ -172,6 +172,18 @@ public class TestArrayNullMarkers {
         }
     }
 
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class IntAndArrayOop {
+        int i;
+        MyClass[] array;
+
+        public IntAndArrayOop(int i, MyClass[] array) {
+            this.i = i;
+            this.array = array;
+        }
+    }
+
     public static void testWrite0(OneByte[] array, int i, OneByte val) {
         array[i] = val;
     }
@@ -691,6 +703,11 @@ public class TestArrayNullMarkers {
         ByteAndOop[] nullableArray5 = new ByteAndOop[3];
         ByteAndOop[] nullableAtomicArray5 = (ByteAndOop[])ValueClass.newNullableAtomicArray(ByteAndOop.class, 3);
 
+        IntAndArrayOop[] nullFreeArray6 = (IntAndArrayOop[])ValueClass.newNullRestrictedArray(IntAndArrayOop.class, 3);
+        IntAndArrayOop[] nullFreeAtomicArray6 = (IntAndArrayOop[])ValueClass.newNullRestrictedAtomicArray(IntAndArrayOop.class, 3);
+        IntAndArrayOop[] nullableArray6 = new IntAndArrayOop[3];
+        IntAndArrayOop[] nullableAtomicArray6 = (IntAndArrayOop[])ValueClass.newNullableAtomicArray(IntAndArrayOop.class, 3);
+
         // Write canary values to detect out of bound writes
         nullFreeArray0[0] = CANARY0;
         nullFreeArray0[2] = CANARY0;
@@ -869,6 +886,28 @@ public class TestArrayNullMarkers {
             testWrite5(nullFreeAtomicArray5, 1, val5);
             testWrite5(nullableArray5, 1, val5);
             testWrite5(nullableAtomicArray5, 1, val5);
+
+            IntAndArrayOop val6 = new IntAndArrayOop(i, new MyClass[1]);
+            nullFreeArray6[1] = val6;
+            nullFreeArray6[2] = nullFreeArray6[1];
+            nullFreeAtomicArray6[1] = val6;
+            nullFreeAtomicArray6[2] = nullFreeAtomicArray6[1];
+            nullableArray6[1] = val6;
+            nullableArray6[2] = nullableArray6[1];
+            nullableAtomicArray6[1] = val6;
+            nullableAtomicArray6[2] = nullableAtomicArray6[1];
+            Asserts.assertEQ(nullFreeArray6[0], new IntAndArrayOop(0, null));
+            Asserts.assertEQ(nullFreeAtomicArray6[0], new IntAndArrayOop(0, null));
+            Asserts.assertEQ(nullableArray6[0], null);
+            Asserts.assertEQ(nullableAtomicArray6[0], null);
+            Asserts.assertEQ(nullFreeArray6[1], val6);
+            Asserts.assertEQ(nullFreeAtomicArray6[1], val6);
+            Asserts.assertEQ(nullableArray6[1], val6);
+            Asserts.assertEQ(nullableAtomicArray6[1], val6);
+            Asserts.assertEQ(nullFreeArray6[2], val6);
+            Asserts.assertEQ(nullFreeAtomicArray6[2], val6);
+            Asserts.assertEQ(nullableArray6[2], val6);
+            Asserts.assertEQ(nullableAtomicArray6[2], val6);
 
             if (i > (LIMIT - 50)) {
                 // After warmup, produce some garbage to trigger GC


### PR DESCRIPTION
Code added by [JDK-8341759](https://bugs.openjdk.org/browse/JDK-8341759) needs to handle fields of type `T_ARRAY`.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353212](https://bugs.openjdk.org/browse/JDK-8353212): [lworld] TestFlatArrayAliasesCardMark.java crashes when run with -XX:+UseAtomicValueFlattening (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1417/head:pull/1417` \
`$ git checkout pull/1417`

Update a local copy of the PR: \
`$ git checkout pull/1417` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1417`

View PR using the GUI difftool: \
`$ git pr show -t 1417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1417.diff">https://git.openjdk.org/valhalla/pull/1417.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1417#issuecomment-2777745590)
</details>
