### PR TITLE
8332886: [lworld] TestBasicFunctionality::test21 counts incorrectly

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -514,9 +514,7 @@ static MyValue1 tmp = null;
 
     // Test value class fields in objects
     @Test
-    // TODO 8332886 Re-enable this
-    // @IR(counts = {ALLOC, "= 2"},
-    //     failOn = TRAP)
+    @IR(counts = {ALLOC, "= 4"}, failOn = TRAP)
     public long test21(int x, long y) {
         // Compute hash of value class fields
         long result = val1.hash() + val2.hash() + val3.hash() + val4.hash() + val5.hash();


### PR DESCRIPTION
Hi,

The issue here is that the test counts incorrectly, the test looks like this:

        val1 = MyValue1.createWithFieldsInline(x, y);
        val2 = MyValue2.createWithFieldsInline(x, rD);
        val4 = MyValue1.createWithFieldsInline(x, y);

All of these are reference fields since they are nullable and `MyValue1` and `MyValue2` are both very large. `MyValue1` has an identity field `int[] oa`, so `val1` and `val4` cannot be commoned. As a result, there should be 4 allocations: `val1`, `val4`, `val1.v4` , and `val2`.

Please take a look and leave your reviews, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8332886](https://bugs.openjdk.org/browse/JDK-8332886): [lworld] TestBasicFunctionality::test21 counts incorrectly (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1457/head:pull/1457` \
`$ git checkout pull/1457`

Update a local copy of the PR: \
`$ git checkout pull/1457` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1457`

View PR using the GUI difftool: \
`$ git pr show -t 1457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1457.diff">https://git.openjdk.org/valhalla/pull/1457.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1457#issuecomment-2884558415)
</details>
