### PR TITLE
8341761: Update JNI methods to support new field and array layouts

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1927,7 +1927,16 @@ JNI_ENTRY_NO_PRESERVE(void, jni_SetObjectField(JNIEnv *env, jobject obj, jfieldI
     o = JvmtiExport::jni_SetField_probe(thread, obj, o, k, fieldID, false, JVM_SIGNATURE_CLASS, (jvalue *)&field_value);
   }
   if (!jfieldIDWorkaround::is_flat_jfieldID(fieldID)) {
-    HeapAccess<ON_UNKNOWN_OOP_REF>::oop_store_at(o, offset, JNIHandles::resolve(value));
+    oop v = JNIHandles::resolve(value);
+    if (v == nullptr) {
+      InstanceKlass *ik = InstanceKlass::cast(k);
+      fieldDescriptor fd;
+      ik->find_field_from_offset(offset, false, &fd);
+      if (fd.is_null_free_inline_type()) {
+        THROW_MSG(vmSymbols::java_lang_NullPointerException(), "Cannot store null in a null-restricted field");
+      }
+    }
+    HeapAccess<ON_UNKNOWN_OOP_REF>::oop_store_at(o, offset, v);
   } else {
     assert(k->is_instance_klass(), "Only instances can have flat fields");
     InstanceKlass* ik = InstanceKlass::cast(k);
@@ -1936,8 +1945,8 @@ JNI_ENTRY_NO_PRESERVE(void, jni_SetObjectField(JNIEnv *env, jobject obj, jfieldI
     InstanceKlass* holder = fd.field_holder();
     InlineLayoutInfo* li = holder->inline_layout_info_adr(fd.index());
     InlineKlass* vklass = li->klass();
-    oop v = JNIHandles::resolve_non_null(value);
-    vklass->write_value_to_addr(v, ((char*)(oopDesc*)obj) + offset, li->kind(), true, CHECK);
+    oop v = JNIHandles::resolve(value);
+    vklass->write_value_to_addr(v, ((char*)(oopDesc*)o) + offset, li->kind(), true, CHECK);
   }
   HOTSPOT_JNI_SETOBJECTFIELD_RETURN();
 JNI_END
@@ -2369,7 +2378,7 @@ JNI_ENTRY(jobject, jni_GetObjectArrayElement(JNIEnv *env, jobjectArray array, js
     if (arr->is_flatArray()) {
       flatArrayOop a = flatArrayOop(JNIHandles::resolve_non_null(array));
       res = a->read_value_from_flat_array(index, CHECK_NULL);
-      assert(res != nullptr, "Must be set in one of two paths above");
+      assert(res != nullptr || !arr->is_null_free_array(), "Invalid value");
     } else {
       assert(arr->is_objArray(), "If not a valueArray. must be an objArray");
       objArrayOop a = objArrayOop(JNIHandles::resolve_non_null(array));
@@ -2402,26 +2411,15 @@ JNI_ENTRY(void, jni_SetObjectArrayElement(JNIEnv *env, jobjectArray array, jsize
        oop v = JNIHandles::resolve(value);
        FlatArrayKlass* vaklass = FlatArrayKlass::cast(a->klass());
        InlineKlass* element_vklass = vaklass->element_klass();
-       if (v != nullptr && v->is_a(element_vklass)) {
-         a->write_value_to_flat_array(v, index, CHECK);
-       } else {
-         ResourceMark rm(THREAD);
-         stringStream ss;
-         Klass *kl = FlatArrayKlass::cast(a->klass());
-         ss.print("type mismatch: can not store %s to %s[%d]",
-             v->klass()->external_name(),
-             kl->external_name(),
-             index);
-         for (int dims = ArrayKlass::cast(a->klass())->dimension(); dims > 1; --dims) {
-           ss.print("[]");
-         }
-         THROW_MSG(vmSymbols::java_lang_ArrayStoreException(), ss.as_string());
-       }
+       a->write_value_to_flat_array(v, index, CHECK);
      } else {
        assert(arr->is_objArray(), "If not a valueArray. must be an objArray");
        objArrayOop a = objArrayOop(JNIHandles::resolve_non_null(array));
        oop v = JNIHandles::resolve(value);
        if (v == nullptr || v->is_a(ObjArrayKlass::cast(a->klass())->element_klass())) {
+         if (v == nullptr && ObjArrayKlass::cast(a->klass())->is_null_free_array_klass()) {
+           THROW_MSG(vmSymbols::java_lang_NullPointerException(), "Cannot store null in a null-restricted array");
+         }
          a->obj_at_put(index, v);
        } else {
          ResourceMark rm(THREAD);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,21 @@ package runtime.valhalla.inlinetypes;
 /* @test
  * @summary test JNI functions with instances of value classes
  * @library /test/lib
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
  * @enablePreview
- * @run main/othervm/native runtime.valhalla.inlinetypes.InlineWithJni
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED -XX:+UseNullableValueFlattening runtime.valhalla.inlinetypes.InlineWithJni
  */
 
- import jdk.test.lib.Asserts;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+import jdk.test.lib.Asserts;
 
 public value class InlineWithJni {
 
@@ -43,6 +53,8 @@ public value class InlineWithJni {
 
     public static void main(String[] args) {
         testJniMonitorOps();
+        testJniFieldAccess();
+        testJniArrayAccess();
     }
 
     final int x;
@@ -70,5 +82,284 @@ public value class InlineWithJni {
             sawImse = true;
         }
         Asserts.assertTrue(sawImse, "Missing IllegalMonitorStateException");
+    }
+
+    public static native Object readInstanceField(Object obj, String name, String signature);
+    public static native void writeInstanceField(Object obj, String name, String signature, Object value);
+
+    public static native Object readArrayElement(Object[] array, int index);
+    public static native void writeArrayElement(Object[] array, int index, Object value);
+
+
+    static value class SmallValue {
+        byte b;
+        SmallValue() { b = 1; }
+        SmallValue(byte b0) { b = b0; }
+        static public SmallValue getValueA() { return new SmallValue((byte)42); }
+        static public SmallValue getValueB() { return new SmallValue((byte)111); }
+    }
+
+    static value class MediumValue {
+        int i0;
+        int i1;
+        MediumValue() {
+            i0 = 2;
+            i1 = 3;
+        }
+        MediumValue(int ia, int ib) {
+            i0 = ia;
+            i1 = ib;
+        }
+        static public MediumValue getValueA() { return new MediumValue(23, 64); }
+        static public MediumValue getValueB() { return new MediumValue(-51, -1023); }
+    }
+
+    static value class BigValue {
+        long l0;
+        long l1;
+        long l2;
+        BigValue() {
+            l0 = 4L;
+            l1 = 5L;
+            l2 = 6L;
+        }
+        BigValue(long la, long lb, long lc) {
+            l0 = la;
+            l1 = lb;
+            l2 = lc;
+        }
+        static public BigValue getValueA() { return new BigValue(0L, 65525L, Long.MIN_VALUE); }
+        static public BigValue getValueB() { return new BigValue(Long.MIN_VALUE, 32000L, 0L); }
+    }
+
+    static value class ValueWithOop {
+        String s;
+        byte b;
+        ValueWithOop() {
+            s = "Hello Duke!";
+            b = (byte)7;
+        }
+        ValueWithOop(String s0, byte b0) {
+            s = s0;
+            b = b0;
+        }
+        static public ValueWithOop getValueA() { return new ValueWithOop("Bretagne", (byte)123); }
+        static public ValueWithOop getValueB() { return new ValueWithOop("Alsace", (byte)-31); }
+    }
+
+    // Container with nullable fields (potentially flattened)
+    static class Container0 {
+        SmallValue sv = new SmallValue();
+        MediumValue mv = new MediumValue();
+        BigValue bv = new BigValue();
+        ValueWithOop vwo = new ValueWithOop();
+    }
+
+    // Container with null-restricted fields (potentially flattened)
+    static class Container1 {
+        @Strict
+        @NullRestricted
+        SmallValue sv = new SmallValue();
+        @Strict
+        @NullRestricted
+        MediumValue mv = new MediumValue();
+        @Strict
+        @NullRestricted
+        BigValue bv = new BigValue();
+        @Strict
+        @NullRestricted
+        ValueWithOop vwo = new ValueWithOop();
+    }
+
+    static String getFieldSignature(Class c, String name) {
+        try {
+            return "L"+c.getDeclaredField(name).getType().getName().replaceAll("\\.", "/")+";";
+        } catch(NoSuchFieldException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void testJniFieldAccessHelper(Object c, boolean nullRestriction) {
+
+        String smallSignature = getFieldSignature(c.getClass(), "sv");
+        String mediumSignature = getFieldSignature(c.getClass(), "mv");
+        String bigSignature = getFieldSignature(c.getClass(), "bv");
+        String withOopSignature = getFieldSignature(c.getClass(), "vwo");
+
+
+        // Reading nullable value fields
+        SmallValue sv = (SmallValue)readInstanceField(c, "sv", smallSignature);
+        Asserts.assertEQ(sv, new SmallValue());
+        Asserts.assertTrue(sv.b == 1);
+        MediumValue mv = (MediumValue)readInstanceField(c, "mv", mediumSignature);
+        Asserts.assertEQ(mv, new MediumValue());
+        Asserts.assertTrue(mv.i0 == 2);
+        Asserts.assertTrue(mv.i1 == 3);
+        BigValue bv = (BigValue)readInstanceField(c, "bv", bigSignature);
+        Asserts.assertEQ(bv, new BigValue());
+        Asserts.assertTrue(bv.l0 == 4);
+        Asserts.assertTrue(bv.l1 == 5);
+        Asserts.assertTrue(bv.l2 == 6);
+        ValueWithOop vwo = (ValueWithOop)readInstanceField(c, "vwo", withOopSignature);
+        Asserts.assertEQ(vwo, new ValueWithOop());
+        Asserts.assertTrue(vwo.s.equals("Hello Duke!"));
+        Asserts.assertTrue(vwo.b == 7);
+
+
+        // Writing non-null value to nullable field
+        SmallValue nsv = new SmallValue((byte)8);
+        writeInstanceField(c, "sv", smallSignature, nsv);
+        sv = (SmallValue)readInstanceField(c, "sv", smallSignature);
+        Asserts.assertTrue(sv == nsv);
+        MediumValue nmv = new MediumValue(9, 10);
+        writeInstanceField(c, "mv", mediumSignature, nmv);
+        mv = (MediumValue)readInstanceField(c, "mv", mediumSignature);
+        Asserts.assertTrue(mv == nmv);
+        BigValue nbv = new BigValue(11L, 12L, 13L);
+        writeInstanceField(c, "bv", bigSignature, nbv);
+        bv = (BigValue)readInstanceField(c, "bv", bigSignature);
+        Asserts.assertTrue(bv == nbv);
+        ValueWithOop nvwo = new ValueWithOop("Bye Duke!", (byte)14);
+        writeInstanceField(c, "vwo", withOopSignature, nvwo);
+        vwo = (ValueWithOop)readInstanceField(c, "vwo", withOopSignature);
+        Asserts.assertTrue(vwo == nvwo);
+
+
+        // Writing null to nullable field
+        Exception ex = null;
+        try {
+            writeInstanceField(c, "sv", smallSignature, null);
+            sv = (SmallValue)readInstanceField(c, "sv", smallSignature);
+            Asserts.assertTrue(sv == null);
+        } catch(NullPointerException npe) {
+            ex = npe;
+        }
+        Asserts.assertTrue((nullRestriction && ex != null) || (!nullRestriction && ex == null));
+        ex = null;
+        try {
+            writeInstanceField(c, "mv", mediumSignature, null);
+            mv = (MediumValue)readInstanceField(c, "mv", mediumSignature);
+            Asserts.assertTrue(mv == null);
+         } catch(NullPointerException npe) {
+            ex = npe;
+        }
+        System.out.println(ex + " / " + nullRestriction);
+        Asserts.assertTrue((nullRestriction && ex != null) || (!nullRestriction && ex == null));
+        ex = null;
+        try {
+            writeInstanceField(c, "bv", bigSignature, null);
+            bv = (BigValue)readInstanceField(c, "bv", bigSignature);
+            Asserts.assertTrue(bv == null);
+        } catch(NullPointerException npe) {
+            ex = npe;
+        }
+        Asserts.assertTrue((nullRestriction && ex != null) || (!nullRestriction && ex == null));
+        ex = null;
+        try {
+            writeInstanceField(c, "vwo", withOopSignature, null);
+            vwo = (ValueWithOop)readInstanceField(c, "vwo", withOopSignature);
+            Asserts.assertTrue(vwo == null);
+        } catch(NullPointerException npe) {
+            ex = npe;
+        }
+        Asserts.assertTrue((nullRestriction && ex != null) || (!nullRestriction && ex == null));
+    }
+
+    static void testJniFieldAccess() {
+        // Reading nullable field
+        try {
+            Container0 c0 = new Container0();
+            testJniFieldAccessHelper(c0, false);
+            Container1 c1 = new Container1();
+            testJniFieldAccessHelper(c1, true);
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw new RuntimeException(t);
+        }
+    }
+
+    static void testJniArrayAccessHelper(Object[] array, boolean nullRestriction) {
+        Object valueA = getValueA(array.getClass().getComponentType());
+        Object valueB = getValueB(array.getClass().getComponentType());
+        int length = array.length;
+
+        // Reading elements
+        for (int i = 0; i < length; i++) {
+            Object element = readArrayElement(array, i);
+            Asserts.assertTrue(element == valueA);
+        }
+
+        // Writing elements
+        for (int i = 0; i < length; i++) {
+            writeArrayElement(array, i, valueB);
+        }
+        for (int i = 0; i < length; i++) {
+            Object element = readArrayElement(array, i);
+            Asserts.assertTrue(element == valueB);
+        }
+
+        // Writing null
+        for (int i = 0; i < length; i++) {
+            Exception ex = null;
+            try {
+                writeArrayElement(array, i, null);
+                Object element = readArrayElement(array, i);
+                Asserts.assertTrue(element == null);
+            } catch(NullPointerException npe) {
+                ex = npe;
+            }
+            Asserts.assertTrue((nullRestriction && ex != null) || (!nullRestriction && ex == null));
+        }
+    }
+
+    static Object getValueA(Class c) {
+        try {
+            Method mA = c.getMethod("getValueA");
+            return mA.invoke(null);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Object getValueB(Class c) {
+        try {
+            Method mB = c.getMethod("getValueB");
+            return mB.invoke(null);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void fillArrayWithValueA(Object[] array) {
+        Object valueA = getValueA(array.getClass().getComponentType());
+        for (int i = 0; i < array.length; i++) {
+            array[i] = valueA;
+        }
+    }
+
+    static void testJniArrayAccessHelper2(Class c) {
+
+        Object[] array0 = (Object[])Array.newInstance(c, 10);
+        fillArrayWithValueA(array0);
+        testJniArrayAccessHelper(array0, false);
+
+        Object[] array1 = ValueClass.newNullableAtomicArray(c, 31);
+        fillArrayWithValueA(array1);
+        testJniArrayAccessHelper(array1, false);
+
+        Object[] array2 = ValueClass.newNullRestrictedAtomicArray(c, 127, getValueA(c));
+        fillArrayWithValueA(array2);
+        testJniArrayAccessHelper(array2, true);
+    }
+
+    static void testJniArrayAccess() {
+        testJniArrayAccessHelper2(SmallValue.class);
+        testJniArrayAccessHelper2(MediumValue.class);
+        testJniArrayAccessHelper2(BigValue.class);
+        testJniArrayAccessHelper2(ValueWithOop.class);
+
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInlineWithJni.c
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInlineWithJni.c
@@ -35,3 +35,40 @@ JNIEXPORT void JNICALL
 Java_runtime_valhalla_inlinetypes_InlineWithJni_doJniMonitorExit(JNIEnv *env, jobject obj) {
     (*env)->MonitorExit(env, obj);
 }
+
+JNIEXPORT jobject JNICALL Java_runtime_valhalla_inlinetypes_InlineWithJni_readInstanceField(JNIEnv *env,
+                       jclass k, jobject obj, jstring name, jstring signature) {
+    jclass class = (*env)->GetObjectClass(env, obj);
+    jboolean copy;
+    const char* name_string = (*env)->GetStringUTFChars(env, name, &copy);
+    const char *signature_string = (*env)->GetStringUTFChars(env, signature, &copy);
+    jfieldID fieldId = (*env)->GetFieldID(env, class, name_string, signature_string);
+    jobject ret =  (*env)->GetObjectField(env, obj, fieldId);
+    (*env)->ReleaseStringUTFChars(env, name, name_string);
+    (*env)->ReleaseStringUTFChars(env, signature, signature_string);
+    return ret;
+}
+
+JNIEXPORT void JNICALL Java_runtime_valhalla_inlinetypes_InlineWithJni_writeInstanceField(JNIEnv *env,
+                        jclass k, jobject obj, jstring name, jstring signature, jobject value)
+{
+    jclass class = (*env)->GetObjectClass(env, obj);
+    jboolean copy;
+    const char *name_string = (*env)->GetStringUTFChars(env, name, &copy);
+    const char *signature_string = (*env)->GetStringUTFChars(env, signature, &copy);
+    jfieldID fieldId = (*env)->GetFieldID(env, class, name_string, signature_string);
+    (*env)->SetObjectField(env, obj, fieldId, value);
+    (*env)->ReleaseStringUTFChars(env, name, name_string);
+    (*env)->ReleaseStringUTFChars(env, signature, signature_string);
+    return;
+}
+
+JNIEXPORT jobject JNICALL Java_runtime_valhalla_inlinetypes_InlineWithJni_readArrayElement(JNIEnv *env,
+                        jclass k, jarray array, int index) {
+    return (*env)->GetObjectArrayElement(env, array, index);
+}
+
+JNIEXPORT void JNICALL Java_runtime_valhalla_inlinetypes_InlineWithJni_writeArrayElement(JNIEnv *env,
+                        jclass k, jarray array, int index, jobject value) {
+    (*env)->SetObjectArrayElement(env, array, index, value);
+}


### PR DESCRIPTION
Update JNI methods to support new field and array layouts.
Extend testing of JNI methods

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341761](https://bugs.openjdk.org/browse/JDK-8341761): Update JNI methods to support new field and array layouts (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1427/head:pull/1427` \
`$ git checkout pull/1427`

Update a local copy of the PR: \
`$ git checkout pull/1427` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1427`

View PR using the GUI difftool: \
`$ git pr show -t 1427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1427.diff">https://git.openjdk.org/valhalla/pull/1427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1427#issuecomment-2794363816)
</details>
