### PR TITLE
8354694: [lworld] Refactor AssertUnsetFields to Early Larval Frame

### DIFF
--- a/src/hotspot/share/classfile/stackMapTable.hpp
+++ b/src/hotspot/share/classfile/stackMapTable.hpp
@@ -151,7 +151,7 @@ class StackMapReader : StackObj {
   }
 
   enum {
-    ASSERT_UNSET_FIELDS = 246,
+    EARLY_LARVAL = 246,
     SAME_LOCALS_1_STACK_ITEM_EXTENDED = 247,
     SAME_EXTENDED = 251,
     FULL = 255

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -491,7 +491,7 @@ void ErrorContext::reason_details(outputStream* ss) const {
       ss->print("Current frame's stack size doesn't match stackmap.");
       break;
     case STRICT_FIELDS_MISMATCH:
-    ss->print("Current frame's strict instance fields not compatible with stackmap.");
+      ss->print("Current frame's strict instance fields not compatible with stackmap.");
       break;
     case STACK_OVERFLOW:
       ss->print("Exceeded max stack size.");

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -490,6 +490,9 @@ void ErrorContext::reason_details(outputStream* ss) const {
     case STACK_SIZE_MISMATCH:
       ss->print("Current frame's stack size doesn't match stackmap.");
       break;
+    case STRICT_FIELDS_MISMATCH:
+    ss->print("Current frame's strict instance fields not compatible with stackmap.");
+      break;
     case STACK_OVERFLOW:
       ss->print("Exceeded max stack size.");
       break;


### PR DESCRIPTION
This patch adds refactors so the runtime aligns with the new strict field initialization spec (https://cr.openjdk.org/~dlsmith/jep401/jep401-20250409/specs/strict-fields-jvms.html). The stackmap table entry `AssertUnsetFields` is now referred to as `Early_Larval` and it follows a new format where it is a frame that encompasses a base frame.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8354694](https://bugs.openjdk.org/browse/JDK-8354694): [lworld] Refactor AssertUnsetFields to Early Larval Frame (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1435/head:pull/1435` \
`$ git checkout pull/1435`

Update a local copy of the PR: \
`$ git checkout pull/1435` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1435`

View PR using the GUI difftool: \
`$ git pr show -t 1435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1435.diff">https://git.openjdk.org/valhalla/pull/1435.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1435#issuecomment-2813949073)
</details>
