### PR TITLE
8355560: SetTag/GetTag should consider equal value objects as the same object

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -41,11 +41,11 @@ class JvmtiTagMapKeyClosure;
 // Its get_hash() and equals() methods are also used for getting the hash
 // value of a Key and comparing two Keys, respectively.
 //
-// Valhalla: tags for equal ("the same") value object are the same.
-// We have to keep strong reference to each unique value object with non-0 tag.
+// Valhalla: Keep just one tag for all equal value objects including heap allocated value objects.
+// We have to keep a strong reference to each unique value object with a non-zero tag.
 class JvmtiTagMapKey : public CHeapObj<mtServiceability> {
   // All equal value objects should have the same tag.
-  // So have to keep alive value objects (1 copy for each "value") until their tags are removed.
+  // Keep value objects alive (1 copy for each "value") until their tags are removed.
   union {
     WeakHandle _wh;
     OopHandle _h; // for value objects (_is_weak == false)

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Tests SetTag/GetTag functionality for value objects.
+ * @requires vm.jvmti
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @run main/othervm/native -agentlib:ValueTagMapTest
+ *                          -XX:+PrintInlineLayout
+ *                          -XX:+PrintFlatArrayLayout
+ *                          -Xlog:jvmti+table
+ *                          ValueTagMapTest
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
+
+public class ValueTagMapTest {
+
+    private static value class ValueClass {
+        public int f1;
+        public ValueClass(int v1) { f1 = v1 + 1; }
+        public String toString() {
+            return String.valueOf(f1);
+        }
+    }
+
+    private static value class ValueHolder {
+        @Strict
+        @NullRestricted
+        public ValueClass f1;
+
+        public ValueHolder(int v) {
+            f1 = new ValueClass(v);
+        }
+        public String toString() {
+            return "holder{" + f1 + "}";
+        }
+    }
+
+    private static value class ValueHolder2 {
+        public ValueHolder f1;
+        @Strict
+        @NullRestricted
+        public ValueHolder f2;
+
+        public ValueHolder2(int v, int v2) {
+            f1 = new ValueHolder(v);
+            f2 = new ValueHolder(v2);
+        }
+        public ValueHolder2(ValueHolder h1, int v2) {
+            f1 = h1;
+            f2 = new ValueHolder(v2);
+        }
+        public String toString() {
+            return "holder2{" + f1 + ", " + f2 + "}";
+        }
+    }
+
+
+    private static native void setTag0(Object object, long tag);
+    private static void setTag(Object object, long tag) {
+        setTag0(object, tag);
+    }
+    private static native long getTag0(Object object);
+    private static long getTag(Object object) {
+        long tag = getTag0(object);
+        if (tag == 0) {
+            throw new RuntimeException("Zero tag for object " + object);
+        }
+        return tag;
+    }
+
+    private static void testGetTag(Object o1, Object o2) {
+        long tag1 = getTag(o1);
+        long tag2 = getTag(o2);
+        if (o1 == o2) {
+            if (tag1 != tag2) {
+                throw new RuntimeException("different tags for equal objects: "
+                                           + o1 + " (tag " + tag1 + "), "
+                                           + o2 + " (tag " + tag2 + ")");
+            }
+        } else {
+            if (tag1 == tag2) {
+                throw new RuntimeException("equal tags for different objects: "
+                                           + o1 + " (tag " + tag1 + "), "
+                                           + o2 + " (tag " + tag2 + ")");
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("ValueTagMapTest");
+        List<ValueHolder2> items = new ArrayList<>();
+
+        for (int i = 0; i < 20; i++) {
+            items.add(new ValueHolder2(i % 4, i % 8));
+        }
+
+        long startTime = System.nanoTime();
+        long tag = 1;
+        for (ValueHolder2 item : items) {
+            setTag(item, tag++);
+            setTag(item.f1, tag++);
+            setTag(item.f2, tag++);
+        }
+
+        for (ValueHolder2 item: items) {
+            long tag0 = getTag(item);
+            long tag1 = getTag(item.f1);
+            long tag2 = getTag(item.f2);
+            System.out.println("getTag (" + item + "): " + tag0 + ", f1: " + tag1 + ", f2:" + tag2);
+        }
+
+        startTime = System.nanoTime();
+        for (ValueHolder2 item1: items) {
+            for (ValueHolder2 item2 : items) {
+                testGetTag(item1, item2);
+                testGetTag(item1.f1, item2.f1);
+                testGetTag(item1.f2, item2.f2);
+                testGetTag(item1.f1, item2.f2);
+                testGetTag(item1.f2, item2.f1);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java
@@ -43,23 +43,23 @@ import jdk.internal.vm.annotation.Strict;
 public class ValueTagMapTest {
 
     private static value class ValueClass {
-        public int f1;
-        public ValueClass(int v1) { f1 = v1 + 1; }
+        public int f;
+        public ValueClass(int v) { f = v + 1; }
         public String toString() {
-            return String.valueOf(f1);
+            return String.valueOf(f);
         }
     }
 
     private static value class ValueHolder {
         @Strict
         @NullRestricted
-        public ValueClass f1;
+        public ValueClass f0;
 
         public ValueHolder(int v) {
-            f1 = new ValueClass(v);
+            f0 = new ValueClass(v);
         }
         public String toString() {
-            return "holder{" + f1 + "}";
+            return "holder{" + f0 + "}";
         }
     }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/libValueTagMapTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/libValueTagMapTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jvmti.h>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+jvmtiEnv *jvmti = nullptr;
+
+void checkJvmti(int code, const char* message) {
+  if (code != JVMTI_ERROR_NONE) {
+    printf("Error %s: %d\n", message, code);
+    fflush(nullptr);
+    abort();
+  }
+}
+
+}
+
+extern "C" JNIEXPORT void JNICALL Java_ValueTagMapTest_setTag0(JNIEnv* jni_env, jclass clazz, jobject object, jlong tag) {
+  jvmtiError err = jvmti->SetTag(object, tag);
+  checkJvmti(err, "could not set tag");
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_ValueTagMapTest_getTag0(JNIEnv* jni_env, jclass clazz, jobject object) {
+  jlong tag;
+  checkJvmti(jvmti->GetTag(object, &tag), "could not get tag");
+  return tag;
+}
+
+extern "C" JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved) {
+  if (vm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION) != JNI_OK || !jvmti) {
+    printf("Could not initialize JVMTI\n");
+    fflush(nullptr);
+    abort();
+  }
+  jvmtiCapabilities capabilities;
+  memset(&capabilities, 0, sizeof(capabilities));
+  capabilities.can_tag_objects = 1;
+  checkJvmti(jvmti->AddCapabilities(&capabilities), "adding capabilities");
+  return JVMTI_ERROR_NONE;
+}
+

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/libValueTagMapTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/libValueTagMapTest.cpp
@@ -22,44 +22,34 @@
  */
 
 #include <jvmti.h>
-#include <cstdlib>
-#include <cstring>
+#include "jvmti_common.hpp"
 
 namespace {
 
 jvmtiEnv *jvmti = nullptr;
 
-void checkJvmti(int code, const char* message) {
-  if (code != JVMTI_ERROR_NONE) {
-    printf("Error %s: %d\n", message, code);
-    fflush(nullptr);
-    abort();
-  }
-}
-
 }
 
 extern "C" JNIEXPORT void JNICALL Java_ValueTagMapTest_setTag0(JNIEnv* jni_env, jclass clazz, jobject object, jlong tag) {
   jvmtiError err = jvmti->SetTag(object, tag);
-  checkJvmti(err, "could not set tag");
+  check_jvmti_error(err, "could not set tag");
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_ValueTagMapTest_getTag0(JNIEnv* jni_env, jclass clazz, jobject object) {
   jlong tag;
-  checkJvmti(jvmti->GetTag(object, &tag), "could not get tag");
+  check_jvmti_error(jvmti->GetTag(object, &tag), "could not get tag");
   return tag;
 }
 
 extern "C" JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved) {
   if (vm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION) != JNI_OK || !jvmti) {
-    printf("Could not initialize JVMTI\n");
-    fflush(nullptr);
+    LOG("Could not initialize JVMTI\n");
     abort();
   }
   jvmtiCapabilities capabilities;
   memset(&capabilities, 0, sizeof(capabilities));
   capabilities.can_tag_objects = 1;
-  checkJvmti(jvmti->AddCapabilities(&capabilities), "adding capabilities");
+  check_jvmti_error(jvmti->AddCapabilities(&capabilities), "adding capabilities");
   return JVMTI_ERROR_NONE;
 }
 


### PR DESCRIPTION
Fixes SetTag/GetTag JVMTI functions so they consider equal value object as a single object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8355560](https://bugs.openjdk.org/browse/JDK-8355560): SetTag/GetTag should consider equal value objects as the same object (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1444/head:pull/1444` \
`$ git checkout pull/1444`

Update a local copy of the PR: \
`$ git checkout pull/1444` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1444`

View PR using the GUI difftool: \
`$ git pr show -t 1444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1444.diff">https://git.openjdk.org/valhalla/pull/1444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1444#issuecomment-2829139130)
</details>
