### PR TITLE
[lworld] Problem listing test until JDK-8357785 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -132,6 +132,7 @@ containers/docker/TestJcmdWithSideCar.java 8341518 linux-x64
 # Valhalla
 runtime/AccModule/ConstModule.java 8294051 generic-all
 runtime/valhalla/inlinetypes/CircularityTest.java 8349037 generic-all
+compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java 8357785 generic-all
 
 # Valhalla + COH
 compiler/c2/autovectorization/TestIndexOverflowIR.java                          8348568 generic-all


### PR DESCRIPTION
Test fails since recent merge. Let's problem list it.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1476/head:pull/1476` \
`$ git checkout pull/1476`

Update a local copy of the PR: \
`$ git checkout pull/1476` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1476`

View PR using the GUI difftool: \
`$ git pr show -t 1476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1476.diff">https://git.openjdk.org/valhalla/pull/1476.diff</a>

</details>
