### PR TITLE
[lworld] Some more problem listing for JDK-8348972

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/AccessZeroNKlassHitsProtectionZone.java
@@ -207,8 +207,9 @@ public class AccessZeroNKlassHitsProtectionZone {
             case runwb -> WhiteBox.getWhiteBox().decodeNKlassAndAccessKlass(0);
             case no_coh_no_cds -> run_test(false, false);
             case no_coh_cds -> run_test(false, true);
-            case coh_no_cds -> run_test(true, false);
-            case coh_cds -> run_test(true, true);
+            // TODO 8348568 Re-enable
+            // case coh_no_cds -> run_test(true, false);
+            // case coh_cds -> run_test(true, true);
         }
     }
 }


### PR DESCRIPTION
Test currently fails. Will be fixed and re-enabled with [JDK-8348568](https://bugs.openjdk.org/browse/JDK-8348568).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1468/head:pull/1468` \
`$ git checkout pull/1468`

Update a local copy of the PR: \
`$ git checkout pull/1468` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1468`

View PR using the GUI difftool: \
`$ git pr show -t 1468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1468.diff">https://git.openjdk.org/valhalla/pull/1468.diff</a>

</details>
