### PR TITLE
8336795: [lworld] JNI MonitorEnter doesn't return the right value when it throws an exception

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2818,7 +2818,7 @@ JNI_ENTRY(jint, jni_MonitorEnter(JNIEnv *env, jobject jobj))
   }
 
   Handle obj(thread, JNIHandles::resolve_non_null(jobj));
-  ObjectSynchronizer::jni_enter(obj, thread);
+  ObjectSynchronizer::jni_enter(obj, CHECK_(JNI_ERR));
   return JNI_OK;
 JNI_END
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
@@ -34,6 +34,9 @@ package runtime.valhalla.inlinetypes;
 
 public value class InlineWithJni {
 
+    static int returnValue = 999;
+    static final int JNI_ERR = -1;  // from jni.h
+
     static {
         System.loadLibrary("InlineWithJni");
     }
@@ -60,6 +63,7 @@ public value class InlineWithJni {
             sawIe = true;
         }
         Asserts.assertTrue(sawIe, "Missing IdentityException");
+        Asserts.assertEQ(returnValue, JNI_ERR);
         try {
             new InlineWithJni(0).doJniMonitorExit();
         } catch (IllegalMonitorStateException imse) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInlineWithJni.c
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInlineWithJni.c
@@ -25,7 +25,10 @@
 
 JNIEXPORT void JNICALL
 Java_runtime_valhalla_inlinetypes_InlineWithJni_doJniMonitorEnter(JNIEnv *env, jobject obj) {
-    (*env)->MonitorEnter(env, obj);
+    int ret = (*env)->MonitorEnter(env, obj);
+    jclass class = (*env)->GetObjectClass(env, obj);
+    jfieldID fieldId = (*env)->GetStaticFieldID(env, class, "returnValue", "I");
+    (*env)->SetStaticIntField(env, class, fieldId, ret);
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
Fix the value returned by JNI MonitorEnter when called on a value class instance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336795](https://bugs.openjdk.org/browse/JDK-8336795): [lworld] JNI MonitorEnter doesn't return the right value when it throws an exception (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1422/head:pull/1422` \
`$ git checkout pull/1422`

Update a local copy of the PR: \
`$ git checkout pull/1422` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1422`

View PR using the GUI difftool: \
`$ git pr show -t 1422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1422.diff">https://git.openjdk.org/valhalla/pull/1422.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1422#issuecomment-2783593377)
</details>
