### PR TITLE
8353236: [lworld] Better documentation for Valhalla Unsafe intrinsics

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -60,6 +60,7 @@ import static jdk.internal.misc.UnsafeConstants.*;
  * behaviors may include but not be limited to:
  *
  * <ul>
+ * <li>Working as expected.
  * <li>Crashing the VM.
  * <li>Corruption of the heap or JVM memory.
  * <li>Nonsensical variable value. E.g. an {@code int} may appear to be
@@ -89,9 +90,6 @@ import static jdk.internal.misc.UnsafeConstants.*;
  * {@code Unsafe} invocation, these assumptions may propagate backward to
  * previous statements, leading to wrong executions if the assumptions are
  * invalid.
- * <p>
- * By default, usage of all methods in this class exhibits undefined behavior,
- * unless otherwise explicitly specified.
  *
  * @author John R. Rose
  * @see #getUnsafe


### PR DESCRIPTION
Hi,

This patch clarifies the meaning of undefined behavior when working with `Unsafe` and specifies the requirements when working with `Unsafe::makePrivateBuffer` and `Unsafe::finishPrivateBuffer`.

Please take a look and leave your suggestions, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353236](https://bugs.openjdk.org/browse/JDK-8353236): [lworld] Better documentation for Valhalla Unsafe intrinsics (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1425/head:pull/1425` \
`$ git checkout pull/1425`

Update a local copy of the PR: \
`$ git checkout pull/1425` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1425`

View PR using the GUI difftool: \
`$ git pr show -t 1425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1425.diff">https://git.openjdk.org/valhalla/pull/1425.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1425#issuecomment-2789698891)
</details>
