### PR TITLE
8357617: [lworld] trivial: remove remaining references to "jdk.jdeps/com.sun.tools.classfile"

### DIFF
--- a/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttributeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttributeTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8280164 8334313
  * @summary Check emission of LoadableDescriptors attribute
- * @modules jdk.jdeps/com.sun.tools.classfile
  * @enablePreview
  * @run main LoadableDescriptorsAttributeTest
  */

--- a/test/langtools/tools/javac/valhalla/value-objects/NoUnnecessaryLoadableDescriptorsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/NoUnnecessaryLoadableDescriptorsTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8281323
  * @summary Check emission of LoadableDescriptors attribute to make sure javac does not emit unneeded entries.
- * @modules jdk.jdeps/com.sun.tools.classfile
  * @enablePreview
  * @run main NoUnnecessaryLoadableDescriptorsTest
  */

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectsBinaryCompatibilityTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectsBinaryCompatibilityTests.java
@@ -29,7 +29,6 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  *          jdk.compiler/com.sun.tools.javac.code
- *          jdk.jdeps/com.sun.tools.classfile
  * @build toolbox.ToolBox toolbox.JavacTask
  * @enablePreview
  * @run main ValueObjectsBinaryCompatibilityTests


### PR DESCRIPTION
Removed old jtreg modules directives

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8357617](https://bugs.openjdk.org/browse/JDK-8357617): [lworld] trivial: remove remaining references to "jdk.jdeps/com.sun.tools.classfile" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1473/head:pull/1473` \
`$ git checkout pull/1473`

Update a local copy of the PR: \
`$ git checkout pull/1473` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1473`

View PR using the GUI difftool: \
`$ git pr show -t 1473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1473.diff">https://git.openjdk.org/valhalla/pull/1473.diff</a>

</details>
