### PR TITLE
8357461: [lworld] TestFlatInArraysFolding.java fails with UseNullableValueFlattening enabled by default

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
@@ -118,9 +118,15 @@ public class TestFlatInArraysFolding {
                   IRNode.STORE_I, "1"}, // CmpP folded in unswitched loop version with flat in array?
         applyIf = {"LoopMaxUnroll", "0"})
     static void testCmpP() {
+        Object[] arr = oArr;
+        if (arr == null) {
+            // Needed for the 'arrayElement == arr' to fold in
+            // the flat array case because both could be null.
+            throw new NullPointerException("arr is null");
+        }
         for (int i = 0; i < 100; i++) {
             Object arrayElement = oArrArr[i];
-            if (arrayElement == oArr) {
+            if (arrayElement == arr) {
                 iFld = 34;
             }
         }


### PR DESCRIPTION
The test expects folding of `arrayElement == oArr` in the flat array array loop version which does not happen anymore when the flat array element can be null with `-XX:+UseNullableValueFlattening` (because `oArr` can be null as well). I adjusted the test so that C2 can deduce that `oArr` is never null and can therefore fold the check.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357461](https://bugs.openjdk.org/browse/JDK-8357461): [lworld] TestFlatInArraysFolding.java fails with UseNullableValueFlattening enabled by default (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1469/head:pull/1469` \
`$ git checkout pull/1469`

Update a local copy of the PR: \
`$ git checkout pull/1469` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1469`

View PR using the GUI difftool: \
`$ git pr show -t 1469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1469.diff">https://git.openjdk.org/valhalla/pull/1469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1469#issuecomment-2897823306)
</details>
