### PR TITLE
8336003: [lworld] TestLWorld::test151 triggers "Should have been buffered" assert

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1580,19 +1580,18 @@ Node* PhiNode::unique_input(PhaseValues* phase, bool uncast) {
 }
 
 // Find the unique input, try to look recursively through input Phis
-Node* PhiNode::unique_input_recursive(PhaseGVN* phase) const {
+Node* PhiNode::unique_input_recursive(PhaseGVN* phase) {
   if (!phase->is_IterGVN()) {
     return nullptr;
   }
 
   ResourceMark rm;
   Node* unique = nullptr;
-  GrowableArray<const PhiNode*> visited;
+  Unique_Node_List visited;
   visited.push(this);
 
-  for (int visited_idx = 0; visited_idx < visited.length(); visited_idx++) {
-    const PhiNode* current = visited.at(visited_idx);
-    RegionNode* current_region = current->region();
+  for (uint visited_idx = 0; visited_idx < visited.size(); visited_idx++) {
+    Node* current = visited.at(visited_idx);
     for (uint i = 1; i < current->req(); i++) {
       Node* phi_in = current->in(i);
       if (phi_in == nullptr) {
@@ -1600,7 +1599,7 @@ Node* PhiNode::unique_input_recursive(PhaseGVN* phase) const {
       }
 
       if (phi_in->is_Phi()) {
-        visited.append_if_missing(phi_in->as_Phi());
+        visited.push(phi_in);
       } else {
         if (unique == nullptr) {
           unique = phi_in;

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1594,12 +1594,11 @@ Node* PhiNode::unique_input_recursive(PhaseGVN* phase) const {
     const PhiNode* current = visited.at(visited_idx);
     RegionNode* current_region = current->region();
     for (uint i = 1; i < current->req(); i++) {
-      Node* region_in = current_region->in(i);
-      if (region_in == nullptr || phase->type(region_in) != Type::CONTROL) {
+      Node* phi_in = current->in(i);
+      if (phi_in == nullptr) {
         continue;
       }
 
-      Node* phi_in = current->in(i);
       if (phi_in->is_Phi()) {
         visited.append_if_missing(phi_in->as_Phi());
       } else {

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -232,6 +232,7 @@ public:
     }
     return uin;
   }
+  Node* unique_input_recursive(PhaseGVN* phase) const;
 
   // Check for a simple dead loop.
   enum LoopSafety { Safe = 0, Unsafe, UnsafeLoop };

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -232,7 +232,7 @@ public:
     }
     return uin;
   }
-  Node* unique_input_recursive(PhaseGVN* phase) const;
+  Node* unique_input_recursive(PhaseGVN* phase);
 
   // Check for a simple dead loop.
   enum LoopSafety { Safe = 0, Unsafe, UnsafeLoop };

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4158,13 +4158,14 @@ public class TestLWorld {
         Asserts.assertEquals(test150(), testValue2.hash());
     }
 
-// TODO 8336003 This triggers #  assert(false) failed: Should have been buffered
-/*
-    // Same as test150 but with val not being allocated in the scope of the method
+    // Same as test150 but with a real loop and val not being allocated in the scope of the method
     @Test
+    // Dynamic call does not null check the receiver, so it cannot be strength reduced to a static
+    // call without an explicit null check
     @IR(failOn = {compiler.lib.ir_framework.IRNode.DYNAMIC_CALL_OF_METHOD, "MyValue2::hash"},
         counts = {compiler.lib.ir_framework.IRNode.STATIC_CALL_OF_METHOD, "MyValue2::hash", "= 1"})
     public long test151(MyValue2 val) {
+        val = Objects.requireNonNull(val);
         MyAbstract receiver = MyValue1.createWithFieldsInline(rI, rL);
 
         for (int i = 0; i < 100; i++) {
@@ -4182,7 +4183,6 @@ public class TestLWorld {
     public void test151_verifier() {
         Asserts.assertEquals(test151(testValue2), testValue2.hash());
     }
-*/
 
     static interface MyInterface2 {
         public int val();


### PR DESCRIPTION
Hi,

The issue here is that the IGVN cannot deduce that the `IsBuffered` input is a constant 1. This is because after the `InlineTypeNode` is pushed down through a `Phi` cluster, the `IsBuffered` input is a `Phi` cluster with loop phis, which makes it difficult for the IGVN to see through. A solution is to do another round of CCP after loop opts, but it is rather a big hammer. In this PR, I propose to make it possible for a `PhiNode` to look through its `Phi` inputs to discover the unique non-phi input of a `Phi` cluster. The test still fails but it seems more like an expected behaviour rather than an issue this time, I have modified the test a little bit for it to pass.

Please take a look and share your thoughts, thanks very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336003](https://bugs.openjdk.org/browse/JDK-8336003): [lworld] TestLWorld::test151 triggers "Should have been buffered" assert (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1489/head:pull/1489` \
`$ git checkout pull/1489`

Update a local copy of the PR: \
`$ git checkout pull/1489` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1489`

View PR using the GUI difftool: \
`$ git pr show -t 1489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1489.diff">https://git.openjdk.org/valhalla/pull/1489.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1489#issuecomment-2971914316)
</details>
