### PR TITLE
[lworld] Enable all flattening by default

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -823,10 +823,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, UseNonAtomicValueFlattening, true,                          \
           "Allow the JVM to flatten some non-atomic null-free values")      \
                                                                             \
-  product(bool, UseNullableValueFlattening, false,                          \
+  product(bool, UseNullableValueFlattening, true,                           \
           "Allow the JVM to flatten some nullable values")                  \
                                                                             \
-  product(bool, UseAtomicValueFlattening, false,                            \
+  product(bool, UseAtomicValueFlattening, true,                             \
           "Allow the JVM to flatten some atomic values")                    \
                                                                             \
   product(intx, FlatArrayElementMaxOops, 4,                                 \


### PR DESCRIPTION
Now that the implementation is sufficiently stable, let's enable all flattening by default. At this point, I think the flags are still useful but we might want to remove/merge them later.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1480/head:pull/1480` \
`$ git checkout pull/1480`

Update a local copy of the PR: \
`$ git checkout pull/1480` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1480`

View PR using the GUI difftool: \
`$ git pr show -t 1480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1480.diff">https://git.openjdk.org/valhalla/pull/1480.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1480#issuecomment-2940321701)
</details>
