### PR TITLE
8349630: [lworld] runtime/valhalla/inlinetypes/ValuePreloadTest.java fails on linux-aarch64-debug after jdk-25+5

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -132,9 +132,6 @@ containers/docker/TestJcmdWithSideCar.java 8341518 linux-x64
 
 # Valhalla
 runtime/AccModule/ConstModule.java 8294051 generic-all
-runtime/valhalla/inlinetypes/CircularityTest.java 8349037 generic-all
-runtime/valhalla/inlinetypes/PreloadCircularityTest.java 8349631 linux-aarch64-debug
-runtime/valhalla/inlinetypes/ValuePreloadTest.java 8349630 linux-aarch64-debug
 compiler/gcbarriers/TestG1BarrierGeneration.java 8343420 generic-all
 
 # Valhalla + COH

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -132,6 +132,7 @@ containers/docker/TestJcmdWithSideCar.java 8341518 linux-x64
 
 # Valhalla
 runtime/AccModule/ConstModule.java 8294051 generic-all
+runtime/valhalla/inlinetypes/CircularityTest.java 8349037 generic-all
 compiler/gcbarriers/TestG1BarrierGeneration.java 8343420 generic-all
 
 # Valhalla + COH


### PR DESCRIPTION
Un-problem listing some more tests that don't fail anymore.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8349630](https://bugs.openjdk.org/browse/JDK-8349630): [lworld] runtime/valhalla/inlinetypes/ValuePreloadTest.java fails on linux-aarch64-debug after jdk-25+5 (**Bug** - P4)
 * [JDK-8349631](https://bugs.openjdk.org/browse/JDK-8349631): [lworld] runtime/valhalla/inlinetypes/PreloadCircularityTest.java fails on linux-aarch64-debug after jdk-25+5 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1461/head:pull/1461` \
`$ git checkout pull/1461`

Update a local copy of the PR: \
`$ git checkout pull/1461` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1461`

View PR using the GUI difftool: \
`$ git pr show -t 1461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1461.diff">https://git.openjdk.org/valhalla/pull/1461.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1461#issuecomment-2886713396)
</details>
