### PR TITLE
8331551: [lworld] compiler/gcbarriers/TestZGCUnrolling.java fails after merging jdk-23+6

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
@@ -59,8 +59,7 @@ public class TestZGCUnrolling {
     }
 
     @Test
-    // TODO JDK-8331551
-    // @IR(counts = {IRNode.STORE_P, "1"})
+    @IR(counts = {IRNode.STORE_P, "1"})
     public static void testNoUnrolling(Outer o, Object o1) {
         for (int i = 0; i < 64; i++) {
             fVarHandle.setVolatile(o, o1);


### PR DESCRIPTION
Re-activating the IR check removed in [JDK-8331538](https://bugs.openjdk.org/browse/JDK-8331538) as `compiler/gcbarriers/TestZGCUnrolling.java` is not failing anymore.

Testing: Tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331551](https://bugs.openjdk.org/browse/JDK-8331551): [lworld] compiler/gcbarriers/TestZGCUnrolling.java fails after merging jdk-23+6 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1488/head:pull/1488` \
`$ git checkout pull/1488`

Update a local copy of the PR: \
`$ git checkout pull/1488` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1488`

View PR using the GUI difftool: \
`$ git pr show -t 1488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1488.diff">https://git.openjdk.org/valhalla/pull/1488.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1488#issuecomment-2970435620)
</details>
