### PR TITLE
8357035: [lworld] ValueTagMapTest missing -XX:+UnlockDiagnosticVMOptions

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
  * @run main/othervm/native -agentlib:ValueTagMapTest
+ *                          -XX:+UnlockDiagnosticVMOptions
  *                          -XX:+PrintInlineLayout
  *                          -XX:+PrintFlatArrayLayout
  *                          -Xlog:jvmti+table


### PR DESCRIPTION
Use UnlockDiagnosticVMOptions for print layout

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357035](https://bugs.openjdk.org/browse/JDK-8357035): [lworld] ValueTagMapTest missing -XX:+UnlockDiagnosticVMOptions (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1454/head:pull/1454` \
`$ git checkout pull/1454`

Update a local copy of the PR: \
`$ git checkout pull/1454` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1454`

View PR using the GUI difftool: \
`$ git pr show -t 1454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1454.diff">https://git.openjdk.org/valhalla/pull/1454.diff</a>

</details>
