### PR TITLE
8358093: [lworld] Crash when passing invalid constant pool index to early_larval frame

### DIFF
--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -254,6 +254,14 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
 
     for (u2 i = 0; i < num_unset_fields; i++) {
       u2 index = _stream->get_u2(CHECK_NULL);
+
+      if (!_cp->is_within_bounds(index) || !_cp->tag_at(index).is_name_and_type()) {
+        _prev_frame->verifier()->verify_error(
+          ErrorContext::bad_strict_fields(_prev_frame->offset(), _prev_frame),
+          "Invalid constant pool index in early larval frame: %d", index);
+        return nullptr;
+      }
+
       Symbol* name = _cp->symbol_at(_cp->name_ref_index_at(index));
       Symbol* sig = _cp->symbol_at(_cp->signature_ref_index_at(index));
       NameAndSig tmp(name, sig);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/InvalidIndexInEarlyLarval.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/InvalidIndexInEarlyLarval.jcod
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+class InvalidIndexInEarlyLarval extends Parent {
+    @Strict
+    int x;
+    @Strict
+    int y;
+
+    InvalidIndexInEarlyLarval(boolean a, boolean b) {
+        if (a) {
+            x = 1;
+            if (b) {
+                y = 1;
+            } else {
+                y = 2;
+            }
+        } else {
+            x = y = 3;
+        }
+        super();
+    }
+}
+*/
+
+class InvalidIndexInEarlyLarval {
+  0xCAFEBABE;
+  65535;                                   // minor version
+  69;                                      // version
+  [] {                                     // Constant Pool
+    ;                                      // first element is empty
+    Field #2 #3;                           // #1
+    Class #4;                              // #2
+    NameAndType #5 #6;                     // #3
+    Utf8 "InvalidIndexInEarlyLarval";      // #4
+    Utf8 "x";                              // #5
+    Utf8 "I";                              // #6
+    Field #2 #8;                           // #7
+    NameAndType #9 #6;                     // #8
+    Utf8 "y";                              // #9
+    Method #11 #12;                        // #10
+    Class #13;                             // #11
+    NameAndType #14 #15;                   // #12
+    Utf8 "Parent";                         // #13
+    Utf8 "<init>";                         // #14
+    Utf8 "()V";                            // #15
+    Method #2 #17;                         // #16
+    NameAndType #18 #19;                   // #17
+    Utf8 "get_x";                          // #18
+    Utf8 "()I";                            // #19
+    Method #2 #21;                         // #20
+    NameAndType #22 #19;                   // #21
+    Utf8 "get_y";                          // #22
+    Method #11 #24;                        // #23
+    NameAndType #25 #26;                   // #24
+    Utf8 "toString";                       // #25
+    Utf8 "()Ljava/lang/String;";           // #26
+    InvokeDynamic 0s #28;                  // #27
+    NameAndType #29 #30;                   // #28
+    Utf8 "makeConcatWithConstants";        // #29
+    Utf8 "(IILjava/lang/String;)Ljava/lang/String;";  // #30
+    Utf8 "RuntimeInvisibleAnnotations";    // #31
+    Utf8 "Ljdk/internal/vm/annotation/Strict;";  // #32
+    Utf8 "(ZZ)V";                          // #33
+    Utf8 "Code";                           // #34
+    Utf8 "LineNumberTable";                // #35
+    Utf8 "StackMapTable";                  // #36
+    Utf8 "SourceFile";                     // #37
+    Utf8 "StrictInstanceFieldsTest.java";  // #38
+    Utf8 "BootstrapMethods";               // #39
+    String #41;                            // #40
+    Utf8 "x: \u0001\ny: \u0001\n\u0001";   // #41
+    MethodHandle 6b #43;                   // #42
+    Method #44 #45;                        // #43
+    Class #46;                             // #44
+    NameAndType #29 #47;                   // #45
+    Utf8 "java/lang/invoke/StringConcatFactory";  // #46
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;";  // #47
+    Utf8 "InnerClasses";                   // #48
+    Class #50;                             // #49
+    Utf8 "java/lang/invoke/MethodHandles$Lookup";  // #50
+    Class #52;                             // #51
+    Utf8 "java/lang/invoke/MethodHandles";  // #52
+    Utf8 "Lookup";                         // #53
+  }
+
+  0x0020;                                  // access
+  #2;                                      // this_cpx
+  #11;                                     // super_cpx
+
+  [] {                                     // Interfaces
+  }                                        // end of Interfaces
+
+  [] {                                     // Fields
+    {                                      // field
+      0x0800;                              // access
+      #5;                                  // name_index
+      #6;                                  // descriptor_index
+      [] {                                 // Attributes
+        Attr(#31) {                        // RuntimeInvisibleAnnotations
+          [] {                             // annotations
+            {                              // annotation
+              #32;
+              [] {                         // element_value_pairs
+              }                            // element_value_pairs
+            }                              // annotation
+          }
+        }                                  // end of RuntimeInvisibleAnnotations
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // field
+      0x0800;                              // access
+      #9;                                  // name_index
+      #6;                                  // descriptor_index
+      [] {                                 // Attributes
+        Attr(#31) {                        // RuntimeInvisibleAnnotations
+          [] {                             // annotations
+            {                              // annotation
+              #32;
+              [] {                         // element_value_pairs
+              }                            // element_value_pairs
+            }                              // annotation
+          }
+        }                                  // end of RuntimeInvisibleAnnotations
+      }                                    // end of Attributes
+    }
+  }                                        // end of Fields
+
+  [] {                                     // Methods
+    {                                      // method
+      0x0000;                              // access
+      #14;                                 // name_index
+      #33;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#34) {                        // Code
+          4;                               // max_stack
+          3;                               // max_locals
+          Bytes[]{
+            0x1B 0x99 0x00 0x1C 0x2A 0x04 0xB5 0x00 0x01 0x1C 0x99 0x00;
+            0x0B 0x2A 0x04 0xB5 0x00 0x07 0xA7 0x00 0x15 0x2A 0x05 0xB5;
+            0x00 0x07 0xA7 0x00 0x0D 0x2A 0x2A 0x06 0x5A 0xB5 0x00 0x07;
+            0xB5 0x00 0x01 0x2A 0xB7 0x00 0x0A 0xB1;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#35) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0  121;
+                   4  122;
+                   9  123;
+                  13  124;
+                  21  126;
+                  29  129;
+                  39  131;
+                  43  132;
+              }
+            }                              // end of LineNumberTable
+            ;
+            Attr(#36) {                    // StackMapTable
+              [] {                         //
+                246b, []{#8; #5}, {       // FAIL: early_larval_frame contains NameAndType not present in original list of strict fields
+                  21b;                     // same
+                };
+                246b, []{#3; #8}, {        // early_larval_frame
+                  7b;                      // same_frame
+                };
+                246b, []{}, {              // early_larval_frame
+                  9b;                      // same_frame
+                };
+              }
+            }                              // end of StackMapTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0000;                              // access
+      #18;                                 // name_index
+      #19;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#34) {                        // Code
+          1;                               // max_stack
+          1;                               // max_locals
+          Bytes[]{
+            0x2A 0xB4 0x00 0x01 0xAC;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#35) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0  134;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0000;                              // access
+      #22;                                 // name_index
+      #19;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#34) {                        // Code
+          1;                               // max_stack
+          1;                               // max_locals
+          Bytes[]{
+            0x2A 0xB4 0x00 0x07 0xAC;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#35) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0  135;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0001;                              // access
+      #25;                                 // name_index
+      #26;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#34) {                        // Code
+          3;                               // max_stack
+          1;                               // max_locals
+          Bytes[]{
+            0x2A 0xB6 0x00 0x10 0x2A 0xB6 0x00 0x14 0x2A 0xB7 0x00 0x17;
+            0xBA 0x00 0x1B 0x00 0x00 0xB0;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#35) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0  139;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+  }                                        // end of Methods
+
+  [] {                                     // Attributes
+    Attr(#37) {                            // SourceFile
+      #38;
+    }                                      // end of SourceFile
+    ;
+    Attr(#39) {                            // BootstrapMethods
+      [] {                                 // bootstrap_methods
+        {                                  // bootstrap_method
+          #42;                             // bootstrap_method_ref
+          [] {                             // bootstrap_arguments
+            #40;
+          }                                // bootstrap_arguments
+        }                                  // bootstrap_method
+      }
+    }                                      // end of BootstrapMethods
+    ;
+    Attr(#48) {                            // InnerClasses
+      [] {                                 // classes
+          #49   #51   #53  57;
+      }
+    }                                      // end of InnerClasses
+  }                                        // end of Attributes
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/InvalidIndexInEarlyLarval.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/InvalidIndexInEarlyLarval.jcod
@@ -181,7 +181,7 @@ class InvalidIndexInEarlyLarval {
             ;
             Attr(#36) {                    // StackMapTable
               [] {                         //
-                246b, []{#8; #5}, {       // FAIL: early_larval_frame contains NameAndType not present in original list of strict fields
+                246b, []{#8; #5}, {       // FAIL: early_larval_frame contains cp index that isn't NameAndType
                   21b;                     // same
                 };
                 246b, []{#3; #8}, {        // early_larval_frame

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java
@@ -31,6 +31,7 @@
  *          NestedEarlyLarval.jcod
  *          EndsInEarlyLarval.jcod
  *          StrictFieldsNotSubset.jcod
+ *          InvalidIndexInEarlyLarval.jcod
  * @compile --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED -XDgenerateEarlyLarvalFrame -XDnoLocalProxyVars StrictInstanceFieldsTest.java
  * @run main/othervm -Xlog:verification StrictInstanceFieldsTest
  */
@@ -156,6 +157,18 @@ public class StrictInstanceFieldsTest {
             throw new RuntimeException("Should fail verification");
         } catch (java.lang.VerifyError e) {
             if (!e.getMessage().contains("Strict fields not a subset of initial strict instance fields")) {
+                throw new RuntimeException("wrong exception: " + e.getMessage());
+            }
+            e.printStackTrace();
+        }
+
+        // Early_larval frame includes a constant pool index that doesn't point to a NameAndType
+        try {
+            InvalidIndexInEarlyLarval child = new InvalidIndexInEarlyLarval(true, false);
+            System.out.println(child);
+            throw new RuntimeException("Should fail verification");
+        } catch (java.lang.VerifyError e) {
+            if (!e.getMessage().contains("Invalid constant pool index in early larval frame")) {
                 throw new RuntimeException("wrong exception: " + e.getMessage());
             }
             e.printStackTrace();


### PR DESCRIPTION
An early_larval frame contains a set of constant pool indices that are meant to refer to NameAndTypes. These NameAndType entries should refer to strict fields which must be marked as unset and there exists a verify error and associated test to check this, but there are no checks to ensure the input values actually refer to a NameAndType or valid constant pool index.

 This patch introduces a new error case and adds a test case to `StrictInstanceFieldsTest`. Note that `StrictInstanceFieldsTest.java` is problem listed so the test will not be used until JTREG 7.6 is integrated. Verified with tier 1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8358093](https://bugs.openjdk.org/browse/JDK-8358093): [lworld] Crash when passing invalid constant pool index to early_larval frame (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1484/head:pull/1484` \
`$ git checkout pull/1484`

Update a local copy of the PR: \
`$ git checkout pull/1484` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1484`

View PR using the GUI difftool: \
`$ git pr show -t 1484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1484.diff">https://git.openjdk.org/valhalla/pull/1484.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1484#issuecomment-2963662867)
</details>
