### PR TITLE
8361218: [lworld] Remove LockingMode from test

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -26,23 +26,7 @@
 * @library /test/lib
 * @enablePreview
 * @compile MonitorEnterTest.java
-* @run main/othervm -XX:LockingMode=0 runtime.valhalla.inlinetypes.MonitorEnterTest
-*/
-
-/**
-* @test MonitorEnterTest
-* @library /test/lib
-* @enablePreview
-* @compile MonitorEnterTest.java
-* @run main/othervm -XX:LockingMode=1 runtime.valhalla.inlinetypes.MonitorEnterTest
-*/
-
-/**
-* @test MonitorEnterTest
-* @library /test/lib
-* @enablePreview
-* @compile MonitorEnterTest.java
-* @run main/othervm -XX:LockingMode=2 runtime.valhalla.inlinetypes.MonitorEnterTest
+* @run main/othervm runtime.valhalla.inlinetypes.MonitorEnterTest
 */
 
 package runtime.valhalla.inlinetypes;


### PR DESCRIPTION
See issue - the LockingMode flags will be removed in mainline, so adjusting this test.
Tested with the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8361218](https://bugs.openjdk.org/browse/JDK-8361218): [lworld] Remove LockingMode from test (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1495/head:pull/1495` \
`$ git checkout pull/1495`

Update a local copy of the PR: \
`$ git checkout pull/1495` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1495`

View PR using the GUI difftool: \
`$ git pr show -t 1495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1495.diff">https://git.openjdk.org/valhalla/pull/1495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1495#issuecomment-3025336919)
</details>
