### PR TITLE
8344532: [lworld] TestLWord.test88 IR mismatch after jdk-24+20

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -2448,12 +2448,10 @@ public class TestLWorld {
     }
 
     @Test
-    /* FIX: JDK-8344532
     @IR(applyIf = {"UseArrayFlattening", "true"},
         counts = {COUNTEDLOOP_MAIN, "= 2"})
     @IR(applyIf = {"UseArrayFlattening", "false"},
         counts = {COUNTEDLOOP_MAIN, "= 0"})
-    */
     public void test88(Object[] src1, Object[] dst1, Object[] src2, Object[] dst2) {
         for (int i = 0; i < src1.length; i++) {
             dst1[i] = src1[i];


### PR DESCRIPTION
The disabled IR rules no longer seem to fail with latest lworld. Let's re-enable them.

Ran test through tier1-4 + stress.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8344532](https://bugs.openjdk.org/browse/JDK-8344532): [lworld] TestLWord.test88 IR mismatch after jdk-24+20 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1485/head:pull/1485` \
`$ git checkout pull/1485`

Update a local copy of the PR: \
`$ git checkout pull/1485` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1485`

View PR using the GUI difftool: \
`$ git pr show -t 1485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1485.diff">https://git.openjdk.org/valhalla/pull/1485.diff</a>

</details>
