### PR TITLE
8339481: [lworld] C2: Rename InlineTypeNode::IsInit to NotNull

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3688,13 +3688,13 @@ encode %{
       __ call_Unimplemented();
     }
     if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
-      // The last return value is not set by the callee but used to pass IsInit information to compiled code.
+      // The last return value is not set by the callee but used to pass the null marker to compiled code.
       // Search for the corresponding projection, get the register and emit code that initialized it.
       uint con = (tf()->range_cc()->cnt() - 1);
       for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
         ProjNode* proj = fast_out(i)->as_Proj();
         if (proj->_con == con) {
-          // Set IsInit if r0 is non-null (a non-null value is returned buffered or scalarized)
+          // Set null marker if r0 is non-null (a non-null value is returned buffered or scalarized)
           OptoReg::Name optoReg = ra_->get_reg_first(proj);
           VMReg reg = OptoReg::as_VMReg(optoReg, ra_->_framesize, OptoReg::reg2stack(ra_->_matcher._new_SP));
           Register toReg = reg->is_reg() ? reg->as_Register() : rscratch1;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7307,7 +7307,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
     if (done) {
       b(L_notNull);
       bind(L_null);
-      // Set IsInit field to zero to signal that the argument is null.
+      // Set null marker to zero to signal that the argument is null.
       // Also set all oop fields to zero to make the GC happy.
       stream.reset(sig_index, to_index);
       while (stream.next(toReg, bt)) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6223,7 +6223,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
     if (done) {
       jmp(L_notNull);
       bind(L_null);
-      // Set IsInit field to zero to signal that the argument is null.
+      // Set null marker to zero to signal that the argument is null.
       // Also set all oop fields to zero to make the GC happy.
       stream.reset(sig_index, to_index);
       while (stream.next(toReg, bt)) {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2719,13 +2719,13 @@ encode %{
       __ bind(L);
     }
     if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
-      // The last return value is not set by the callee but used to pass IsInit information to compiled code.
+      // The last return value is not set by the callee but used to pass the null marker to compiled code.
       // Search for the corresponding projection, get the register and emit code that initialized it.
       uint con = (tf()->range_cc()->cnt() - 1);
       for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
         ProjNode* proj = fast_out(i)->as_Proj();
         if (proj->_con == con) {
-          // Set IsInit if rax is non-null (a non-null value is returned buffered or scalarized)
+          // Set null marker if rax is non-null (a non-null value is returned buffered or scalarized)
           OptoReg::Name optoReg = ra_->get_reg_first(proj);
           VMReg reg = OptoReg::as_VMReg(optoReg, ra_->_framesize, OptoReg::reg2stack(ra_->_matcher._new_SP));
           Register toReg = reg->is_reg() ? reg->as_Register() : rscratch1;

--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -161,7 +161,7 @@ void ObjectValue::set_value(oop value) {
 void ObjectValue::read_object(DebugInfoReadStream* stream) {
   _is_root = stream->read_bool();
   _klass = read_from(stream);
-  _is_init = read_from(stream);
+  _null_marker = read_from(stream);
   assert(_klass->is_constant_oop(), "should be constant java mirror oop");
   int length = stream->read_int();
   for (int i = 0; i < length; i++) {
@@ -180,11 +180,11 @@ void ObjectValue::write_on(DebugInfoWriteStream* stream) {
     stream->write_int(_id);
     stream->write_bool(_is_root);
     _klass->write_on(stream);
-    if (_is_init == nullptr) {
+    if (_null_marker == nullptr) {
       // MarkerValue is used for null-free objects
-      _is_init = new MarkerValue();
+      _null_marker = new MarkerValue();
     }
-    _is_init->write_on(stream);
+    _null_marker->write_on(stream);
     int length = _field_values.length();
     stream->write_int(length);
     for (int i = 0; i < length; i++) {

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -130,7 +130,7 @@ class ObjectValue: public ScopeValue {
  protected:
   int                        _id;
   ScopeValue*                _klass;
-  ScopeValue*                _is_init;
+  ScopeValue*                _null_marker;
   GrowableArray<ScopeValue*> _field_values;
   Handle                     _value;
   bool                       _visited;
@@ -141,10 +141,10 @@ class ObjectValue: public ScopeValue {
                                          // Otherwise false, meaning it's just a candidate
                                          // in an object allocation merge.
  public:
-  ObjectValue(int id, ScopeValue* klass = nullptr, bool is_scalar_replaced = true, ScopeValue* is_init = nullptr)
+  ObjectValue(int id, ScopeValue* klass = nullptr, bool is_scalar_replaced = true, ScopeValue* null_marker = nullptr)
      : _id(id)
      , _klass(klass)
-     , _is_init((is_init == nullptr) ? new MarkerValue() : is_init)
+     , _null_marker((null_marker == nullptr) ? new MarkerValue() : null_marker)
      , _field_values()
      , _value()
      , _visited(false)
@@ -157,7 +157,7 @@ class ObjectValue: public ScopeValue {
   bool                        is_object() const           { return true; }
   int                         id() const                  { return _id; }
   virtual ScopeValue*         klass() const               { return _klass; }
-  virtual ScopeValue*         is_init() const             { return _is_init; }
+  virtual ScopeValue*         null_marker() const         { return _null_marker; }
   virtual GrowableArray<ScopeValue*>* field_values()      { return &_field_values; }
   virtual ScopeValue*         field_at(int i) const       { return _field_values.at(i); }
   virtual int                 field_size()                { return _field_values.length(); }
@@ -165,7 +165,7 @@ class ObjectValue: public ScopeValue {
   bool                        is_visited() const          { return _visited; }
   bool                        is_scalar_replaced() const  { return _is_scalar_replaced; }
   bool                        is_root() const             { return _is_root; }
-  bool                        maybe_null() const          { return !_is_init->is_marker(); }
+  bool                        maybe_null() const          { return !_null_marker->is_marker(); }
 
   void                        set_id(int id)                   { _id = id; }
   virtual void                set_value(oop value);

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -798,7 +798,7 @@ void CallGenerator::do_late_inline_helper() {
 
           // Check if result is null
           Node* null_ctl = kit.top();
-          kit.null_check_common(vt->get_is_init(), T_INT, false, &null_ctl);
+          kit.null_check_common(vt->get_null_marker(), T_INT, false, &null_ctl);
           region->init_req(1, null_ctl);
           PhiNode* oop = PhiNode::make(region, kit.gvn().zerocon(T_OBJECT), TypeInstPtr::make(TypePtr::BotPTR, vt->type()->inline_klass()));
           Node* init_mem = kit.reset_memory();

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -111,7 +111,7 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     cast->set_req(1, vt->get_oop());
     vt = vt->clone()->as_InlineType();
     if (!_type->maybe_null()) {
-      vt->as_InlineType()->set_is_init(*phase);
+      vt->as_InlineType()->set_null_marker(*phase);
     }
     vt->set_oop(*phase, phase->transform(cast));
     return vt;

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -903,7 +903,7 @@ Compile::Compile(ciEnv* ci_env, ciMethod* target, int osr_bci,
   }
   // TODO 8284443 Only reserve extra slot if needed
   if (InlineTypeReturnedAsFields) {
-    // One extra slot to hold the IsInit information for a nullable
+    // One extra slot to hold the null marker for a nullable
     // inline type return if we run out of registers.
     next_slot += 2;
   }

--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -71,7 +71,7 @@ Node* Conv2BNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (in(1)->is_InlineType()) {
     // Null checking a scalarized but nullable inline type. Check the IsInit
     // input instead of the oop input to avoid keeping buffer allocations alive.
-    set_req_X(1, in(1)->as_InlineType()->get_is_init(), phase);
+    set_req_X(1, in(1)->as_InlineType()->get_null_marker(), phase);
     return this;
   }
   if (!Matcher::match_rule_supported(Op_Conv2B)) {

--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -69,7 +69,7 @@ const Type* Conv2BNode::Value(PhaseGVN* phase) const {
 //------------------------------Ideal------------------------------------------
 Node* Conv2BNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (in(1)->is_InlineType()) {
-    // Null checking a scalarized but nullable inline type. Check the IsInit
+    // Null checking a scalarized but nullable inline type. Check the null marker
     // input instead of the oop input to avoid keeping buffer allocations alive.
     set_req_X(1, in(1)->as_InlineType()->get_null_marker(), phase);
     return this;

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1290,7 +1290,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
   NOT_PRODUCT(explicit_null_checks_inserted++);
 
   if (value->is_InlineType()) {
-    // Null checking a scalarized but nullable inline type. Check the IsInit
+    // Null checking a scalarized but nullable inline type. Check the null marker
     // input instead of the oop input to avoid keeping buffer allocations alive.
     InlineTypeNode* vtptr = value->as_InlineType();
     while (vtptr->get_oop()->is_InlineType()) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1296,7 +1296,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
     while (vtptr->get_oop()->is_InlineType()) {
       vtptr = vtptr->get_oop()->as_InlineType();
     }
-    null_check_common(vtptr->get_is_init(), T_INT, assert_null, null_control, speculative, true);
+    null_check_common(vtptr->get_null_marker(), T_INT, assert_null, null_control, speculative, true);
     if (stopped()) {
       return top();
     }
@@ -1494,7 +1494,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
 Node* GraphKit::cast_not_null(Node* obj, bool do_replace_in_map) {
   if (obj->is_InlineType()) {
     Node* vt = obj->isa_InlineType()->clone_if_required(&gvn(), map(), do_replace_in_map);
-    vt->as_InlineType()->set_is_init(_gvn);
+    vt->as_InlineType()->set_null_marker(_gvn);
     vt = _gvn.transform(vt);
     if (do_replace_in_map) {
       replace_in_map(obj, vt);

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -307,7 +307,7 @@ void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_Li
   uint first_ind = (sfpt->req() - jvms->scloff());
 
   // Iterate over the inline type fields in order of increasing offset and add the
-  // field values to the safepoint. Nullable inline types have an IsInit field that
+  // field values to the safepoint. Nullable inline types have an null marker field that
   // needs to be checked before using the field values.
   sfpt->add_req(get_null_marker());
   uint nfields = add_fields_to_safepoint(worklist, sfpt);
@@ -1435,7 +1435,7 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, uint& base_input, bool 
       }
     }
   }
-  // The last argument is used to pass IsInit information to compiled code and not required here.
+  // The last argument is used to pass the null marker to compiled code and not required here.
   if (!null_free && !in) {
     n->init_req(base_input++, kit->top());
   }
@@ -1447,7 +1447,7 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
   if (!null_free) {
     // Nullable inline type
     if (in) {
-      // Set IsInit field
+      // Set null marker
       if (multi->is_Start()) {
         null_marker = gvn.transform(new ParmNode(multi->as_Start(), base_input));
       } else {
@@ -1539,7 +1539,7 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
     set_field_value(i, parm);
     gvn.record_for_igvn(parm);
   }
-  // The last argument is used to pass IsInit information to compiled code
+  // The last argument is used to pass the null marker to compiled code
   if (!null_free && !in) {
     Node* cmp = null_marker->raw_out(0);
     null_marker = gvn.transform(new ProjNode(multi->as_Call(), base_input));

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -42,7 +42,7 @@
 
 // Clones the inline type to handle control flow merges involving multiple inline types.
 // The inputs are replaced by PhiNodes to represent the merged values for the given region.
-InlineTypeNode* InlineTypeNode::clone_with_phis(PhaseGVN* gvn, Node* region, SafePointNode* map, bool is_init) {
+InlineTypeNode* InlineTypeNode::clone_with_phis(PhaseGVN* gvn, Node* region, SafePointNode* map, bool is_non_null) {
   InlineTypeNode* vt = clone_if_required(gvn, map);
   const Type* t = Type::get_const_type(inline_klass());
   gvn->set_type(vt, t);
@@ -61,17 +61,17 @@ InlineTypeNode* InlineTypeNode::clone_with_phis(PhaseGVN* gvn, Node* region, Saf
   gvn->record_for_igvn(is_buffered_node);
   vt->set_req(IsBuffered, is_buffered_node);
 
-  // Create a PhiNode for merging the is_init values
-  Node* is_init_node;
-  if (is_init) {
-    is_init_node = gvn->intcon(1);
+  // Create a PhiNode for merging the null_marker values
+  Node* null_marker_node;
+  if (is_non_null) {
+    null_marker_node = gvn->intcon(1);
   } else {
     t = Type::get_const_basic_type(T_BOOLEAN);
-    is_init_node = PhiNode::make(region, vt->get_is_init(), t);
-    gvn->set_type(is_init_node, t);
-    gvn->record_for_igvn(is_init_node);
+    null_marker_node = PhiNode::make(region, vt->get_null_marker(), t);
+    gvn->set_type(null_marker_node, t);
+    gvn->record_for_igvn(null_marker_node);
   }
-  vt->set_req(NullMarker, is_init_node);
+  vt->set_req(NullMarker, null_marker_node);
 
   // Create a PhiNode each for merging the field values
   for (uint i = 0; i < vt->field_count(); ++i) {
@@ -135,16 +135,16 @@ InlineTypeNode* InlineTypeNode::merge_with(PhaseGVN* gvn, const InlineTypeNode* 
     set_req(IsBuffered, gvn->transform(phi));
   }
 
-  // Merge is_init inputs
-  Node* is_init = get_is_init();
-  if (is_init->is_Phi()) {
-    phi = is_init->as_Phi();
-    phi->set_req(pnum, other->get_is_init());
+  // Merge null_marker inputs
+  Node* null_marker = get_null_marker();
+  if (null_marker->is_Phi()) {
+    phi = null_marker->as_Phi();
+    phi->set_req(pnum, other->get_null_marker());
     if (transform) {
       set_req(NullMarker, gvn->transform(phi));
     }
   } else {
-    assert(is_init->find_int_con(0) == 1, "only with a non null inline type");
+    assert(null_marker->find_int_con(0) == 1, "only with a non null inline type");
   }
 
   // Merge field values
@@ -179,7 +179,7 @@ void InlineTypeNode::add_new_path(Node* region) {
   phi->add_req(nullptr);
   assert(phi->req() == region->req(), "must be same size as region");
 
-  phi = get_is_init()->as_Phi();
+  phi = get_null_marker()->as_Phi();
   phi->add_req(nullptr);
   assert(phi->req() == region->req(), "must be same size as region");
 
@@ -215,7 +215,7 @@ Node* InlineTypeNode::field_value_by_offset(int offset, bool recursive) const {
   // Flat inline type field
   InlineTypeNode* vt = value->as_InlineType();
   if (offset == field_null_marker_offset(index)) {
-    return vt->get_is_init();
+    return vt->get_null_marker();
   } else {
     int sub_offset = offset - field_offset(index); // Offset of the flattened field inside the declared field
     sub_offset += vt->inline_klass()->payload_offset(); // Add header size
@@ -286,7 +286,7 @@ uint InlineTypeNode::add_fields_to_safepoint(Unique_Node_List& worklist, SafePoi
       cnt += vt->add_fields_to_safepoint(worklist, sfpt);
       if (!field_is_null_free(i)) {
         // The null marker of a flat field is added right after we scalarize that field
-        sfpt->add_req(vt->get_is_init());
+        sfpt->add_req(vt->get_null_marker());
         cnt++;
       }
       continue;
@@ -309,7 +309,7 @@ void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_Li
   // Iterate over the inline type fields in order of increasing offset and add the
   // field values to the safepoint. Nullable inline types have an IsInit field that
   // needs to be checked before using the field values.
-  sfpt->add_req(get_is_init());
+  sfpt->add_req(get_null_marker());
   uint nfields = add_fields_to_safepoint(worklist, sfpt);
   jvms->set_endoff(sfpt->req());
   // Replace safepoint edge by SafePointScalarObjectNode
@@ -591,7 +591,7 @@ Node* InlineTypeNode::convert_to_payload(GraphKit* kit, BasicType bt, Node* payl
   Node* value = nullptr;
   if (!null_free) {
     // Set the null marker
-    value = get_is_init();
+    value = get_null_marker();
     payload = set_payload_value(gvn, payload, bt, value, T_BOOLEAN, null_marker_offset);
   }
   // Iterate over the fields and add their values to the payload
@@ -649,7 +649,7 @@ void InlineTypeNode::store_flat(GraphKit* kit, Node* base, Node* ptr, bool atomi
       int nm_offset = vk->null_marker_offset_in_payload();
       Node* nm_ptr = kit->basic_plus_adr(base, ptr, nm_offset);
       const TypePtr* nm_ptr_type = (decorators & C2_MISMATCHED) == 0 ? kit->gvn().type(nm_ptr)->is_ptr() : TypeRawPtr::BOTTOM;
-      kit->access_store_at(base, nm_ptr, nm_ptr_type, get_is_init(), TypeInt::BOOL, T_BOOLEAN, decorators);
+      kit->access_store_at(base, nm_ptr, nm_ptr_type, get_null_marker(), TypeInt::BOOL, T_BOOLEAN, decorators);
     }
     store(kit, base, ptr, immutable_memory, decorators);
     return;
@@ -821,7 +821,7 @@ InlineTypeNode* InlineTypeNode::buffer(GraphKit* kit, bool safe_for_replace) {
 
   // Inline type is not buffered, check if it is null.
   Node* null_ctl = kit->top();
-  kit->null_check_common(get_is_init(), T_INT, false, &null_ctl);
+  kit->null_check_common(get_null_marker(), T_INT, false, &null_ctl);
   bool null_free = null_ctl->is_top();
 
   RegionNode* region = new RegionNode(4);
@@ -915,8 +915,8 @@ void InlineTypeNode::replace_call_results(GraphKit* kit, CallNode* call, Compile
   replace_proj(C, call, proj_idx, get_oop(), T_OBJECT);
   // Replace field projections
   replace_field_projs(C, call, proj_idx);
-  // Replace is_init projection
-  replace_proj(C, call, proj_idx, get_is_init(), T_BOOLEAN);
+  // Replace null_marker projection
+  replace_proj(C, call, proj_idx, get_null_marker(), T_BOOLEAN);
   assert(proj_idx == call->tf()->range_cc()->cnt(), "missed a projection");
 }
 
@@ -928,8 +928,8 @@ void InlineTypeNode::replace_field_projs(Compile* C, CallNode* call, uint& proj_
       // Replace field projections for flat field
       vt->replace_field_projs(C, call, proj_idx);
       if (!field_is_null_free(i)) {
-        // Replace is_init projection for nullable field
-        replace_proj(C, call, proj_idx, vt->get_is_init(), T_BOOLEAN);
+        // Replace null_marker projection for nullable field
+        replace_proj(C, call, proj_idx, vt->get_null_marker(), T_BOOLEAN);
       }
       continue;
     }
@@ -991,7 +991,7 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     InlineTypeNode* vtptr = oop->as_InlineType();
     set_oop(*phase, vtptr->get_oop());
     set_is_buffered(*phase);
-    set_is_init(*phase);
+    set_null_marker(*phase);
     for (uint i = Values; i < vtptr->req(); ++i) {
       set_req(i, vtptr->in(i));
     }
@@ -1048,7 +1048,7 @@ InlineTypeNode* InlineTypeNode::make_uninitialized(PhaseGVN& gvn, ciInlineKlass*
   // Create a new InlineTypeNode with uninitialized values and nullptr oop
   InlineTypeNode* vt = new InlineTypeNode(vk, gvn.zerocon(T_OBJECT), null_free);
   vt->set_is_buffered(gvn, false);
-  vt->set_is_init(gvn);
+  vt->set_null_marker(gvn);
   return vt;
 }
 
@@ -1062,7 +1062,7 @@ InlineTypeNode* InlineTypeNode::make_all_zero_impl(PhaseGVN& gvn, ciInlineKlass*
   // Create a new InlineTypeNode initialized with all zero
   InlineTypeNode* vt = new InlineTypeNode(vk, gvn.zerocon(T_OBJECT), /* null_free= */ true);
   vt->set_is_buffered(gvn, false);
-  vt->set_is_init(gvn);
+  vt->set_null_marker(gvn);
   for (uint i = 0; i < vt->field_count(); ++i) {
     ciType* ft = vt->field_type(i);
     Node* value = gvn.zerocon(ft->basic_type());
@@ -1087,7 +1087,7 @@ InlineTypeNode* InlineTypeNode::make_all_zero_impl(PhaseGVN& gvn, ciInlineKlass*
 }
 
 bool InlineTypeNode::is_all_zero(PhaseGVN* gvn, bool flat) const {
-  const TypeInt* tinit = gvn->type(get_is_init())->isa_int();
+  const TypeInt* tinit = gvn->type(get_null_marker())->isa_int();
   if (tinit == nullptr || !tinit->is_con(1)) {
     return false; // May be null
   }
@@ -1102,7 +1102,7 @@ bool InlineTypeNode::is_all_zero(PhaseGVN* gvn, bool flat) const {
       continue;
     } else if (value->is_InlineType()) {
       // Nullable value class field must be null
-      tinit = gvn->type(value->as_InlineType()->get_is_init())->isa_int();
+      tinit = gvn->type(value->as_InlineType()->get_null_marker())->isa_int();
       if (tinit != nullptr && tinit->is_con(0)) {
         continue;
       }
@@ -1144,7 +1144,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     }
     vt = new InlineTypeNode(vk, not_null_oop, /* null_free= */ false);
     vt->set_is_buffered(gvn);
-    vt->set_is_init(gvn);
+    vt->set_null_marker(gvn);
     Node* payload_ptr = kit->basic_plus_adr(not_null_oop, vk->payload_offset());
     vt->load(kit, not_null_oop, payload_ptr, true, true, IN_HEAP | MO_UNORDERED, visited);
 
@@ -1163,7 +1163,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     vt = new InlineTypeNode(vk, oop, /* null_free= */ true);
     Node* init_ctl = kit->control();
     vt->set_is_buffered(gvn);
-    vt->set_is_init(gvn);
+    vt->set_null_marker(gvn);
     Node* payload_ptr = kit->basic_plus_adr(oop, vk->payload_offset());
     vt->load(kit, oop, payload_ptr, true, true, IN_HEAP | MO_UNORDERED, visited);
 // TODO 8284443
@@ -1410,7 +1410,7 @@ Node* InlineTypeNode::tagged_klass(ciInlineKlass* vk, PhaseGVN& gvn) {
 
 void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, uint& base_input, bool in, bool null_free) {
   if (!null_free && in) {
-    n->init_req(base_input++, get_is_init());
+    n->init_req(base_input++, get_null_marker());
   }
   for (uint i = 0; i < field_count(); i++) {
     Node* arg = field_value(i);
@@ -1419,7 +1419,7 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, uint& base_input, bool 
       arg->as_InlineType()->pass_fields(kit, n, base_input, in);
       if (!field_is_null_free(i)) {
         assert(field_null_marker_offset(i) != -1, "inconsistency");
-        n->init_req(base_input++, arg->as_InlineType()->get_is_init());
+        n->init_req(base_input++, arg->as_InlineType()->get_null_marker());
       }
     } else {
       if (arg->is_InlineType()) {
@@ -1443,29 +1443,29 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, uint& base_input, bool 
 
 void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in, bool null_free, Node* null_check_region, GrowableArray<ciType*>& visited) {
   PhaseGVN& gvn = kit->gvn();
-  Node* is_init = nullptr;
+  Node* null_marker = nullptr;
   if (!null_free) {
     // Nullable inline type
     if (in) {
       // Set IsInit field
       if (multi->is_Start()) {
-        is_init = gvn.transform(new ParmNode(multi->as_Start(), base_input));
+        null_marker = gvn.transform(new ParmNode(multi->as_Start(), base_input));
       } else {
-        is_init = multi->as_Call()->in(base_input);
+        null_marker = multi->as_Call()->in(base_input);
       }
-      set_req(NullMarker, is_init);
+      set_req(NullMarker, null_marker);
       base_input++;
     }
     // Add a null check to make subsequent loads dependent on
     assert(null_check_region == nullptr, "already set");
-    if (is_init == nullptr) {
+    if (null_marker == nullptr) {
       // Will only be initialized below, use dummy node for now
-      is_init = new Node(1);
-      is_init->init_req(0, kit->control()); // Add an input to prevent dummy from being dead
-      gvn.set_type_bottom(is_init);
+      null_marker = new Node(1);
+      null_marker->init_req(0, kit->control()); // Add an input to prevent dummy from being dead
+      gvn.set_type_bottom(null_marker);
     }
     Node* null_ctrl = kit->top();
-    kit->null_check_common(is_init, T_INT, false, &null_ctrl);
+    kit->null_check_common(null_marker, T_INT, false, &null_ctrl);
     Node* non_null_ctrl = kit->control();
     null_check_region = new RegionNode(3);
     null_check_region->init_req(1, non_null_ctrl);
@@ -1483,15 +1483,15 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
       vt->initialize_fields(kit, multi, base_input, in, true, null_check_region, visited);
       if (!field_is_null_free(i)) {
         assert(field_null_marker_offset(i) != -1, "inconsistency");
-        Node* is_init = nullptr;
+        Node* null_marker = nullptr;
         if (multi->is_Start()) {
-          is_init = gvn.transform(new ParmNode(multi->as_Start(), base_input));
+          null_marker = gvn.transform(new ParmNode(multi->as_Start(), base_input));
         } else if (in) {
-          is_init = multi->as_Call()->in(base_input);
+          null_marker = multi->as_Call()->in(base_input);
         } else {
-          is_init = gvn.transform(new ProjNode(multi->as_Call(), base_input));
+          null_marker = gvn.transform(new ProjNode(multi->as_Call(), base_input));
         }
-        vt->set_req(NullMarker, is_init);
+        vt->set_req(NullMarker, null_marker);
         base_input++;
       }
       parm = gvn.transform(vt);
@@ -1541,11 +1541,11 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
   }
   // The last argument is used to pass IsInit information to compiled code
   if (!null_free && !in) {
-    Node* cmp = is_init->raw_out(0);
-    is_init = gvn.transform(new ProjNode(multi->as_Call(), base_input));
-    set_req(NullMarker, is_init);
+    Node* cmp = null_marker->raw_out(0);
+    null_marker = gvn.transform(new ProjNode(multi->as_Call(), base_input));
+    set_req(NullMarker, null_marker);
     gvn.hash_delete(cmp);
-    cmp->set_req(1, is_init);
+    cmp->set_req(1, null_marker);
     gvn.hash_find_insert(cmp);
     gvn.record_for_igvn(cmp);
     base_input++;
@@ -1597,7 +1597,7 @@ InlineTypeNode* InlineTypeNode::make_null(PhaseGVN& gvn, ciInlineKlass* vk, bool
 InlineTypeNode* InlineTypeNode::make_null_impl(PhaseGVN& gvn, ciInlineKlass* vk, GrowableArray<ciType*>& visited, bool transform) {
   InlineTypeNode* vt = new InlineTypeNode(vk, gvn.zerocon(T_OBJECT), /* null_free= */ false);
   vt->set_is_buffered(gvn);
-  vt->set_is_init(gvn, gvn.intcon(0));
+  vt->set_null_marker(gvn, gvn.intcon(0));
   for (uint i = 0; i < vt->field_count(); i++) {
     ciType* ft = vt->field_type(i);
     Node* value = gvn.zerocon(ft->basic_type());

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -48,7 +48,10 @@ private:
   enum { Control,    // Control input.
          Oop,        // Oop to heap allocated buffer.
          IsBuffered, // True if inline type is heap allocated (or nullptr), false otherwise.
-         IsInit,     // Needs to be checked for nullptr before using the field values.
+         NullMarker, // Needs to be checked for nullptr before using the field values.
+                     // 0 => InlineType is null
+                     // 1 => InlineType is non-null
+                     // Can be dynamic value, not necessarily statically known
          Values      // Nodes corresponding to values of the inline type's fields.
                      // Nodes are connected in increasing order of the index of the field they correspond to.
   };
@@ -105,8 +108,8 @@ public:
   // Get oop for heap allocated inline type (may be TypePtr::NULL_PTR)
   Node* get_oop() const    { return in(Oop); }
   void  set_oop(PhaseGVN& gvn, Node* oop) { set_req_X(Oop, oop, &gvn); }
-  Node* get_is_init() const { return in(IsInit); }
-  void  set_is_init(PhaseGVN& gvn, Node* init) { set_req_X(IsInit, init, &gvn); }
+  Node* get_is_init() const { return in(NullMarker); }
+  void  set_is_init(PhaseGVN& gvn, Node* init) { set_req_X(NullMarker, init, &gvn); }
   void  set_is_init(PhaseGVN& gvn) { set_is_init(gvn, gvn.intcon(1)); }
   Node* get_is_buffered() const { return in(IsBuffered); }
   void  set_is_buffered(PhaseGVN& gvn, bool buffered = true) { set_req_X(IsBuffered, gvn.intcon(buffered ? 1 : 0), &gvn); }

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -101,16 +101,16 @@ public:
 
   // Support for control flow merges
   bool has_phi_inputs(Node* region);
-  InlineTypeNode* clone_with_phis(PhaseGVN* gvn, Node* region, SafePointNode* map = nullptr, bool is_init = false);
+  InlineTypeNode* clone_with_phis(PhaseGVN* gvn, Node* region, SafePointNode* map = nullptr, bool is_non_null = false);
   InlineTypeNode* merge_with(PhaseGVN* gvn, const InlineTypeNode* other, int pnum, bool transform);
   void add_new_path(Node* region);
 
   // Get oop for heap allocated inline type (may be TypePtr::NULL_PTR)
   Node* get_oop() const    { return in(Oop); }
   void  set_oop(PhaseGVN& gvn, Node* oop) { set_req_X(Oop, oop, &gvn); }
-  Node* get_is_init() const { return in(NullMarker); }
-  void  set_is_init(PhaseGVN& gvn, Node* init) { set_req_X(NullMarker, init, &gvn); }
-  void  set_is_init(PhaseGVN& gvn) { set_is_init(gvn, gvn.intcon(1)); }
+  Node* get_null_marker() const { return in(NullMarker); }
+  void  set_null_marker(PhaseGVN& gvn, Node* init) { set_req_X(NullMarker, init, &gvn); }
+  void  set_null_marker(PhaseGVN& gvn) { set_null_marker(gvn, gvn.intcon(1)); }
   Node* get_is_buffered() const { return in(IsBuffered); }
   void  set_is_buffered(PhaseGVN& gvn, bool buffered = true) { set_req_X(IsBuffered, gvn.intcon(buffered ? 1 : 0), &gvn); }
 

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -48,7 +48,7 @@ private:
   enum { Control,    // Control input.
          Oop,        // Oop to heap allocated buffer.
          IsBuffered, // True if inline type is heap allocated (or nullptr), false otherwise.
-         NullMarker, // Needs to be checked for nullptr before using the field values.
+         NullMarker, // Needs to be checked before using the field values.
                      // 0 => InlineType is null
                      // 1 => InlineType is non-null
                      // Can be dynamic value, not necessarily statically known

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -609,13 +609,13 @@ Node* PhaseMacroExpand::inline_type_from_mem(ciInlineKlass* vk, const TypeAryPtr
   InlineTypeNode* vt = InlineTypeNode::make_uninitialized(_igvn, vk, false);
   transform_later(vt);
   if (null_free) {
-    vt->set_is_init(_igvn);
+    vt->set_null_marker(_igvn);
   } else {
     int nm_offset_in_element = offset_in_element + vk->null_marker_offset_in_payload();
     const TypeAryPtr* nm_adr_type = elem_adr_type->with_field_offset(nm_offset_in_element);
     Node* nm_value = value_from_mem(sfpt->memory(), sfpt->control(), T_BOOLEAN, TypeInt::BOOL, nm_adr_type, alloc);
     if (nm_value != nullptr) {
-      vt->set_is_init(_igvn, nm_value);
+      vt->set_null_marker(_igvn, nm_value);
     } else {
       report_failure(nm_offset_in_element);
       return nullptr;

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1046,11 +1046,11 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
     }
 
     if (res->bottom_type()->is_inlinetypeptr()) {
-      // Nullable inline types have an IsInit field which is added to the safepoint when scalarizing them (see
+      // Nullable inline types have a null marker field which is added to the safepoint when scalarizing them (see
       // InlineTypeNode::make_scalar_in_safepoint()). When having circular inline types, we stop scalarizing at depth 1
       // to avoid an endless recursion. Therefore, we do not have a SafePointScalarObjectNode node here, yet.
       // We are about to create a SafePointScalarObjectNode as if this is a normal object. Add an additional int input
-      // with value 1 which sets IsInit to true to indicate that the object is always non-null. This input is checked
+      // with value 1 which sets the null marker to true to indicate that the object is always non-null. This input is checked
       // later in PhaseOutput::filLocArray() for inline types.
       sfpt->add_req(_igvn.intcon(1));
     }

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -203,7 +203,7 @@ RegMask* Matcher::return_values_mask(const TypeFunc* tf) {
 
   int regs = SharedRuntime::java_return_convention(sig_bt, vm_parm_regs, cnt);
   if (regs <= 0) {
-    // We ran out of registers to store the IsInit information for a nullable inline type return.
+    // We ran out of registers to store the null marker for a nullable inline type return.
     // Since it is only set in the 'call_epilog', we can simply put it on the stack.
     assert(tf->returns_inline_type_as_fields(), "should have been tested during graph construction");
     // TODO 8284443 Can we teach the register allocator to reserve a stack slot instead?

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -801,24 +801,24 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
       assert(cik->is_instance_klass() ||
              cik->is_array_klass(), "Not supported allocation.");
       uint first_ind = spobj->first_index(sfpt->jvms());
-      // Nullable, scalarized inline types have an is_init input
+      // Nullable, scalarized inline types have a null_marker input
       // that needs to be checked before using the field values.
-      ScopeValue* is_init = nullptr;
+      ScopeValue* null_marker = nullptr;
       if (cik->is_inlinetype()) {
-        Node* init_node = sfpt->in(first_ind++);
-        assert(init_node != nullptr, "is_init node not found");
-        if (!init_node->is_top()) {
-          const TypeInt* init_type = init_node->bottom_type()->is_int();
-          if (init_node->is_Con()) {
-            is_init = new ConstantIntValue(init_type->get_con());
+        Node* null_marker_node = sfpt->in(first_ind++);
+        assert(null_marker_node != nullptr, "null_marker node not found");
+        if (!null_marker_node->is_top()) {
+          const TypeInt* null_marker_type = null_marker_node->bottom_type()->is_int();
+          if (null_marker_node->is_Con()) {
+            null_marker = new ConstantIntValue(null_marker_type->get_con());
           } else {
-            OptoReg::Name init_reg = C->regalloc()->get_reg_first(init_node);
-            is_init = new_loc_value(C->regalloc(), init_reg, Location::normal);
+            OptoReg::Name null_marker_reg = C->regalloc()->get_reg_first(null_marker_node);
+            null_marker = new_loc_value(C->regalloc(), null_marker_reg, Location::normal);
           }
         }
       }
       sv = new ObjectValue(spobj->_idx,
-                           new ConstantOopWriteValue(cik->java_mirror()->constant_encoding()), true, is_init);
+                           new ConstantOopWriteValue(cik->java_mirror()->constant_encoding()), true, null_marker);
       set_sv_for_object_node(objs, sv);
 
       for (uint i = 0; i < spobj->n_fields(); i++) {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -959,7 +959,7 @@ void Compile::return_values(JVMState* jvms) {
         // Return the tagged klass pointer to signal scalarization to the caller
         Node* tagged_klass = vt->tagged_klass(kit.gvn());
         // Return null if the inline type is null (IsInit field is not set)
-        Node* conv   = kit.gvn().transform(new ConvI2LNode(vt->get_is_init()));
+        Node* conv   = kit.gvn().transform(new ConvI2LNode(vt->get_null_marker()));
         Node* shl    = kit.gvn().transform(new LShiftLNode(conv, kit.intcon(63)));
         Node* shr    = kit.gvn().transform(new RShiftLNode(shl, kit.intcon(63)));
         tagged_klass = kit.gvn().transform(new AndLNode(tagged_klass, shr));

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -958,7 +958,7 @@ void Compile::return_values(JVMState* jvms) {
       } else {
         // Return the tagged klass pointer to signal scalarization to the caller
         Node* tagged_klass = vt->tagged_klass(kit.gvn());
-        // Return null if the inline type is null (IsInit field is not set)
+        // Return null if the inline type is null (null marker field is not set)
         Node* conv   = kit.gvn().transform(new ConvI2LNode(vt->get_null_marker()));
         Node* shl    = kit.gvn().transform(new LShiftLNode(conv, kit.intcon(63)));
         Node* shr    = kit.gvn().transform(new RShiftLNode(shl, kit.intcon(63)));

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2117,7 +2117,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   if (left->is_InlineType()) {
     if (_gvn.type(right)->is_zero_type() ||
         (right->is_InlineType() && _gvn.type(right->as_InlineType()->get_null_marker())->is_zero_type())) {
-      // Null checking a scalarized but nullable inline type. Check the IsInit
+      // Null checking a scalarized but nullable inline type. Check the null marker
       // input instead of the oop input to avoid keeping buffer allocations alive.
       Node* cmp = CmpI(left->as_InlineType()->get_null_marker(), intcon(0));
       do_if(btest, cmp);
@@ -3440,7 +3440,7 @@ void Parse::do_one_bytecode() {
     a = null();
     b = cast_to_non_larval(pop());
     if (b->is_InlineType()) {
-      // Null checking a scalarized but nullable inline type. Check the IsInit
+      // Null checking a scalarized but nullable inline type. Check the null marker
       // input instead of the oop input to avoid keeping buffer allocations alive
       c = _gvn.transform(new CmpINode(b->as_InlineType()->get_null_marker(), zerocon(T_INT)));
     } else {

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2116,10 +2116,10 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   // Allocate inline type operands and re-execute on deoptimization
   if (left->is_InlineType()) {
     if (_gvn.type(right)->is_zero_type() ||
-        (right->is_InlineType() && _gvn.type(right->as_InlineType()->get_is_init())->is_zero_type())) {
+        (right->is_InlineType() && _gvn.type(right->as_InlineType()->get_null_marker())->is_zero_type())) {
       // Null checking a scalarized but nullable inline type. Check the IsInit
       // input instead of the oop input to avoid keeping buffer allocations alive.
-      Node* cmp = CmpI(left->as_InlineType()->get_is_init(), intcon(0));
+      Node* cmp = CmpI(left->as_InlineType()->get_null_marker(), intcon(0));
       do_if(btest, cmp);
       return;
     } else {
@@ -3442,7 +3442,7 @@ void Parse::do_one_bytecode() {
     if (b->is_InlineType()) {
       // Null checking a scalarized but nullable inline type. Check the IsInit
       // input instead of the oop input to avoid keeping buffer allocations alive
-      c = _gvn.transform(new CmpINode(b->as_InlineType()->get_is_init(), zerocon(T_INT)));
+      c = _gvn.transform(new CmpINode(b->as_InlineType()->get_null_marker(), zerocon(T_INT)));
     } else {
       if (!_gvn.type(b)->speculative_maybe_null() &&
           !too_many_traps(Deoptimization::Reason_speculate_null_check)) {

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1188,7 +1188,7 @@ Node* CmpPNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   if (in(1)->is_InlineType() && phase->type(in(2))->is_zero_type()) {
     // Null checking a scalarized but nullable inline type. Check the IsInit
     // input instead of the oop input to avoid keeping buffer allocations alive.
-    return new CmpINode(in(1)->as_InlineType()->get_is_init(), phase->intcon(0));
+    return new CmpINode(in(1)->as_InlineType()->get_null_marker(), phase->intcon(0));
   }
 
   // Normalize comparisons between Java mirrors into comparisons of the low-

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1186,7 +1186,7 @@ static inline Node* isa_const_java_mirror(PhaseGVN* phase, Node* n) {
 Node* CmpPNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // TODO 8284443 in(1) could be cast?
   if (in(1)->is_InlineType() && phase->type(in(2))->is_zero_type()) {
-    // Null checking a scalarized but nullable inline type. Check the IsInit
+    // Null checking a scalarized but nullable inline type. Check the null marker
     // input instead of the oop input to avoid keeping buffer allocations alive.
     return new CmpINode(in(1)->as_InlineType()->get_null_marker(), phase->intcon(0));
   }

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2416,7 +2416,7 @@ const TypeTuple *TypeTuple::make_range(ciSignature* sig, InterfaceHandling inter
   uint arg_cnt = return_type->size();
   if (ret_vt_fields) {
     arg_cnt = return_type->as_inline_klass()->inline_arg_slots() + 1;
-    // InlineTypeNode::IsInit field used for null checking
+    // InlineTypeNode::NullMarker field used for null checking
     arg_cnt++;
   }
   const Type **field_array = fields(arg_cnt);
@@ -2434,7 +2434,7 @@ const TypeTuple *TypeTuple::make_range(ciSignature* sig, InterfaceHandling inter
       uint pos = TypeFunc::Parms;
       field_array[pos++] = get_const_type(return_type); // Oop might be null when returning as fields
       collect_inline_fields(return_type->as_inline_klass(), field_array, pos);
-      // InlineTypeNode::IsInit field used for null checking
+      // InlineTypeNode::NullMarker field used for null checking
       field_array[pos++] = get_const_basic_type(T_BOOLEAN);
       assert(pos == (TypeFunc::Parms + arg_cnt), "out of bounds");
       break;
@@ -2498,7 +2498,7 @@ const TypeTuple *TypeTuple::make_domain(ciMethod* method, InterfaceHandling inte
       break;
     case T_OBJECT:
       if (type->is_inlinetype() && vt_fields_as_args && method->is_scalarized_arg(i + (method->is_static() ? 0 : 1))) {
-        // InlineTypeNode::IsInit field used for null checking
+        // InlineTypeNode::NullMarker field used for null checking
         field_array[pos++] = get_const_basic_type(T_BOOLEAN);
         collect_inline_fields(type->as_inline_klass(), field_array, pos);
       } else {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1255,12 +1255,12 @@ bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap*
     ObjectValue* sv = (ObjectValue*) objects->at(i);
     Klass* k = java_lang_Class::as_Klass(sv->klass()->as_ConstantOopReadValue()->value()());
 
-    // Check if the object may be null and has an additional is_init input that needs
+    // Check if the object may be null and has an additional null_marker input that needs
     // to be checked before using the field values. Skip re-allocation if it is null.
     if (sv->maybe_null()) {
       assert(k->is_inline_klass(), "must be an inline klass");
-      jint is_init = StackValue::create_stack_value(fr, reg_map, sv->is_init())->get_jint();
-      if (is_init == 0) {
+      jint null_marker = StackValue::create_stack_value(fr, reg_map, sv->null_marker())->get_jint();
+      if (null_marker == 0) {
         continue;
       }
     }

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2865,7 +2865,7 @@ void CompiledEntrySignature::compute_calling_conventions(bool init) {
             _sig_cc->appendAll(vk->extended_sig());
             _sig_cc_ro->appendAll(vk->extended_sig());
             if (bt == T_OBJECT) {
-              // Nullable inline type argument, insert InlineTypeNode::IsInit field right after T_METADATA delimiter
+              // Nullable inline type argument, insert InlineTypeNode::NullMarker field right after T_METADATA delimiter
               // Set the sort_offset so that the field is detected as null marker by nmethod::print_nmethod_labels.
               _sig_cc->insert_before(last+1, SigEntry(T_BOOLEAN, -1, 0));
               _sig_cc_ro->insert_before(last_ro+1, SigEntry(T_BOOLEAN, -1, 0));

--- a/src/hotspot/share/runtime/stackValue.cpp
+++ b/src/hotspot/share/runtime/stackValue.cpp
@@ -250,8 +250,8 @@ StackValue* StackValue::create_stack_value(const frame* fr, const RegisterMapT* 
     bool scalar_replaced = hdl.is_null() && ov->is_scalar_replaced();
     if (ov->maybe_null()) {
       // Don't treat inline type as scalar replaced if it is null
-      jint is_init = StackValue::create_stack_value(fr, reg_map, ov->is_init())->get_jint();
-      scalar_replaced &= (is_init != 0);
+      jint null_marker = StackValue::create_stack_value(fr, reg_map, ov->null_marker())->get_jint();
+      scalar_replaced &= (null_marker != 0);
     }
     return new StackValue(hdl, scalar_replaced ? 1 : 0);
   } else if (sv->is_marker()) {


### PR DESCRIPTION
Picked the proposed name I found the most fitting. Added a comment to address the concern in the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339481](https://bugs.openjdk.org/browse/JDK-8339481): [lworld] C2: Rename InlineTypeNode::IsInit to NotNull (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1491/head:pull/1491` \
`$ git checkout pull/1491`

Update a local copy of the PR: \
`$ git checkout pull/1491` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1491`

View PR using the GUI difftool: \
`$ git pr show -t 1491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1491.diff">https://git.openjdk.org/valhalla/pull/1491.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1491#issuecomment-2999314340)
</details>
