### PR TITLE
8357508: [lworld] build with CDS disabled is broken

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -55,11 +55,6 @@ bool CDSConfig::_disable_heap_dumping = false;
 bool CDSConfig::_module_patching_disables_cds = false;
 bool CDSConfig::_java_base_module_patching_disables_cds = false;
 
-bool CDSConfig::is_valhalla_preview() {
-  return Arguments::enable_preview() && EnableValhalla;
-}
-
-
 const char* CDSConfig::_default_archive_path = nullptr;
 const char* CDSConfig::_input_static_archive_path = nullptr;
 const char* CDSConfig::_input_dynamic_archive_path = nullptr;

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -26,6 +26,7 @@
 #define SHARE_CDS_CDSCONFIG_HPP
 
 #include "memory/allStatic.hpp"
+#include "runtime/arguments.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
@@ -96,10 +97,10 @@ public:
   static bool has_unsupported_runtime_module_options() NOT_CDS_RETURN_(false);
   static bool check_vm_args_consistency(bool mode_flag_cmd_line) NOT_CDS_RETURN_(true);
 
-  static bool module_patching_disables_cds() { return _module_patching_disables_cds; }
-  static void set_module_patching_disables_cds() { _module_patching_disables_cds = true; }
-  static bool java_base_module_patching_disables_cds() { return _java_base_module_patching_disables_cds; }
-  static void set_java_base_module_patching_disables_cds() { _java_base_module_patching_disables_cds = true; }
+  static bool module_patching_disables_cds() { return CDS_ONLY(_module_patching_disables_cds) NOT_CDS(false); }
+  static void set_module_patching_disables_cds() { CDS_ONLY(_module_patching_disables_cds = true;) }
+  static bool java_base_module_patching_disables_cds() { return CDS_ONLY(_java_base_module_patching_disables_cds) NOT_CDS(false); }
+  static void set_java_base_module_patching_disables_cds() { CDS_ONLY(_java_base_module_patching_disables_cds = true;) }
   static const char* type_of_archive_being_loaded();
   static const char* type_of_archive_being_written();
   static void prepare_for_dumping();
@@ -189,7 +190,9 @@ public:
   static void stop_dumping_full_module_graph(const char* reason = nullptr) NOT_CDS_JAVA_HEAP_RETURN;
   static void stop_using_full_module_graph(const char* reason = nullptr) NOT_CDS_JAVA_HEAP_RETURN;
 
-  static bool is_valhalla_preview();
+  static bool is_valhalla_preview() {
+    return Arguments::enable_preview() && EnableValhalla;
+  }
 
   // Some CDS functions assume that they are called only within a single-threaded context. I.e.,
   // they are called from:

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1131,7 +1131,9 @@ InstanceKlass* ClassLoader::load_class(Symbol* name, PackageEntry* pkg_entry, bo
   result->set_classpath_index(classpath_index);
   if (is_patched) {
     result->set_shared_classpath_index(0);
+#if INCLUDE_CDS
     result->set_shared_class_loader_type(ClassLoader::BOOT_LOADER);
+#endif
   }
   return result;
 }

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -683,7 +683,7 @@ InlineKlass* InlineKlass::returned_inline_klass(const RegisterMap& map) {
 }
 
 // CDS support
-
+#if INCLUDE_CDS
 void InlineKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   InstanceKlass::metaspace_pointers_do(it);
 
@@ -752,7 +752,7 @@ void InlineKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle 
     null_free_reference_array_klass()->restore_unshareable_info(ClassLoaderData::the_null_class_loader_data(), Handle(), CHECK);
   }
 }
-
+#endif // CDS
 // oop verify
 
 void InlineKlass::verify_on(outputStream* st) {

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -212,10 +212,12 @@ class InlineKlass: public InstanceKlass {
   int layout_alignment(LayoutKind kind) const;
   int layout_size_in_bytes(LayoutKind kind) const;
 
+#if INCLUDE_CDS
   virtual void remove_unshareable_info();
   virtual void remove_java_mirror();
   virtual void restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS);
   virtual void metaspace_pointers_do(MetaspaceClosure* it);
+#endif
 
  private:
   int collect_fields(GrowableArray<SigEntry>* sig, float& max_offset, int base_off = 0, int null_marker_offset = -1);


### PR DESCRIPTION
Fix build when CDS is disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357508](https://bugs.openjdk.org/browse/JDK-8357508): [lworld] build with CDS disabled is broken (**Bug** - P3)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1471/head:pull/1471` \
`$ git checkout pull/1471`

Update a local copy of the PR: \
`$ git checkout pull/1471` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1471`

View PR using the GUI difftool: \
`$ git pr show -t 1471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1471.diff">https://git.openjdk.org/valhalla/pull/1471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1471#issuecomment-2899273406)
</details>
