### PR TITLE
8355317: [lworld] C2 Runtime load_unknown_inline should not return null-free type

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -922,6 +922,7 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
         // Below code only iterates over the flat representation and therefore misses to
         // add null markers like we do in InlineTypeNode::add_fields_to_safepoint for value
         // class holders.
+        _igvn._worklist.push(sfpt);
         return nullptr;
       }
 

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -138,6 +138,10 @@ void Parse::array_load(BasicType bt) {
           // Element type is unknown, and thus we cannot statically determine the exact flat array layout. Emit a
           // runtime call to correctly load the inline type element from the flat array.
           Node* inline_type = load_from_unknown_flat_array(array, array_index, element_ptr);
+          bool is_null_free = array_type->is_null_free() || !UseNullableValueFlattening;
+          if (is_null_free) {
+            inline_type = cast_not_null(inline_type);
+          }
           ideal.set(res, inline_type);
         }
       }

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -2284,7 +2284,7 @@ const TypeFunc* OptoRuntime::load_unknown_inline_Type() {
 
   // create result type (range)
   fields = TypeTuple::fields(1);
-  fields[TypeFunc::Parms] = TypeInstPtr::NOTNULL;
+  fields[TypeFunc::Parms] = TypeInstPtr::BOTTOM;
 
   const TypeTuple* range = TypeTuple::make(TypeFunc::Parms+1, fields);
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -2526,18 +2526,18 @@ public class TestLWorld {
     }
 
     @Test
-    @IR(applyIf = {"UseArrayFlattening", "true"},
+    // TODO 8355382 The optimization only applies to null-free, flat arrays
+    @IR(applyIfAnd = {"UseArrayFlattening", "true", "UseNullableValueFlattening", "false"},
         counts = {CLASS_CHECK_TRAP, "= 2"},
         failOn = {LOAD_UNKNOWN_INLINE, ALLOC_G, MEMBAR})
     public Object test92(Object[] array) {
         // Dummy loops to ensure we run enough passes of split if
         for (int i = 0; i < 2; i++) {
             for (int j = 0; j < 2; j++) {
-              for (int k = 0; k < 2; k++) {
-              }
+                for (int k = 0; k < 2; k++) {
+                }
             }
         }
-
         return (NonValueClass)array[0];
     }
 
@@ -2561,8 +2561,7 @@ public class TestLWorld {
             }
         }
 
-        Object v = (NonValueClass)array[0];
-        return v;
+        return (NonValueClass)array[0];
     }
 
     @Run(test = "test93")
@@ -2595,7 +2594,8 @@ public class TestLWorld {
     }
 
     @Test
-    @IR(applyIf = {"UseArrayFlattening", "true"},
+    // TODO 8355382 The optimization only applies to null-free, flat arrays
+    @IR(applyIfAnd = {"UseArrayFlattening", "true", "UseNullableValueFlattening", "false"},
         counts = {CLASS_CHECK_TRAP, "= 2", LOOP, "= 1"},
         failOn = {LOAD_UNKNOWN_INLINE, ALLOC_G, MEMBAR})
     public int test94(Object[] array) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3292,5 +3292,49 @@ public class TestNullableArrays {
         if (!info.isWarmUp()) {
             Asserts.assertEquals(test125(true, val1, info.getTest(), true), val2.hash());
         }
+    }
+
+    static Object oFld = null;
+
+    static value class MyValue126  {
+        int x;
+
+        MyValue126(int x) {
+            this.x = x;
+        }
+    }
+
+    // Test that result of access to unknown flat array is not marked as null-free
+    @Test
+    public void test126(Object[] array, int i) {
+        oFld = array[i];
+    }
+
+    @Run(test = "test126")
+    @Warmup(0)
+    public void test126_verifier() {
+        MyValue126[] array = (MyValue126[]) ValueClass.newNullableAtomicArray(MyValue126.class, 2);
+        array[1] = new MyValue126(rI);
+        test126(array, 1);
+        Asserts.assertEquals(oFld, new MyValue126(rI));
+        test126(array, 0);
+        Asserts.assertEquals(oFld, null);
+    }
+
+    // Same as test126 but different failure mode
+    @Test
+    public void test127(Object[] array, int i) {
+        oFld = (MyValue126)array[i];
+    }
+
+    @Run(test = "test127")
+    @Warmup(0)
+    public void test127_verifier() {
+        MyValue126[] array = (MyValue126[]) ValueClass.newNullableAtomicArray(MyValue126.class, 2);
+        array[1] = new MyValue126(rI);
+        test127(array, 1);
+        Asserts.assertEquals(oFld, new MyValue126(rI));
+        test127(array, 0);
+        Asserts.assertEquals(oFld, null);
     }
 }


### PR DESCRIPTION
We incorrectly mark the result of `load_unknown_inline` as null-free which is not correct anymore after [JDK-8341767](https://bugs.openjdk.org/browse/JDK-8341767) because nullable arrays can now be flat as well.

I also noticed that the optimization added by [JDK-8228622](https://bugs.openjdk.org/browse/JDK-8228622) assumes that when we load from an unknown array and then cast the result to a non-value class, we can deduce that the array is not flat if the cast succeeds. That only applies to null-free, flat but not to nullable, flat arrays because null will pass the cast. I filed [JDK-8355382](https://bugs.openjdk.org/browse/JDK-8355382) to follow up on this.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8355317](https://bugs.openjdk.org/browse/JDK-8355317): [lworld] C2 Runtime load_unknown_inline should not return null-free type (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1441/head:pull/1441` \
`$ git checkout pull/1441`

Update a local copy of the PR: \
`$ git checkout pull/1441` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1441`

View PR using the GUI difftool: \
`$ git pr show -t 1441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1441.diff">https://git.openjdk.org/valhalla/pull/1441.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1441#issuecomment-2824257521)
</details>
