### PR TITLE
8357156: [lworld] ValueClass.newNullRestrictedAtomicArray and newNullableAtomicArray do not respect FlatArrayElementMaxOops

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -514,12 +514,12 @@ JVM_ENTRY(jarray, JVM_NewNullRestrictedAtomicArray(JNIEnv *env, jclass elmClass,
   validate_array_arguments(klass, len, CHECK_NULL);
   InlineKlass* vk = InlineKlass::cast(klass);
   oop array = nullptr;
-  if (UseArrayFlattening && vk->is_naturally_atomic()  && vk->has_non_atomic_layout()) {
+  if (vk->maybe_flat_in_array() && vk->is_naturally_atomic() && vk->has_non_atomic_layout()) {
     array = oopFactory::new_flatArray(vk, len, LayoutKind::NON_ATOMIC_FLAT, CHECK_NULL);
     for (int i = 0; i < len; i++) {
       ((flatArrayOop)array)->write_value_to_flat_array(init_h(), i, CHECK_NULL);
     }
-  } else if (UseArrayFlattening && vk->has_atomic_layout()) {
+  } else if (vk->maybe_flat_in_array() && vk->has_atomic_layout()) {
     array = oopFactory::new_flatArray(vk, len, LayoutKind::ATOMIC_FLAT, CHECK_NULL);
     for (int i = 0; i < len; i++) {
       ((flatArrayOop)array)->write_value_to_flat_array(init_h(), i, CHECK_NULL);
@@ -542,7 +542,7 @@ JVM_ENTRY(jarray, JVM_NewNullableAtomicArray(JNIEnv *env, jclass elmClass, jint 
   validate_array_arguments(klass, len, CHECK_NULL);
   InlineKlass* vk = InlineKlass::cast(klass);
   oop array = nullptr;
-  if (UseArrayFlattening && vk->has_nullable_atomic_layout()) {
+  if (vk->maybe_flat_in_array() && vk->has_nullable_atomic_layout()) {
     array = oopFactory::new_flatArray(vk, len, LayoutKind::NULLABLE_ATOMIC_FLAT, CHECK_NULL);
   } else {
     array = oopFactory::new_objArray(vk, len, CHECK_NULL);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+
+import jdk.test.lib.Asserts;
+
+/*
+ * @test TestFlatArrayElementMaxOops
+ * @summary Test that the FlatArrayElementMaxOops flag works as expected.
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @library /test/lib
+ * @enablePreview
+ * @run main/othervm -XX:+UseArrayFlattening -XX:FlatArrayElementMaxOops=0
+ *                   -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening -XX:+UseNonAtomicValueFlattening
+ *                   runtime.valhalla.inlinetypes.TestFlatArrayElementMaxOops 0
+ * @run main/othervm -XX:+UseArrayFlattening -XX:FlatArrayElementMaxOops=1
+ *                   -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening -XX:+UseNonAtomicValueFlattening
+ *                   runtime.valhalla.inlinetypes.TestFlatArrayElementMaxOops 1
+ * @run main/othervm -XX:+UseArrayFlattening -XX:FlatArrayElementMaxOops=2
+ *                   -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening -XX:+UseNonAtomicValueFlattening
+ *                   runtime.valhalla.inlinetypes.TestFlatArrayElementMaxOops 2
+ */
+
+public class TestFlatArrayElementMaxOops {
+
+    @LooselyConsistentValue
+    static value class ValueWithOneOoop {
+        Object obj1 = null;
+    }
+
+    @LooselyConsistentValue
+    static value class ValueWithTwoOoops {
+        Object obj1 = null;
+        Object obj2 = null;
+    }
+
+    public static void main(String[] args) {
+        int FlatArrayElementMaxOops = Integer.valueOf(args[0]);
+        Object[] array = ValueClass.newNullRestrictedNonAtomicArray(ValueWithOneOoop.class, 1, new ValueWithOneOoop());
+        Asserts.assertEquals(ValueClass.isFlatArray(array), FlatArrayElementMaxOops >= 1);
+        array = ValueClass.newNullRestrictedAtomicArray(ValueWithOneOoop.class, 1, new ValueWithOneOoop());
+        Asserts.assertEquals(ValueClass.isFlatArray(array), FlatArrayElementMaxOops >= 1);
+        array = ValueClass.newNullableAtomicArray(ValueWithOneOoop.class, 1);
+        Asserts.assertEquals(ValueClass.isFlatArray(array), FlatArrayElementMaxOops >= 1);
+
+        array = ValueClass.newNullRestrictedNonAtomicArray(ValueWithTwoOoops.class, 1, new ValueWithTwoOoops());
+        Asserts.assertEquals(ValueClass.isFlatArray(array), FlatArrayElementMaxOops >= 2);
+        array = ValueClass.newNullRestrictedAtomicArray(ValueWithTwoOoops.class, 1, new ValueWithTwoOoops());
+        Asserts.assertEquals(ValueClass.isFlatArray(array), FlatArrayElementMaxOops >= 2);
+        array = ValueClass.newNullableAtomicArray(ValueWithTwoOoops.class, 1);
+        Asserts.assertFalse(ValueClass.isFlatArray(array));
+    }
+}


### PR DESCRIPTION
`ValueClass.newNullRestrictedAtomicArray` and `ValueClass.newNullableAtomicArray ` should respect `-XX:FlatArrayElementMaxOops` when deciding if an array should be flat or not.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357156](https://bugs.openjdk.org/browse/JDK-8357156): [lworld] ValueClass.newNullRestrictedAtomicArray and newNullableAtomicArray do not respect FlatArrayElementMaxOops (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1463/head:pull/1463` \
`$ git checkout pull/1463`

Update a local copy of the PR: \
`$ git checkout pull/1463` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1463`

View PR using the GUI difftool: \
`$ git pr show -t 1463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1463.diff">https://git.openjdk.org/valhalla/pull/1463.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1463#issuecomment-2893644155)
</details>
