### PR TITLE
8354322: [lworld] InlineKlass::collect_fields fails to look up flat fields declared in abstract super class

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -410,6 +410,7 @@ int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, float& max_offset,
   for (HierarchicalFieldStream<JavaFieldStream> fs(this); !fs.done(); fs.next()) {
     if (fs.access_flags().is_static()) continue;
     int offset = base_off + fs.offset() - (base_off > 0 ? payload_offset() : 0);
+    InstanceKlass* field_holder = fs.field_descriptor().field_holder();
     // TODO 8284443 Use different heuristic to decide what should be scalarized in the calling convention
     if (fs.is_flat()) {
       // Resolve klass of flat field and recursively collect fields
@@ -417,14 +418,14 @@ int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, float& max_offset,
       if (!fs.is_null_free_inline_type()) {
         field_null_marker_offset = base_off + fs.null_marker_offset() - (base_off > 0 ? payload_offset() : 0);
       }
-      Klass* vk = get_inline_type_field_klass(fs.index());
+      Klass* vk = field_holder->get_inline_type_field_klass(fs.index());
       count += InlineKlass::cast(vk)->collect_fields(sig, max_offset, offset, field_null_marker_offset);
     } else {
       BasicType bt = Signature::basic_type(fs.signature());
       SigEntry::add_entry(sig, bt, fs.signature(), offset);
       count += type2size[bt];
     }
-    if (fs.field_descriptor().field_holder() != this) {
+    if (field_holder != this) {
       // Inherited field, add an empty wrapper to this to distinguish it from a "local" field
       // with a different offset and avoid false adapter sharing. TODO 8348547 Is this sufficient?
       SigEntry::add_entry(sig, T_METADATA, name(), base_off);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyAbstract.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyAbstract.java
@@ -24,6 +24,8 @@
 package compiler.valhalla.inlinetypes;
 
 import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
 
 @LooselyConsistentValue
 public abstract value class MyAbstract implements MyInterface {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyAbstract.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyAbstract.java
@@ -24,8 +24,6 @@
 package compiler.valhalla.inlinetypes;
 
 import jdk.internal.vm.annotation.LooselyConsistentValue;
-import jdk.internal.vm.annotation.NullRestricted;
-import jdk.internal.vm.annotation.Strict;
 
 @LooselyConsistentValue
 public abstract value class MyAbstract implements MyInterface {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -1336,7 +1336,55 @@ public class TestCallingConvention {
     }
 
     @Run(test = "test57")
-    public void test57_verifier(RunInfo info) throws Throwable {
+    public void test57_verifier() {
         Asserts.assertEQ(test57(), expectedUseArrayFlattening);
+    }
+
+    // Test abstract value class with flat fields
+    @LooselyConsistentValue
+    abstract value class MyAbstract58 {
+        @Strict
+        @NullRestricted
+        MyValue58Inline nullfree = new MyValue58Inline();
+
+        MyValue58Inline nullable = new MyValue58Inline();
+    }
+
+    @LooselyConsistentValue
+    value class MyValue58Inline {
+        int x = rI;
+    }
+
+    @LooselyConsistentValue
+    value class MyValue58_1 extends MyAbstract58 {
+    }
+
+    @LooselyConsistentValue
+    value class MyValue58_2 extends MyAbstract58 {
+        int x = rI;
+    }
+
+    @LooselyConsistentValue
+    value class MyValue58_3 extends MyAbstract58 {
+        int x = rI;
+
+        @Strict
+        @NullRestricted
+        MyValue1 nullfree = MyValue1.DEFAULT;
+
+        MyValue1 nullable = null;
+    }
+
+    @Test
+    public MyValue58_3 test58(MyValue58_1 arg1, MyValue58_2 arg2, MyValue58_3 arg3) {
+        Asserts.assertEQ(arg1, new MyValue58_1());
+        Asserts.assertEQ(arg2, new MyValue58_2());
+        Asserts.assertEQ(arg3, new MyValue58_3());
+        return arg3;
+    }
+
+    @Run(test = "test58")
+    public void test58_verifier() {
+        Asserts.assertEQ(test58(new MyValue58_1(), new MyValue58_2(), new MyValue58_3()), new MyValue58_3());
     }
 }


### PR DESCRIPTION
The problem is that we are doing the lookup for a flat field declared in an abstract super class in the subclass and don't find it there.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8354322](https://bugs.openjdk.org/browse/JDK-8354322): [lworld] InlineKlass::collect_fields fails to look up flat fields declared in abstract super class (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1445/head:pull/1445` \
`$ git checkout pull/1445`

Update a local copy of the PR: \
`$ git checkout pull/1445` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1445`

View PR using the GUI difftool: \
`$ git pr show -t 1445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1445.diff">https://git.openjdk.org/valhalla/pull/1445.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1445#issuecomment-2830071170)
</details>
