### PR TITLE
8355299: [lworld] C2 compilation fails with "unexpected yanked node"

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8260034 8260225 8260283 8261037 8261874 8262128 8262831 8306986
+ * @bug 8260034 8260225 8260283 8261037 8261874 8262128 8262831 8306986 8355299
  * @summary A selection of generated tests that triggered bugs not covered by other tests.
  * @enablePreview
  * @modules java.base/jdk.internal.value
@@ -31,6 +31,8 @@
  * @run main/othervm -Xbatch
  *                   compiler.valhalla.inlinetypes.TestGenerated
  * @run main/othervm -Xbatch -XX:-UseArrayFlattening
+ *                   compiler.valhalla.inlinetypes.TestGenerated
+ * @run main/othervm -Xbatch -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening -XX:+UseNonAtomicValueFlattening
  *                   compiler.valhalla.inlinetypes.TestGenerated
  */
 


### PR DESCRIPTION
We hit an assert in the register allocator because a `DecodeN` is kept alive by a `MemBarVolatile`:
```
o183 ConvL2I === _ o182 [[ o184 ]] #int
o184 CastI2N === o179 o183 [[ o419 ]]
o419 DecodeN === _ o184 [[ o187 65 ]] #float[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact *
o187 MemBarVolatile === o179 o1 o180 o1 o1 o419 [[ o188 o189 64 ]]
 65 membar_volatile === 67 0 94 0 0 o419 [[ 66 ]] !jvms: TestGenerated::test11 @ bci:2 (line 201)
```

The membar is emitted by `InlineTypeNode::convert_from_payload` to prevent a `CastI2N` from floating below a safepoint. This is necessary to avoid having the raw pointer span a safepoint, making it opaque to the GC.

On second thought, I don't think we need a membar to prevent this from happening. I removed it and added a comment explaining the details. All tests, including our stress testing, still pass.

Thanks,
Tobias