### PR TITLE
8354408: [lworld] compiler/types/TestSubTypeCheckUniqueSubclass.java IR mismatches post jdk-25+16 merge

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,7 +82,6 @@ compiler/ciReplay/TestInliningProtectionDomain.java 8349191 generic-all
 compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
 
 compiler/startup/StartupOutput.java 8354404 generic-all
-compiler/types/TestSubTypeCheckUniqueSubclass.java 8354408 generic-all
 compiler/valhalla/inlinetypes/TestAllocationMergeAndFolding.java 8354283 generic-all
 
 #############################################################################

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1970,7 +1970,8 @@ public class IRNode {
 
     public static final String SUBTYPE_CHECK = PREFIX + "SUBTYPE_CHECK" + POSTFIX;
     static {
-        macroNodes(SUBTYPE_CHECK, "SubTypeCheck");
+        String regex = START + "SubTypeCheck" + MID + END;
+        macroNodes(SUBTYPE_CHECK, regex);
     }
 
     public static final String TRAP = PREFIX + "TRAP" + POSTFIX;


### PR DESCRIPTION
Hi,

The issue here is that `IRNode::macroNodes` takes a full line regex, not only the node name part like `IRNode::beforeMatchingNameRegex`. As a result, we should compute the full regex for `SUBTYPE_CHECK`.

Please kindly review, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8354408](https://bugs.openjdk.org/browse/JDK-8354408): [lworld] compiler/types/TestSubTypeCheckUniqueSubclass.java IR mismatches post jdk-25+16 merge (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1448/head:pull/1448` \
`$ git checkout pull/1448`

Update a local copy of the PR: \
`$ git checkout pull/1448` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1448`

View PR using the GUI difftool: \
`$ git pr show -t 1448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1448.diff">https://git.openjdk.org/valhalla/pull/1448.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1448#issuecomment-2844124064)
</details>
