### PR TITLE
8355295: [lworld] runtime/valhalla/inlinetypes/VolatileTest.java fails with -XX:+UseAtomicValueFlattening

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
@@ -66,9 +66,6 @@ public class VolatileTest {
     }
 
     static public void main(String[] args) {
-        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
-        List<String> arguments = runtimeMxBean.getInputArguments();
-        atomicLayoutEnabled = arguments.contains("-XX:+UseAtomicValueFlattening");
         Class<?> c = MyContainer.class;
         Field f0 = null;
         Field f1 = null;
@@ -80,10 +77,6 @@ public class VolatileTest {
             return;
         }
         Asserts.assertTrue(U.isFlatField(f0), "mv0 should be flattened");
-        if (atomicLayoutEnabled) {
-            Asserts.assertTrue(U.isFlatField(f1), "mv1 should be flattened");
-        } else {
-            Asserts.assertFalse(U.isFlatField(f1), "mv1 should not be flattened");
-        }
+        Asserts.assertFalse(U.isFlatField(f1), "mv1 should not be flattened");
     }
 }


### PR DESCRIPTION
Update test after the semantic change of the volatile keyword (it's now a flattening opt-out again).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8355295](https://bugs.openjdk.org/browse/JDK-8355295): [lworld] runtime/valhalla/inlinetypes/VolatileTest.java fails with -XX:+UseAtomicValueFlattening (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1440/head:pull/1440` \
`$ git checkout pull/1440`

Update a local copy of the PR: \
`$ git checkout pull/1440` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1440`

View PR using the GUI difftool: \
`$ git pr show -t 1440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1440.diff">https://git.openjdk.org/valhalla/pull/1440.diff</a>

</details>
