### PR TITLE
8354852: [lworld] invalid interval when copying elements in arraycopy

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -435,7 +435,7 @@ JVM_ENTRY(jarray, JVM_CopyOfSpecialArray(JNIEnv *env, jarray orig, jint from, ji
   arrayHandle oh(THREAD, org);
   ArrayKlass* ak = ArrayKlass::cast(org->klass());
   InlineKlass* vk = InlineKlass::cast(ak->element_klass());
-  int len = to - from;
+  int len = to - from;  // length of the new array
   if (ak->is_null_free_array_klass()) {
     if (from >= org->length() || to > org->length()) {
       THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Copying of null-free array with uninitialized elements");
@@ -446,7 +446,8 @@ JVM_ENTRY(jarray, JVM_CopyOfSpecialArray(JNIEnv *env, jarray orig, jint from, ji
     LayoutKind lk = fak->layout_kind();
     array = oopFactory::new_flatArray(vk, len, lk, CHECK_NULL);
     arrayHandle ah(THREAD, (arrayOop)array);
-    for (int i = from; i < to; i++) {
+    int end = to < oh()->length() ? to : oh()->length();
+    for (int i = from; i < end; i++) {
       void* src = ((flatArrayOop)oh())->value_at_addr(i, fak->layout_helper());
       void* dst = ((flatArrayOop)ah())->value_at_addr(i - from, fak->layout_helper());
       vk->copy_payload_to_addr(src, dst, lk, false);
@@ -458,7 +459,8 @@ JVM_ENTRY(jarray, JVM_CopyOfSpecialArray(JNIEnv *env, jarray orig, jint from, ji
     } else {
       array = oopFactory::new_objArray(vk, len, CHECK_NULL);
     }
-    for (int i = from; i < to; i++) {
+    int end = to < oh()->length() ? to : oh()->length();
+    for (int i = from; i < end; i++) {
       if (i < ((objArrayOop)oh())->length()) {
         ((objArrayOop)array)->obj_at_put(i - from, ((objArrayOop)oh())->obj_at(i));
       } else {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -45,6 +45,7 @@ import static jdk.test.lib.Asserts.*;
  * @run main/othervm -XX:+UseArrayFlattening -XX:+UseFieldFlattening runtime.valhalla.inlinetypes.InlineTypeArray
  * @run main/othervm -XX:-UseArrayFlattening runtime.valhalla.inlinetypes.InlineTypeArray
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.inlinetypes.InlineTypeArray
+ * @run main/othervm -XX:+UseArrayFlattening -XX:+UseFieldFlattening -XX:+UseNullableValueFlattening runtime.valhalla.inlinetypes.InlineTypeArray
  */
 public class InlineTypeArray {
     public static void main(String[] args) {
@@ -588,7 +589,7 @@ public class InlineTypeArray {
         expected3b[2] = null;
         checkArrayElementsEqual(exceedingRangeCopy, expected3b);
 
-        // Range starting after the end of the original array, must fail for null-restricted arrays
+        // Range starting after the end of the original array, must suceed for nullable arrays
         MyInt[] farRangeCopy = (MyInt[]) Arrays.copyOfRange(myInts, myInts.length, myInts.length + 1);
         MyInt[] expected3c = (MyInt[])ValueClass.newNullableAtomicArray(MyInt.class, 1);
         expected3c[0] = null;


### PR DESCRIPTION
Fixing computation of the interval of values to be copied when array copying is applied to flat arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8354852](https://bugs.openjdk.org/browse/JDK-8354852): [lworld] invalid interval when copying elements in arraycopy (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1433/head:pull/1433` \
`$ git checkout pull/1433`

Update a local copy of the PR: \
`$ git checkout pull/1433` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1433`

View PR using the GUI difftool: \
`$ git pr show -t 1433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1433.diff">https://git.openjdk.org/valhalla/pull/1433.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1433#issuecomment-2809712057)
</details>
