### PR TITLE
8346466: [lworld] compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java asserts using generational zgc

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -125,14 +125,3 @@ compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java  
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java      8343233 generic-aarch64
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java             8343233 generic-aarch64
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java      8343233 generic-aarch64
-
-# Valhalla...
-compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java      8346466   generic-all
-compiler/valhalla/inlinetypes/TestArrays.java                 8341848   generic-all
-compiler/valhalla/inlinetypes/TestBasicFunctionality.java     8341848   generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java             8341849   generic-all
-compiler/valhalla/inlinetypes/TestLWorld.java                 8341848   generic-all
-compiler/valhalla/inlinetypes/TestNullableArrays.java         8341850   generic-all
-compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java   8341848 generic-all
-
-compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java 8341947   generic-aarch64


### PR DESCRIPTION
Un-problem listing tests with ZGC because in the meantime, all issues seem to have been fixed. 

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8346466](https://bugs.openjdk.org/browse/JDK-8346466): [lworld] compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java asserts using generational zgc (**Bug** - P4)
 * [JDK-8341848](https://bugs.openjdk.org/browse/JDK-8341848): [lworld] assert(index == 0 || is_power_of_2(index)) with genzgc in several Valhalla tests (**Bug** - P4)
 * [JDK-8341849](https://bugs.openjdk.org/browse/JDK-8341849): [lworld] Crash compiler.valhalla.inlinetypes.TestIntrinsics.test53 with genzgc (**Bug** - P4)
 * [JDK-8341850](https://bugs.openjdk.org/browse/JDK-8341850): [lworld] Crash in compiler.valhalla.inlinetypes.TestNullableArrays.test78 with genzgc (**Bug** - P4)
 * [JDK-8341947](https://bugs.openjdk.org/browse/JDK-8341947): [lworld] Crashing in java frames specifically on aarch64 with genzgc (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1460/head:pull/1460` \
`$ git checkout pull/1460`

Update a local copy of the PR: \
`$ git checkout pull/1460` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1460`

View PR using the GUI difftool: \
`$ git pr show -t 1460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1460.diff">https://git.openjdk.org/valhalla/pull/1460.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1460#issuecomment-2886666427)
</details>
