### PR TITLE
8332814: [lworld] Loop strip mining verification fails with "nothing between inner and outer loop"

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -347,8 +347,7 @@ public class TestGenerated {
             t.test13(array5);
             t.test14(false, new MyValue4());
             t.test15();
-            // TODO 8332814 This triggers the "nothing between inner and outer loop" assert
-            // t.test16();
+            t.test16();
             t.test17();
             t.test18();
             t.test19();


### PR DESCRIPTION
The test is no longer failing through tier1-4 + stress. I'm therefore re-enabling it.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8332814](https://bugs.openjdk.org/browse/JDK-8332814): [lworld] Loop strip mining verification fails with "nothing between inner and outer loop" (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1486/head:pull/1486` \
`$ git checkout pull/1486`

Update a local copy of the PR: \
`$ git checkout pull/1486` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1486`

View PR using the GUI difftool: \
`$ git pr show -t 1486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1486.diff">https://git.openjdk.org/valhalla/pull/1486.diff</a>

</details>
