### PR TITLE
8329234: [lworld] compiler/gcbarriers/TestZGCBarrierElision.java fails after JDK-8329205

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -196,8 +196,7 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-    // TODO: 8329234
-    //@IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     // TODO: 8353182
     //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testLoadThenAtomic(Outer o, Inner i) {


### PR DESCRIPTION
The `compiler/gcbarriers/TestZGCBarrierElision.java` test failed after [JDK-8329205](https://bugs.openjdk.org/browse/JDK-8329205) but [JDK-8350515](https://bugs.openjdk.org/browse/JDK-8350515) fixed the issue.
This PR removes the TODO and uncomments the IR check.

Tests: Tier 1-3+

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8329234](https://bugs.openjdk.org/browse/JDK-8329234): [lworld] compiler/gcbarriers/TestZGCBarrierElision.java fails after JDK-8329205 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1496/head:pull/1496` \
`$ git checkout pull/1496`

Update a local copy of the PR: \
`$ git checkout pull/1496` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1496`

View PR using the GUI difftool: \
`$ git pr show -t 1496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1496.diff">https://git.openjdk.org/valhalla/pull/1496.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1496#issuecomment-3027411306)
</details>
