### PR TITLE
8349110: [lworld] Intrinsics for Unsafe.get/putFlatValue

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -340,6 +340,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_getFloat:
   case vmIntrinsics::_getDouble:
   case vmIntrinsics::_getValue:
+  case vmIntrinsics::_getFlatValue:
   case vmIntrinsics::_putReference:
   case vmIntrinsics::_putBoolean:
   case vmIntrinsics::_putByte:
@@ -350,6 +351,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_putFloat:
   case vmIntrinsics::_putDouble:
   case vmIntrinsics::_putValue:
+  case vmIntrinsics::_putFlatValue:
   case vmIntrinsics::_getReferenceVolatile:
   case vmIntrinsics::_getBooleanVolatile:
   case vmIntrinsics::_getByteVolatile:

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -739,6 +739,8 @@ class methodHandle;
   do_signature(putDouble_signature,       "(Ljava/lang/Object;JD)V")                                                    \
   do_signature(getValue_signature,        "(Ljava/lang/Object;JLjava/lang/Class;)Ljava/lang/Object;")                   \
   do_signature(putValue_signature,        "(Ljava/lang/Object;JLjava/lang/Class;Ljava/lang/Object;)V")                  \
+  do_signature(getFlatValue_signature,    "(Ljava/lang/Object;JILjava/lang/Class;)Ljava/lang/Object;")                  \
+  do_signature(putFlatValue_signature,    "(Ljava/lang/Object;JILjava/lang/Class;Ljava/lang/Object;)V")                 \
                                                                                                                         \
   do_name(getReference_name,"getReference")     do_name(putReference_name,"putReference")                               \
   do_name(getBoolean_name,"getBoolean")         do_name(putBoolean_name,"putBoolean")                                   \
@@ -750,6 +752,7 @@ class methodHandle;
   do_name(getFloat_name,"getFloat")             do_name(putFloat_name,"putFloat")                                       \
   do_name(getDouble_name,"getDouble")           do_name(putDouble_name,"putDouble")                                     \
   do_name(getValue_name,"getValue")             do_name(putValue_name,"putValue")                                       \
+  do_name(getFlatValue_name,"getFlatValue")     do_name(putFlatValue_name,"putFlatValue")                               \
   do_name(makePrivateBuffer_name,"makePrivateBuffer")                                                                   \
   do_name(finishPrivateBuffer_name,"finishPrivateBuffer")                                                               \
                                                                                                                         \
@@ -763,6 +766,7 @@ class methodHandle;
   do_intrinsic(_getFloat,           jdk_internal_misc_Unsafe,     getFloat_name, getFloat_signature,             F_RN)  \
   do_intrinsic(_getDouble,          jdk_internal_misc_Unsafe,     getDouble_name, getDouble_signature,           F_RN)  \
   do_intrinsic(_getValue,           jdk_internal_misc_Unsafe,     getValue_name, getValue_signature,             F_RN)  \
+  do_intrinsic(_getFlatValue,       jdk_internal_misc_Unsafe,     getFlatValue_name, getFlatValue_signature,     F_RN)  \
   do_intrinsic(_putReference,       jdk_internal_misc_Unsafe,     putReference_name, putReference_signature,     F_RN)  \
   do_intrinsic(_putBoolean,         jdk_internal_misc_Unsafe,     putBoolean_name, putBoolean_signature,         F_RN)  \
   do_intrinsic(_putByte,            jdk_internal_misc_Unsafe,     putByte_name, putByte_signature,               F_RN)  \
@@ -773,6 +777,7 @@ class methodHandle;
   do_intrinsic(_putFloat,           jdk_internal_misc_Unsafe,     putFloat_name, putFloat_signature,             F_RN)  \
   do_intrinsic(_putDouble,          jdk_internal_misc_Unsafe,     putDouble_name, putDouble_signature,           F_RN)  \
   do_intrinsic(_putValue,           jdk_internal_misc_Unsafe,     putValue_name, putValue_signature,             F_RN)  \
+  do_intrinsic(_putFlatValue,       jdk_internal_misc_Unsafe,     putFlatValue_name, putFlatValue_signature,     F_RN)  \
                                                                                                                         \
   do_intrinsic(_makePrivateBuffer,  jdk_internal_misc_Unsafe,     makePrivateBuffer_name, object_object_signature, F_RN)   \
   do_intrinsic(_finishPrivateBuffer,  jdk_internal_misc_Unsafe,   finishPrivateBuffer_name, object_object_signature, F_RN) \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "classfile/vmClasses.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "runtime/handles.inline.hpp"
@@ -663,6 +664,7 @@ bool C2Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_getFloat:
   case vmIntrinsics::_getDouble:
   case vmIntrinsics::_getValue:
+  case vmIntrinsics::_getFlatValue:
   case vmIntrinsics::_putReference:
   case vmIntrinsics::_putBoolean:
   case vmIntrinsics::_putByte:
@@ -673,6 +675,7 @@ bool C2Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_putFloat:
   case vmIntrinsics::_putDouble:
   case vmIntrinsics::_putValue:
+  case vmIntrinsics::_putFlatValue:
   case vmIntrinsics::_getReferenceVolatile:
   case vmIntrinsics::_getBooleanVolatile:
   case vmIntrinsics::_getByteVolatile:

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -249,6 +249,7 @@ class LibraryCallKit : public GraphKit {
   typedef enum { Relaxed, Opaque, Volatile, Acquire, Release } AccessKind;
   DecoratorSet mo_decorator_for_access_kind(AccessKind kind);
   bool inline_unsafe_access(bool is_store, BasicType type, AccessKind kind, bool is_unaligned, bool is_flat = false);
+  bool inline_unsafe_flat_access(bool is_store, AccessKind kind);
   static bool klass_needs_init_guard(Node* kls);
   bool inline_unsafe_allocate();
   bool inline_unsafe_newArray(bool uninitialized);

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -334,6 +334,7 @@ public final class Unsafe {
      * @throws RuntimeException No defined exceptions are thrown, not even
      *         {@link NullPointerException}
      */
+    @IntrinsicCandidate
     public native <V> V getFlatValue(Object o, long offset, int layoutKind, Class<?> valueType);
 
 
@@ -377,6 +378,7 @@ public final class Unsafe {
      * @throws RuntimeException No defined exceptions are thrown, not even
      *         {@link NullPointerException}
      */
+    @IntrinsicCandidate
     public native <V> void putFlatValue(Object o, long offset, int layoutKind, Class<?> valueType, V v);
 
     /**

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1664,6 +1664,7 @@ public class TestIntrinsics {
         }
     }
 
+    /* TODO: 8322547: Unsafe::putInt checks the larval bit which leads to a VM crash
     @Test
     @IR(failOn = {CALL_UNSAFE})
     public MyValue1 test84(MyValue1 v) {
@@ -1682,6 +1683,7 @@ public class TestIntrinsics {
         MyValue1 v2 = test84(MyValue1.setX(v1, 0));
         Asserts.assertEQ(v1.hash(), v2.hash());
     }
+    */
 
     static value class MyValueClonable implements Cloneable {
         int x;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -66,9 +66,6 @@ public class TestIntrinsics {
                    .addScenarios(scenarios)
                    .addFlags("--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
                              "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                             // Disable FlatValue intrinsics check until JDK-8349110 is fixed
-                             "-DExclude=test30,test31,test32,test33,test34,test35,test36,test37," +
-                             "test38,test55,test71,test72,test73,test80",
                              // Don't run with DeoptimizeALot until JDK-8239003 is fixed
                              "-XX:-DeoptimizeALot")
                    .addHelperClasses(MyValue1.class,
@@ -746,7 +743,7 @@ public class TestIntrinsics {
     // putValue to set flattened field in object, non inline argument
     // to store
     @Test
-    @IR(counts = {CALL_UNSAFE, "= 1"})
+    @IR(failOn = {CALL_UNSAFE})
     public void test38(Object o) {
         if (TEST31_VT_FLATTENED) {
             U.putFlatValue(this, TEST31_VT_OFFSET, TEST31_VT_LAYOUT, MyValue1.class, o);
@@ -1621,9 +1618,9 @@ public class TestIntrinsics {
         NonValueClass obj = new NonValueClass(rI);
     }
 
-    // Test that unsafe access is not incorrectly classified as mismatched
+    // layout is not a constant
     @Test
-    @IR(failOn = {CALL_UNSAFE})
+    @IR(counts = {CALL_UNSAFE, "1"})
     public Test80Value2 test80(Test80Value1 v, boolean flat, int layout, long offset) {
         if (flat) {
             return U.getFlatValue(v, offset, layout, Test80Value2.class);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -65,9 +65,7 @@ public class TestIntrinsics {
         InlineTypes.getFramework()
                    .addScenarios(scenarios)
                    .addFlags("--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                             "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                             // Don't run with DeoptimizeALot until JDK-8239003 is fixed
-                             "-XX:-DeoptimizeALot")
+                             "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED")
                    .addHelperClasses(MyValue1.class,
                                      MyValue2.class,
                                      MyValue2Inline.class)

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1060,31 +1060,6 @@ public class TestIntrinsics {
         test53(MyValue1[].class, MyValue1[].class, len, 4);
     }
 
-    // TODO 8239003 Re-enable
-    /*
-    // Same as test39 but Unsafe.putInt to buffer is not intrinsified/compiled
-    @DontCompile
-    public void test54_callee(Object v) { // Use Object here to make sure the argument is not scalarized (otherwise larval information is lost)
-        U.putInt(v, X_OFFSET, rI);
-    }
-
-    @Test
-    public MyValue1 test54(MyValue1 v) {
-        v = U.makePrivateBuffer(v);
-        test54_callee(v);
-        v = U.finishPrivateBuffer(v);
-        return v;
-    }
-
-    @Run(test = "test54")
-    @Warmup(10000) // Fill up the TLAB to trigger slow path allocation
-    public void test54_verifier() {
-        MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
-        MyValue1 res = test54(v.setX(v, 0));
-        Asserts.assertEQ(res.hash(), v.hash());
-    }
-    */
-
     @Strict
     @NullRestricted
     static final MyValue1 test55_vt = MyValue1.createWithFieldsInline(rI, rL);
@@ -1585,8 +1560,6 @@ public class TestIntrinsics {
         }
     }
 
-    // TODO 8284443 Fix this in GraphKit::gen_checkcast
-    /*
     @Test
     public Object test79(MyValue1 vt) {
         Object tmp = vt;
@@ -1603,7 +1576,6 @@ public class TestIntrinsics {
         } catch (ClassCastException cce) {
         }
     }
-    */
 
     @LooselyConsistentValue
     public static value class Test80Value1 {
@@ -1694,10 +1666,8 @@ public class TestIntrinsics {
         }
     }
 
-    /*
-    TODO: 8335256: Properly handle merging of value object oops
     @Test
-    @IR(failOn = {CALL_UNSAFE, ALLOC})
+    @IR(failOn = {CALL_UNSAFE})
     public MyValue1 test84(MyValue1 v) {
         v = U.makePrivateBuffer(v);
         for (int i = 0; i < 10; i++) {
@@ -1714,7 +1684,6 @@ public class TestIntrinsics {
         MyValue1 v2 = test84(MyValue1.setX(v1, 0));
         Asserts.assertEQ(v1.hash(), v2.hash());
     }
-    */
 
     static value class MyValueClonable implements Cloneable {
         int x;


### PR DESCRIPTION
Hi,

This PR implements intrinsics for `Unsafe::get/putFlatValue` and enables the corresponding tests in `TestIntrinsics`.

Please kindly review, thanks very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8349110](https://bugs.openjdk.org/browse/JDK-8349110): [lworld] Intrinsics for Unsafe.get/putFlatValue (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1482/head:pull/1482` \
`$ git checkout pull/1482`

Update a local copy of the PR: \
`$ git checkout pull/1482` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1482`

View PR using the GUI difftool: \
`$ git pr show -t 1482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1482.diff">https://git.openjdk.org/valhalla/pull/1482.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1482#issuecomment-2949010512)
</details>
