### PR TITLE
8353180: [lworld] C2: Meeting two constant TypeAryPtr with different nullness is wrongly treated as exact

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4109,11 +4109,13 @@ const TypeOopPtr* TypeOopPtr::make_from_klass_common(ciKlass *klass, bool klass_
     return arr;
   } else if (klass->is_flat_array_klass()) {
     const TypeOopPtr* etype = TypeOopPtr::make_from_klass_raw(klass->as_array_klass()->element_klass(), trust_interfaces);
-    if (klass->as_array_klass()->is_elem_null_free()) {
-      etype = etype->join_speculative(TypePtr::NOTNULL)->is_oopptr();
+    const bool is_null_free = klass->as_array_klass()->is_elem_null_free();
+    if (is_null_free) {
+      etype = etype->join_speculative(NOTNULL)->is_oopptr();
     }
     const TypeAry* arr0 = TypeAry::make(etype, TypeInt::POS, /* stable= */ false, /* flat= */ true);
-    const TypeAryPtr* arr = TypeAryPtr::make(TypePtr::BotPTR, arr0, klass, true, Offset(0));
+    const bool exact = is_null_free; // Only exact if null-free because "null-free [LMyValue <: null-able [LMyValue".
+    const TypeAryPtr* arr = TypeAryPtr::make(TypePtr::BotPTR, arr0, klass, exact, Offset(0));
     return arr;
   } else {
     ShouldNotReachHere();
@@ -5642,6 +5644,7 @@ template<class T> TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*
   bool other_not_flat = other_ary->is_not_flat();
   bool this_not_null_free = this_ary->is_not_null_free();
   bool other_not_null_free = other_ary->is_not_null_free();
+  const bool same_nullness = this_ary->is_null_free() == other_ary->is_null_free();
   res_klass = nullptr;
   MeetResult result = SUBTYPE;
   res_flat = this_flat && other_flat;
@@ -5704,7 +5707,9 @@ template<class T> TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*
       }
       break;
     case Constant: {
-      if (this_ptr == Constant) {
+      if (this_ptr == Constant && same_nullness) {
+        // Only exact if same nullness since:
+        //     null-free [LMyValue <: nullable [LMyValue.
         res_xk = true;
       } else if (above_centerline(this_ptr)) {
         res_xk = true;
@@ -5732,8 +5737,6 @@ template<class T> TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*
                  (this_ary->is_same_java_type_as(other_ary) || (this_top_or_bottom && other_top_or_bottom)); // Only precise for identical arrays
         // Even though MyValue is final, [LMyValue is only exact if the array
         // is (not) null-free due to null-free [LMyValue <: null-able [LMyValue.
-        // TODO 8350865 If both types are exact and have the same null-free property, the result should be exact, right? Same above for the Constant case.
-        // && elem->make_ptr() != nullptr && elem->make_ptr()->is_inlinetypeptr() && (this_ary->is_null_free() != other_ary->is_null_free()
         if (res_xk && !res_null_free && !res_not_null_free) {
           res_xk = false;
         }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMeetingAryPtr.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMeetingAryPtr.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8353180
+ * @summary Test that meeting TypeAry*Ptr works with new layouts and does not trigger "not monotonic" assert.
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @run main/othervm -Xcomp -XX:CompileOnly=*TestMeetingAryPtr*::test* -XX:+UnlockDiagnosticVMOptions -XX:+StressCCP
+ *                   -XX:RepeatCompilation=100 compiler.valhalla.inlinetypes.TestMeetingAryPtr
+ * @run main         compiler.valhalla.inlinetypes.TestMeetingAryPtr
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+
+public class TestMeetingAryPtr {
+    static V vFld = new V(34);
+
+    static V[] vArrFlat = new V[100];
+    static final V[] vArrFinalNullable = (V[]) ValueClass.newNullableAtomicArray(V.class, 100);
+    static final V[] vArrFinalNullFree = (V[]) ValueClass.newNullRestrictedNonAtomicArray(V.class, 100, new V(0));
+    static final V[] vArrFinalNullFree2 = (V[]) ValueClass.newNullRestrictedNonAtomicArray(V.class, 100, new V(0));
+
+    static boolean flag;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            testNonConstant();
+            testConstantDifferentNullNess();
+            testConstantSameNullNess();
+            flag = !flag;
+        }
+    }
+
+    static void testNonConstant() {
+        for (int i = 0; i < 100; ++i) {
+            vFld = vArrFlat[i];
+        }
+    }
+
+    static void testConstantDifferentNullNess() {
+        // Meeting:      ConP(flat+nullable)   ConP(flat+null-free)
+        V[] arr = flag ? vArrFinalNullable   : vArrFinalNullFree;
+        // Phi for arr after meet: flat+maybe-null-free+exact
+        // -> Wrongly set to exact even though it's maybe null free only.
+        //    This causes an assertion failure during CCP.
+        vFld = arr[2];
+    }
+
+    static void testConstantSameNullNess() {
+        V[] arr = flag ? vArrFinalNullable : vArrFinalNullFree2;
+        vFld = arr[2];
+    }
+}
+
+value class V  {
+    int x;
+
+    V(int x) {
+        this.x = x;
+    }
+}

--- a/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/FlatVarHandleTest.java
@@ -45,11 +45,8 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-// TODO: 8353180: Remove requires != Xcomp
-
 /*
  * @test
- * @requires vm.compMode != "Xcomp"
  * @summary Test atomic access modes on var handles for flattened values
  * @enablePreview
  * @modules java.base/jdk.internal.value java.base/jdk.internal.vm.annotation

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -21,12 +21,9 @@
  * questions.
  */
 
-// TODO: 8353180: Remove requires != Xcomp
-
 /*
  * @test
  * @enablePreview
- * @requires vm.compMode != "Xcomp"
  * @run junit/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening NullRestrictedArraysTest
  * @run junit/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening NullRestrictedArraysTest
  */


### PR DESCRIPTION
We are wrongly setting the result of the meet of two constant `TypeAryPtr` with different nullness as exact:
https://github.com/openjdk/valhalla/blob/aacff31a86a3fc8cbc44a7e993d83c4bf9677055/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMeetingAryPtr.java#L66-L71

This causes an assertion failure during CCP to not be monotonic. This is now fixed.

There have been other occurrences where we wrongly set exactness even though nullness were different. Most of them have now been fixed with https://github.com/openjdk/valhalla/pull/1470 which corrected some of the wrong handling explicitely. 

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353180](https://bugs.openjdk.org/browse/JDK-8353180): [lworld] C2: Meeting two constant TypeAryPtr with different nullness is wrongly treated as exact (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1481/head:pull/1481` \
`$ git checkout pull/1481`

Update a local copy of the PR: \
`$ git checkout pull/1481` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1481`

View PR using the GUI difftool: \
`$ git pr show -t 1481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1481.diff">https://git.openjdk.org/valhalla/pull/1481.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1481#issuecomment-2945020143)
</details>
