### PR TITLE
8348959: [lworld] compiler/c2/TestMergeStores.java fails IR verification

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -76,7 +76,6 @@ compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 compiler/interpreter/Test6833129.java 8335266 generic-i586
 
 compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java 8342488 generic-all
-compiler/c2/TestMergeStores.java#id1 8348959 generic-all
 
 compiler/ciReplay/TestInliningProtectionDomain.java 8349191 generic-all
 compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all


### PR DESCRIPTION
The test now passes after [JDK-8351414](https://bugs.openjdk.org/browse/JDK-8351414) was merged from mainline.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348959](https://bugs.openjdk.org/browse/JDK-8348959): [lworld] compiler/c2/TestMergeStores.java fails IR verification (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1453/head:pull/1453` \
`$ git checkout pull/1453`

Update a local copy of the PR: \
`$ git checkout pull/1453` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1453`

View PR using the GUI difftool: \
`$ git pr show -t 1453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1453.diff">https://git.openjdk.org/valhalla/pull/1453.diff</a>

</details>
