### PR TITLE
8357410: [lworld] Disable UseAtomicValueFlattening in ObjectMethods until JDK-8357373 is fixed

### DIFF
--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -26,7 +26,7 @@
  * @test
  * @summary test Object methods on value classes
  * @enablePreview
- * @run junit/othervm -Dvalue.bsm.salt=1 ObjectMethods
+ * @run junit/othervm -Dvalue.bsm.salt=1 -XX:-UseAtomicValueFlattening ObjectMethods
  * @run junit/othervm -Dvalue.bsm.salt=1 -XX:-UseFieldFlattening ObjectMethods
  */
 import java.util.List;


### PR DESCRIPTION
Setting `-XX:-UseAtomicValueFlattening` until [JDK-8357373](https://bugs.openjdk.org/browse/JDK-8357373) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357410](https://bugs.openjdk.org/browse/JDK-8357410): [lworld] Disable UseAtomicValueFlattening in ObjectMethods until JDK-8357373 is fixed (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1466/head:pull/1466` \
`$ git checkout pull/1466`

Update a local copy of the PR: \
`$ git checkout pull/1466` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1466`

View PR using the GUI difftool: \
`$ git pr show -t 1466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1466.diff">https://git.openjdk.org/valhalla/pull/1466.diff</a>

</details>
