### PR TITLE
8353717: [lworld] Complete merge of 8350756

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2565,7 +2565,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
             }
           }
         }
-      } else if (split_always_terminates) {
+      } else if (mergemem_only || split_always_terminates) {
         // If all inputs reference this phi (directly or through data nodes) -
         // it is a dead loop.
         bool saw_safe_input = false;

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2492,8 +2492,7 @@ void LoopNode::verify_strip_mined(int expect_skeleton) const {
       }
       // Late optimization of loads on backedge can cause Phi of outer loop to be eliminated but Phi of inner loop is
       // not guaranteed to be optimized out.
-      // TODO: 8353717
-      //assert(outer->outcnt() >= phis + 2 - be_loads && outer->outcnt() <= phis + 2 + stores + 1, "only phis");
+      assert(outer->outcnt() >= phis + 2 - be_loads && outer->outcnt() <= phis + 2 + stores + 1, "only phis");
     }
     assert(sfpt->outcnt() == 1, "no data node");
     assert(outer_tail->outcnt() == 1 || !has_skeleton, "no data node");

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeIRNode.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeIRNode.java
@@ -139,7 +139,7 @@ public class InlineTypeIRNode {
 
     public static final String INLINE_ARRAY_NULL_GUARD = PREFIX + "INLINE_ARRAY_NULL_GUARD" + POSTFIX;
     static {
-        IRNode.optoOnly(INLINE_ARRAY_NULL_GUARD, InlineTypeRegexes.INLINE_ARRAY_NULL_GUARD);
+        IRNode.beforeMatching(INLINE_ARRAY_NULL_GUARD, InlineTypeRegexes.INLINE_ARRAY_NULL_GUARD);
     }
 
     public static final String INTRINSIC_SLOW_PATH = PREFIX + "INTRINSIC_SLOW_PATH" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
@@ -52,7 +52,7 @@ public class InlineTypeRegexes {
     public static final String SCOBJ = "(.*# ScObj.*" + END;
     public static final String LOAD_UNKNOWN_INLINE = START + "CallStaticJava" + MID + "C2 Runtime load_unknown_inline" + END;
     public static final String STORE_UNKNOWN_INLINE = START + "CallStaticJava" + MID + "C2 Runtime store_unknown_inline" + END;
-    public static final String INLINE_ARRAY_NULL_GUARD = "(.*call,static.*wrapper for: uncommon_trap.*reason='null_check' action='none'.*" + END;
+    public static final String INLINE_ARRAY_NULL_GUARD = START + "CallStaticJava" + MID + "null_check' action='none'" + END;
     public static final String INTRINSIC_SLOW_PATH = "(.*call,static.*wrapper for: uncommon_trap.*reason='intrinsic_or_type_checked_inlining'.*" + END;
     public static final String CLONE_INTRINSIC_SLOW_PATH = "(.*call,static.*java.lang.Object::clone.*" + END;
     public static final String CLASS_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*class_check" + END;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -2384,10 +2384,8 @@ public class TestLWorld {
     }
 
     @Test
-    @IR(applyIfAnd = {"UseG1GC", "true", "UseArrayFlattening", "true"},
+    @IR(applyIf = {"UseArrayFlattening", "true"},
         counts = {COUNTEDLOOP, "= 2", LOAD_UNKNOWN_INLINE, "= 1"})
-    @IR(applyIfAnd = {"UseG1GC", "false", "UseArrayFlattening", "true"},
-        counts = {COUNTEDLOOP_MAIN, "= 2", LOAD_UNKNOWN_INLINE, "= 4"})
     public void test85(Object[] src, Object[] dst) {
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -2407,10 +2405,8 @@ public class TestLWorld {
     }
 
     @Test
-    @IR(applyIfAnd = {"UseG1GC", "true", "UseArrayFlattening", "true"},
+    @IR(applyIf = {"UseArrayFlattening", "true"},
         counts = {COUNTEDLOOP, "= 2"})
-    @IR(applyIfAnd = {"UseG1GC", "false", "UseArrayFlattening", "true"},
-        counts = {COUNTEDLOOP_MAIN, "= 2"})
     public void test86(Object[] src, Object[] dst) {
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -2989,14 +2985,11 @@ public class TestLWorld {
     Object oFld1, oFld2;
 
     @Test
-    /* TODO: 8353717
-    @IR(applyIfAnd = {"UseG1GC", "true", "UseArrayFlattening", "true"},
+    @IR(applyIf = {"UseArrayFlattening", "true"},
         failOn = {STORE_UNKNOWN_INLINE, INLINE_ARRAY_NULL_GUARD},
-        counts = {COUNTEDLOOP, "= 2", LOAD_UNKNOWN_INLINE, "= 2"})
-    @IR(applyIfAnd = {"UseG1GC", "false", "UseArrayFlattening", "true"},
-        failOn = {STORE_UNKNOWN_INLINE, INLINE_ARRAY_NULL_GUARD},
-        counts = {COUNTEDLOOP, "= 3", LOAD_UNKNOWN_INLINE, "= 2"})
-    */
+        counts = {COUNTEDLOOP, "= 2", LOAD_UNKNOWN_INLINE, "= 2"},
+         // Match on CCP since we are removing one of the unswitched loop versions later due to being empty
+        phase = {CompilePhase.CCP1})
     public void test107(Object[] src1, Object[] src2) {
         for (int i = 0; i < src1.length; i++) {
             oFld1 = src1[i];
@@ -3022,12 +3015,9 @@ public class TestLWorld {
     }
 
     @Test
-    @IR(applyIfAnd = {"UseG1GC", "true", "UseArrayFlattening", "true"},
+    @IR(applyIf = {"UseArrayFlattening", "true"},
         failOn = {LOAD_UNKNOWN_INLINE, INLINE_ARRAY_NULL_GUARD},
         counts = {COUNTEDLOOP, "= 4", STORE_UNKNOWN_INLINE, "= 9"})
-    @IR(applyIfAnd = {"UseG1GC", "false", "UseArrayFlattening", "true"},
-        failOn = {LOAD_UNKNOWN_INLINE, INLINE_ARRAY_NULL_GUARD},
-        counts = {COUNTEDLOOP, "= 4", STORE_UNKNOWN_INLINE, "= 12"})
     public void test108(Object[] dst1, Object[] dst2, Object o1, Object o2) {
         for (int i = 0; i < dst1.length; i++) {
             dst1[i] = o1;
@@ -3204,11 +3194,9 @@ public class TestLWorld {
     }
 
     @Test
-    /* TODO: 8353717
     @IR(failOn = {ALLOC_G, MEMBAR},
         counts = {PREDICATE_TRAP, "= 1"})
     @IR(failOn = {ALLOC_G, MEMBAR})
-    */
     public long test109_sharp() {
         long res = 0;
         for (int i = 0; i < lArr.length; i++) {
@@ -3244,11 +3232,9 @@ public class TestLWorld {
     }
 
     @Test
-    /* TODO: 8353717
     @IR(failOn = {ALLOC_G, MEMBAR},
         counts = {PREDICATE_TRAP, "= 1"})
     @IR(failOn = {ALLOC_G, MEMBAR})
-    */
     public long test110_sharp() {
         long res = 0;
         for (int i = 0; i < lArr.length; i++) {
@@ -3283,10 +3269,8 @@ public class TestLWorld {
     }
 
     @Test
-    /* TODO: 8353717
     @IR(failOn = {ALLOC_G, MEMBAR},
         counts = {PREDICATE_TRAP, "= 1"})
-    */
     public long test111_sharp() {
         long res = 0;
         for (int i = 0; i < lArr.length; i++) {
@@ -3339,10 +3323,8 @@ public class TestLWorld {
     }
 
     @Test
-    /* TODO: 8353717
     @IR(failOn = {ALLOC_G, MEMBAR},
         counts = {PREDICATE_TRAP, "= 1"})
-    */
     public long test113_sharp() {
         long res = 0;
         for (int i = 0; i < lArr.length; i++) {
@@ -3439,9 +3421,8 @@ public class TestLWorld {
 
     // Same as test114 but with dynamic instead of constant ZERO field
     @Test
-    /* TODO: 8353717
-      @IR(failOn = {ALLOC_G, MEMBAR},
-      counts = {PREDICATE_TRAP, "= 1"}) */
+    @IR(failOn = {ALLOC_G, MEMBAR},
+        counts = {PREDICATE_TRAP, "= 1"})
     public long test115() {
         long res = 0;
         for (int i = 0; i < lArr.length; i++) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
@@ -121,9 +121,8 @@ public class TestOnStackReplacement {
         test2();
     }
 
-    // TODO: Should be fixed with JDK-8327465.
     // Test loop peeling and unrolling
-    //@Test(compLevel = CompLevel.WAIT_FOR_COMPILATION)
+    @Test(compLevel = CompLevel.WAIT_FOR_COMPILATION)
     public void test3() {
         MyValue1 v1 = MyValue1.createWithFieldsInline(0, 0);
         MyValue1 v2 = MyValue1.createWithFieldsInline(1, 1);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClasses.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClasses.java
@@ -168,7 +168,7 @@ public class TestValueClasses {
 
     // Test scalarization in safepoint debug info and re-allocation on deopt
     @Test
-    //@IR(failOn = {ALLOC, STORE}) TODO: 8353717
+    @IR(failOn = {ALLOC, STORE})
     public long test3(boolean deopt, boolean b1, boolean b2, Method m) {
         MyValueClass1 ret = MyValueClass1.createWithFieldsInline(rI, rL);
         if (b1) {


### PR DESCRIPTION
This patch fixes some failures after merging JDK-25+14 in:

1. [JDK-8333393](https://bugs.openjdk.org/browse/JDK-8333393) improved the "split Phi through MergeMem" optimization and was merged in:
    1. This should fix [JDK-8327465](https://bugs.openjdk.org/browse/JDK-8327465) (it does not reproduce anymore but I think it's still an issue before this patch): When adding `Phi` nodes to the `OuterStripMinedLoop` node, it should match the number of `Phi` nodes at the `CountedLoop` node. However, during IGVN, we could split some phis of the `CountedLoop` node through `MergeMems` which created more phi nodes at the `OuterStripMinedLoop` node. But these phis could not be split further and we hit an assertion failure due to this phi number mismatch. Only with JDK-8333393, we can further split these phis at the `OuterStripMinedLoop` node and we no longer hit the assert. I've therefore closed JDK-8327465 as a dup.
    2. The merge of JDK-8333393 was not correct:
        1. We ended up splitting fewer phi nodes through mergemems as before and thus hitting case `1.` even more often.
        2. The Valhalla specific "Always split `Phi` when only having `MergeMem` inputs" optimization was broken. This leads to some IR rule failures since the splitting optimization is no longer performed which blocked some loop optimizations (e.g. turning a loop into a counted one and then apply more optimizations).
     
        I fixed both issues.
2. With JDK-25+14, some tests to check Loop Unswitching started to fail which matched on the number of `CountedLoop` nodes. The reason is that we can now eliminate one of the unswitched loop versions which we previously could not. Therefore, the number of `CountedLoop` nodes is one less. To fix that, I've changed the IR matching to `CCP1` where we still have both unswitched loop versions. This required the following:
    1. I had to adjust `INLINE_ARRAY_NULL_GUARD` to match on ideal graphs instead of the opto assembly. This can easily be done since all information is there in the ideal graph.
    2. I removed the `applyIf*` conditions for `UseG1GC` because we are not running any scenario with another GC.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353717](https://bugs.openjdk.org/browse/JDK-8353717): [lworld] Complete merge of 8350756 (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1426/head:pull/1426` \
`$ git checkout pull/1426`

Update a local copy of the PR: \
`$ git checkout pull/1426` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1426`

View PR using the GUI difftool: \
`$ git pr show -t 1426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1426.diff">https://git.openjdk.org/valhalla/pull/1426.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1426#issuecomment-2791667604)
</details>
