### PR TITLE
8357384: [lworld] AnnotationsTests.java fails if UseNullableValueFlattening is enabled by default

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AnnotationsTests.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AnnotationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,7 @@ import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.annotation.LooselyConsistentValue;
 import jdk.internal.vm.annotation.Strict;
-
-
-
-
+import jdk.test.whitebox.WhiteBox;
 
 /*
  * @test
@@ -43,20 +40,19 @@ import jdk.internal.vm.annotation.Strict;
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib
  * @enablePreview
- * @compile AnnotationsTests.java
- * @run main/othervm AnnotationsTests
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI AnnotationsTests
  */
 
-
  public class AnnotationsTests {
+    private static final WhiteBox WHITEBOX = WhiteBox.getWhiteBox();
+    private static final boolean UseNullableValueFlattening = WHITEBOX.getBooleanVMFlag("UseNullableValueFlattening");
 
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
-    static boolean nullableLayoutEnabled;
 
     public static void main(String[] args) {
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
-        List<String> arguments = runtimeMxBean.getInputArguments();
-        nullableLayoutEnabled = arguments.contains("-XX:+UseNullableValueFlattening");
         AnnotationsTests tests = new AnnotationsTests();
         Class c = tests.getClass();
         for (Method m : c.getDeclaredMethods()) {
@@ -159,7 +155,7 @@ import jdk.internal.vm.annotation.Strict;
     }
 
     static class GoodClass5 {
-      ValueClass5 f0 = new ValueClass5();
+        ValueClass5 f0 = new ValueClass5();
 
         @Strict
         @NullRestricted
@@ -171,7 +167,7 @@ import jdk.internal.vm.annotation.Strict;
         try {
             GoodClass5 vc = new GoodClass5();
             Field f0 = vc.getClass().getDeclaredField("f0");
-            if (nullableLayoutEnabled) {
+            if (UseNullableValueFlattening) {
                 Asserts.assertTrue(UNSAFE.isFlatField(f0), "Flat field expected, but field is not flat");
             } else {
                 Asserts.assertFalse(UNSAFE.isFlatField(f0), "Unexpected flat field");


### PR DESCRIPTION
Test only checks if `UseNullableValueFlattening` is set via the command line and fails if it's set by default.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357384](https://bugs.openjdk.org/browse/JDK-8357384): [lworld] AnnotationsTests.java fails if UseNullableValueFlattening is enabled by default (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1464/head:pull/1464` \
`$ git checkout pull/1464`

Update a local copy of the PR: \
`$ git checkout pull/1464` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1464`

View PR using the GUI difftool: \
`$ git pr show -t 1464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1464.diff">https://git.openjdk.org/valhalla/pull/1464.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1464#issuecomment-2895161913)
</details>
