### PR TITLE
8357454: [lworld] trivial: removed modules still named in LoadableDescriptorsAttrTest2 & ValueBasedFlagsTest

### DIFF
--- a/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttrTest2.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttrTest2.java
@@ -32,7 +32,6 @@
  *      jdk.compiler/com.sun.tools.javac.api
  *      jdk.compiler/com.sun.tools.javac.file
  *      jdk.compiler/com.sun.tools.javac.main
- *      jdk.jdeps/com.sun.tools.classfile
  * @build toolbox.ToolBox toolbox.JavacTask
  * @run main LoadableDescriptorsAttrTest2
  */

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueBasedFlagsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueBasedFlagsTest.java
@@ -32,7 +32,6 @@
  *      jdk.compiler/com.sun.tools.javac.api
  *      jdk.compiler/com.sun.tools.javac.file
  *      jdk.compiler/com.sun.tools.javac.main
- *      jdk.jdeps/com.sun.tools.classfile
  * @build toolbox.ToolBox toolbox.JavacTask
  * @run main ValueBasedFlagsTest
  */


### PR DESCRIPTION
Removed old module directives

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357454](https://bugs.openjdk.org/browse/JDK-8357454): [lworld] trivial: removed modules still named in LoadableDescriptorsAttrTest2 &amp; ValueBasedFlagsTest (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1467/head:pull/1467` \
`$ git checkout pull/1467`

Update a local copy of the PR: \
`$ git checkout pull/1467` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1467`

View PR using the GUI difftool: \
`$ git pr show -t 1467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1467.diff">https://git.openjdk.org/valhalla/pull/1467.diff</a>

</details>
