### PR TITLE
8356088: [lworld] dead methods in array code

### DIFF
--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -69,10 +69,6 @@ class ArrayKlass: public Klass {
   // Compiler/Interpreter offset
   static ByteSize element_klass_offset() { return in_ByteSize(offset_of(ArrayKlass, _element_klass)); }
 
-  // Are loads and stores to this concrete array type atomic?
-  // Note that Object[] is naturally atomic, but its subtypes may not be.
-  virtual bool element_access_must_be_atomic() { return true; }
-
   // Testing operation
   DEBUG_ONLY(bool is_array_klass_slow() const { return true; })
 

--- a/src/hotspot/share/oops/flatArrayKlass.hpp
+++ b/src/hotspot/share/oops/flatArrayKlass.hpp
@@ -82,11 +82,6 @@ class FlatArrayKlass : public ArrayKlass {
     return element_klass()->contains_oops();
   }
 
-  // Override.
-  bool element_access_must_be_atomic() {
-    return element_klass()->must_be_atomic();
-  }
-
   oop protection_domain() const;
 
   virtual void metaspace_pointers_do(MetaspaceClosure* iter);
@@ -112,11 +107,6 @@ class FlatArrayKlass : public ArrayKlass {
   void copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos, int length, TRAPS);
 
   // GC specific object visitors
-  //
-  // Mark Sweep
-  int oop_ms_adjust_pointers(oop obj);
-
-
   template <typename T, typename OopClosureType>
   inline void oop_oop_iterate(oop obj, OopClosureType* closure);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2474,43 +2474,6 @@ JVM_ENTRY(jobject, JVM_AssertionStatusDirectives(JNIEnv *env, jclass unused))
   return JNIHandles::make_local(THREAD, asd);
 JVM_END
 
-// Arrays support /////////////////////////////////////////////////////////////
-
-JVM_ENTRY(jboolean, JVM_ArrayIsAccessAtomic(JNIEnv *env, jclass unused, jobject array))
-  oop o = JNIHandles::resolve(array);
-  Klass* k = o->klass();
-  if ((o == nullptr) || (!k->is_array_klass())) {
-    THROW_0(vmSymbols::java_lang_IllegalArgumentException());
-  }
-  return ArrayKlass::cast(k)->element_access_must_be_atomic();
-JVM_END
-
-JVM_ENTRY(jobject, JVM_ArrayEnsureAccessAtomic(JNIEnv *env, jclass unused, jobject array))
-  oop o = JNIHandles::resolve(array);
-  Klass* k = o->klass();
-  if ((o == nullptr) || (!k->is_array_klass())) {
-    THROW_0(vmSymbols::java_lang_IllegalArgumentException());
-  }
-  if (k->is_flatArray_klass()) {
-    FlatArrayKlass* vk = FlatArrayKlass::cast(k);
-    if (!vk->element_access_must_be_atomic()) {
-      /**
-       * Need to decide how to implement:
-       *
-       * 1) Change to objArrayOop layout, therefore oop->klass() differs so
-       * then "<atomic>[Qfoo;" klass needs to subclass "[Qfoo;" to pass through
-       * "checkcast" & "instanceof"
-       *
-       * 2) Use extra header in the flatArrayOop to flag atomicity required and
-       * possibly per instance lock structure. Said info, could be placed in
-       * "trailer" rather than disturb the current arrayOop
-       */
-      Unimplemented();
-    }
-  }
-  return array;
-JVM_END
-
 // Verification ////////////////////////////////////////////////////////////////////////////////
 
 // Reflection for the verifier /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Removal of dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8356088](https://bugs.openjdk.org/browse/JDK-8356088): [lworld] dead methods in array code (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1450/head:pull/1450` \
`$ git checkout pull/1450`

Update a local copy of the PR: \
`$ git checkout pull/1450` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1450`

View PR using the GUI difftool: \
`$ git pr show -t 1450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1450.diff">https://git.openjdk.org/valhalla/pull/1450.diff</a>

</details>
