### PR TITLE
8356599: [lworld] C2 incorrectly folds array object klass load for atomic arrays

### DIFF
--- a/src/hotspot/share/ci/ciArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciArrayKlass.cpp
@@ -117,9 +117,6 @@ ciArrayKlass* ciArrayKlass::make(ciType* element_type, bool flat, bool null_free
       if (flat && vk->maybe_flat_in_array()) {
         LayoutKind lk;
         if (null_free) {
-          if (vk->is_naturally_atomic()) {
-            atomic = vk->has_atomic_layout();
-          }
           if (!atomic && !vk->has_non_atomic_layout()) {
             // TODO 8350865 Impossible type
             lk = vk->has_atomic_layout() ? LayoutKind::ATOMIC_FLAT : LayoutKind::NULLABLE_ATOMIC_FLAT;

--- a/src/hotspot/share/ci/ciKlass.cpp
+++ b/src/hotspot/share/ci/ciKlass.cpp
@@ -251,6 +251,11 @@ void ciKlass::print_impl(outputStream* st) {
   st->print(" name=");
   print_name_on(st);
   st->print(" loaded=%s", (is_loaded() ? "true" : "false"));
+  GUARDED_VM_ENTRY(
+    if (is_flat_array_klass()) {
+      st->print(" layout_kind=%d", (int)((FlatArrayKlass*)get_Klass())->layout_kind());
+    }
+  )
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -355,7 +355,7 @@ class GraphKit : public Phase {
   Node* ConvI2UL(Node* offset);
   Node* ConvL2I(Node* offset);
   // Find out the klass of an object.
-  Node* load_object_klass(Node* object);
+  Node* load_object_klass(Node* object, bool fold_for_arrays = true);
   // Find out the length of an array.
   Node* load_array_length(Node* array);
   // Cast array allocation's length as narrow as possible.

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4599,7 +4599,7 @@ bool LibraryCallKit::inline_newArray(bool null_free, bool atomic) {
 
         ciArrayKlass* array_klass = ciArrayKlass::make(t, flat, null_free, atomic);
         if (array_klass->is_loaded() && array_klass->element_klass()->as_inline_klass()->is_initialized()) {
-          const TypeAryKlassPtr* array_klass_type = TypeKlassPtr::make(array_klass, Type::trust_interfaces)->is_aryklassptr();
+          const TypeAryKlassPtr* array_klass_type = TypeAryKlassPtr::make(array_klass, Type::trust_interfaces);
           if (null_free) {
             if (init_val->is_InlineType()) {
               if (array_klass_type->is_flat() && init_val->as_InlineType()->is_all_zero(&gvn(), /* flat */ true)) {
@@ -5665,6 +5665,7 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
     PhiNode*    result_mem = new PhiNode(result_reg, Type::MEMORY, TypePtr::BOTTOM);
     record_for_igvn(result_reg);
 
+    // TODO 8350865 For arrays, this might be folded and then not account for atomic arrays
     Node* obj_klass = load_object_klass(obj);
     // We only go to the fast case code if we pass a number of guards.
     // The paths which do not pass are accumulated in the slow_region.

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -7312,7 +7312,8 @@ ciKlass* TypeAryKlassPtr::exact_klass_helper() const {
     if (k == nullptr) {
       return nullptr;
     }
-    // TODO 8350865 As long as atomicity is not in the type system, we can't re-compute here
+    // TODO 8350865 LibraryCallKit::inline_newArray passes a constant TypeAryKlassPtr to GraphKit::new_array
+    // As long as atomicity is not tracked by TypeAryKlassPtr, don't re-compute it here to avoid loosing atomicity information
     if (k->is_inlinetype() && _klass != nullptr) {
       return _klass;
     }

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5191,9 +5191,6 @@ const TypeAryPtr* TypeAryPtr::make(PTR ptr, const TypeAry *ary, ciKlass* k, bool
       k->as_obj_array_klass()->base_element_klass()->is_interface()) {
     k = nullptr;
   }
-  if (k != nullptr && k->is_flat_array_klass() && !ary->_flat) {
-    k = nullptr;
-  }
   return (TypeAryPtr*)(new TypeAryPtr(ptr, nullptr, ary, k, xk, offset, field_offset, instance_id, false, speculative, inline_depth))->hashcons();
 }
 
@@ -5208,9 +5205,6 @@ const TypeAryPtr* TypeAryPtr::make(PTR ptr, ciObject* o, const TypeAry *ary, ciK
   assert(instance_id <= 0 || xk, "instances are always exactly typed");
   if (k != nullptr && k->is_loaded() && k->is_obj_array_klass() &&
       k->as_obj_array_klass()->base_element_klass()->is_interface()) {
-    k = nullptr;
-  }
-  if (k != nullptr && k->is_flat_array_klass() && !ary->_flat) {
     k = nullptr;
   }
   return (TypeAryPtr*)(new TypeAryPtr(ptr, o, ary, k, xk, offset, field_offset, instance_id, is_autobox_cache, speculative, inline_depth))->hashcons();
@@ -6804,7 +6798,7 @@ const TypeAryKlassPtr* TypeAryKlassPtr::make(PTR ptr, ciKlass* k, Offset offset,
   } else if (k->is_flat_array_klass()) {
     ciKlass* eklass = k->as_flat_array_klass()->element_klass();
     const TypeKlassPtr* etype = TypeKlassPtr::make(eklass, interface_handling)->cast_to_exactness(false);
-    return TypeAryKlassPtr::make(ptr, etype, nullptr, offset, not_flat, not_null_free, flat, null_free);
+    return TypeAryKlassPtr::make(ptr, etype, k, offset, not_flat, not_null_free, flat, null_free);
   } else {
     ShouldNotReachHere();
     return nullptr;
@@ -6920,9 +6914,7 @@ ciKlass* TypeAryPtr::exact_klass_helper() const {
     if (k == nullptr) {
       return nullptr;
     }
-    // TODO 8350865 We assume atomic if the atomic layout is available
-    bool atomic = k->is_inlinetype() && (is_null_free() ? k->as_inline_klass()->has_atomic_layout() : k->as_inline_klass()->has_nullable_atomic_layout());
-    k = ciArrayKlass::make(k, is_flat(), is_null_free(), atomic);
+    k = ciArrayKlass::make(k, is_flat(), is_null_free());
     return k;
   }
 
@@ -7320,9 +7312,11 @@ ciKlass* TypeAryKlassPtr::exact_klass_helper() const {
     if (k == nullptr) {
       return nullptr;
     }
-    // TODO 8350865 We assume atomic if the atomic layout is available
-    bool atomic = k->is_inlinetype() && (is_null_free() ? k->as_inline_klass()->has_atomic_layout() : k->as_inline_klass()->has_nullable_atomic_layout());
-    k = ciArrayKlass::make(k, is_flat(), is_null_free(), atomic);
+    // TODO 8350865 As long as atomicity is not in the type system, we can't re-compute here
+    if (k->is_inlinetype() && _klass != nullptr) {
+      return _klass;
+    }
+    k = ciArrayKlass::make(k, is_flat(), is_null_free());
     return k;
   }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @summary Verify that certain array accesses do not trigger deoptimization.
+ * @requires vm.debug == true
  * @library /test/lib
  * @enablePreview
  * @modules java.base/jdk.internal.value
@@ -100,6 +101,7 @@ public class TestArrayAccessDeopt {
                             "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,TestArrayAccessDeopt::test*", "-XX:-UseArrayLoadStoreProfile",
                             "-XX:+TraceDeoptimization", "-Xbatch", "-XX:-MonomorphicArrayCheck", "-Xmixed", "-XX:+ProfileInterpreter", "TestArrayAccessDeopt", "run"};
             OutputAnalyzer oa = ProcessTools.executeTestJava(arg);
+            oa.shouldHaveExitValue(0);
             String output = oa.getOutput();
             oa.shouldNotContain("UNCOMMON TRAP");
         } else {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayNullMarkers.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayNullMarkers.java
@@ -294,6 +294,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeArray), UseArrayFlattening && UseNonAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeArray));
+        Asserts.assertTrue(!ValueClass.isFlatArray(nullFreeArray) || !ValueClass.isAtomicArray(nullFreeArray));
         Asserts.assertEquals(nullFreeArray[idx], TwoBytes.DEFAULT);
         testWrite1(nullFreeArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeArray, idx), val);
@@ -310,6 +311,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeArray), UseArrayFlattening && UseNonAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeArray));
+        Asserts.assertTrue(!ValueClass.isFlatArray(nullFreeArray) || !ValueClass.isAtomicArray(nullFreeArray));
         Asserts.assertEquals(nullFreeArray[idx], CANARY1);
         testWrite1(nullFreeArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeArray, idx), val);
@@ -322,6 +324,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeArray), UseArrayFlattening && UseNonAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeArray));
+        Asserts.assertTrue(!ValueClass.isFlatArray(nullFreeArray) || !ValueClass.isAtomicArray(nullFreeArray));
         Asserts.assertEquals(nullFreeArray[idx], CANARY1);
         testWrite1(nullFreeArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeArray, idx), val);
@@ -336,6 +339,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeArray), UseArrayFlattening && UseNonAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeArray));
+        Asserts.assertTrue(!ValueClass.isFlatArray(nullFreeArray) || !ValueClass.isAtomicArray(nullFreeArray));
         Asserts.assertEquals(nullFreeArray[idx], new TwoBytes(myByte, myByte));
         testWrite1(nullFreeArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeArray, idx), val);
@@ -348,6 +352,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeAtomicArray), UseArrayFlattening && UseAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeAtomicArray));
+        Asserts.assertTrue(ValueClass.isAtomicArray(nullFreeAtomicArray));
         Asserts.assertEquals(nullFreeAtomicArray[idx], TwoBytes.DEFAULT);
         testWrite1(nullFreeAtomicArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeAtomicArray, idx), val);
@@ -360,6 +365,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeAtomicArray), UseArrayFlattening && UseAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeAtomicArray));
+        Asserts.assertTrue(ValueClass.isAtomicArray(nullFreeAtomicArray));
         Asserts.assertEquals(nullFreeAtomicArray[idx], CANARY1);
         testWrite1(nullFreeAtomicArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeAtomicArray, idx), val);
@@ -372,6 +378,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeAtomicArray), UseArrayFlattening && UseAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeAtomicArray));
+        Asserts.assertTrue(ValueClass.isAtomicArray(nullFreeAtomicArray));
         Asserts.assertEquals(nullFreeAtomicArray[idx], CANARY1);
         testWrite1(nullFreeAtomicArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeAtomicArray, idx), val);
@@ -384,6 +391,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeAtomicArray), UseArrayFlattening && UseAtomicValueFlattening);
         }
         Asserts.assertTrue(ValueClass.isNullRestrictedArray(nullFreeAtomicArray));
+        Asserts.assertTrue(ValueClass.isAtomicArray(nullFreeAtomicArray));
         Asserts.assertEquals(nullFreeAtomicArray[idx], new TwoBytes(myByte, myByte));
         testWrite1(nullFreeAtomicArray, idx, val);
         Asserts.assertEQ(testRead1(nullFreeAtomicArray, idx), val);
@@ -396,6 +404,7 @@ public class TestArrayNullMarkers {
             Asserts.assertEquals(ValueClass.isFlatArray(nullableAtomicArray), UseArrayFlattening && UseNullableValueFlattening);
         }
         Asserts.assertFalse(ValueClass.isNullRestrictedArray(nullableAtomicArray));
+        Asserts.assertTrue(ValueClass.isAtomicArray(nullableAtomicArray));
         Asserts.assertEquals(nullableAtomicArray[idx], null);
         testWrite1(nullableAtomicArray, idx, val);
         Asserts.assertEQ(testRead1(nullableAtomicArray, idx), val);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayQueryTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayQueryTest.java
@@ -66,47 +66,47 @@
 
     public static void main(String[] args) {
         SmallValue[] array0 = new SmallValue[10];
-        Asserts.assertFalse(ValueClass.isNullRestrictedArray((array0)));
+        Asserts.assertFalse(ValueClass.isNullRestrictedArray(array0));
         Asserts.assertFalse(ValueClass.isFlatArray(array0));
         Asserts.assertTrue(ValueClass.isAtomicArray(array0));
 
         Object[] array1 = ValueClass.newNullRestrictedAtomicArray(SmallValue.class, 10, new SmallValue());
-        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array1)));
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray(array1));
         Asserts.assertTrue(ValueClass.isFlatArray(array1));
         Asserts.assertTrue(ValueClass.isAtomicArray(array1));
 
         Object[] array2 = ValueClass.newNullableAtomicArray(SmallValue.class, 10);
-        Asserts.assertFalse(ValueClass.isNullRestrictedArray((array2)));
+        Asserts.assertFalse(ValueClass.isNullRestrictedArray(array2));
         Asserts.assertTrue(ValueClass.isFlatArray(array2));
         Asserts.assertTrue(ValueClass.isAtomicArray(array2));
 
         Object[] array3 = ValueClass.newNullRestrictedNonAtomicArray(WeakValue.class, 10, new WeakValue());
-        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array3)));
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray(array3));
         Asserts.assertTrue(ValueClass.isFlatArray(array3));
         Asserts.assertFalse(ValueClass.isAtomicArray(array3));
 
         Object[] array4 = ValueClass.newNullRestrictedAtomicArray(WeakValue.class, 10, new WeakValue());
-        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array4)));
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray(array4));
         Asserts.assertTrue(ValueClass.isFlatArray(array4));
         Asserts.assertTrue(ValueClass.isAtomicArray(array4));
 
         Object[] array5 = ValueClass.newNullRestrictedAtomicArray(NaturallyAtomic.class, 10, new NaturallyAtomic());
-        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array5)));
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray(array5));
         Asserts.assertTrue(ValueClass.isFlatArray(array5));
         Asserts.assertTrue(ValueClass.isAtomicArray(array5));
 
         Object[] array6 = ValueClass.newNullRestrictedNonAtomicArray(BigValue.class, 10, new BigValue());
-        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array6)));
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray(array6));
         Asserts.assertTrue(ValueClass.isFlatArray(array6));
         Asserts.assertFalse(ValueClass.isAtomicArray(array6));
 
         Object[] array7 = ValueClass.newNullRestrictedAtomicArray(BigValue.class, 10, new BigValue());
-        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array7)));
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray(array7));
         Asserts.assertFalse(ValueClass.isFlatArray(array7));
         Asserts.assertTrue(ValueClass.isAtomicArray(array7));
 
         Object[] array8 = ValueClass.newNullableAtomicArray(BigValue.class, 10);
-        Asserts.assertFalse(ValueClass.isNullRestrictedArray((array8)));
+        Asserts.assertFalse(ValueClass.isNullRestrictedArray(array8));
         Asserts.assertFalse(ValueClass.isFlatArray(array8));
         Asserts.assertTrue(ValueClass.isAtomicArray(array8));
     }


### PR DESCRIPTION
`TypeAryKlassPtr` and `TypeAryPtr`/`TypeAry` in C2's typesystem currently don't keep track of atomicity of arrays. As a result, C2 might incorrectly fold loads from `GraphKit::load_object_klass` to non-atomic `TypeAryKlassPtr`, resulting in the `GraphKit::null_free_atomic_array_test` to incorrectly return false at runtime.

I fixed this by selectively disabling folding of the klass load done by the `GraphKit::null_free_atomic_array_test` via a `fold_for_arrays` flag for now. I'll revisit this with JDK-8350865.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8356599](https://bugs.openjdk.org/browse/JDK-8356599): [lworld] C2 incorrectly folds array object klass load for atomic arrays (**Bug** - P2)
 * [JDK-8355941](https://bugs.openjdk.org/browse/JDK-8355941): [lworld] TestArrayAccessDeopt.java fails due to unexpected deoptimization (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1451/head:pull/1451` \
`$ git checkout pull/1451`

Update a local copy of the PR: \
`$ git checkout pull/1451` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1451`

View PR using the GUI difftool: \
`$ git pr show -t 1451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1451.diff">https://git.openjdk.org/valhalla/pull/1451.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1451#issuecomment-2865335444)
</details>
