### PR TITLE
JDK-8353182: [lworld] C2: Multiple IR test failures in compiler/gcbarriers/TestZGCBarrierElision.java after JDK-8351569

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -187,8 +187,7 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateThenAtomic(Inner i) {
         Outer o = new Outer();
         Common.blackhole(o);
@@ -198,24 +197,21 @@ class TestZGCCorrectBarrierElision {
     @Test
     // TODO: 8329234
     //@IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testLoadThenAtomic(Outer o, Inner i) {
         Common.blackhole(o.field1);
         Common.field1VarHandle.getAndSet(o, i);
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenAtomicAnotherField(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet(o, i);
         Common.field2VarHandle.getAndSet(o, i);
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateArrayThenAtomicAtKnownIndex(Outer o) {
         Outer[] a = new Outer[42];
         Common.blackhole(a);
@@ -223,8 +219,7 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateArrayThenAtomicAtUnknownIndex(Outer o, int index) {
         Outer[] a = new Outer[42];
         Common.blackhole(a);
@@ -232,8 +227,7 @@ class TestZGCCorrectBarrierElision {
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayAtomicThenAtomicAtUnknownIndices(Outer[] a, Outer o, int index1, int index2) {
         Common.outerArrayVarHandle.getAndSet(a, index1, o);
         Common.outerArrayVarHandle.getAndSet(a, index2, o);
@@ -394,16 +388,14 @@ class TestZGCEffectiveBarrierElision {
 
     @Test
     @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testStoreThenAtomic(Outer o, Inner i) {
         o.field1 = i;
         Common.field1VarHandle.getAndSet(o, i);
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenLoad(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet(o, i);
@@ -411,8 +403,7 @@ class TestZGCEffectiveBarrierElision {
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenStore(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet(o, i);
@@ -420,18 +411,16 @@ class TestZGCEffectiveBarrierElision {
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    //@IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenAtomic(Outer o, Inner i) {
         Common.field1VarHandle.getAndSet(o, i);
         Common.field1VarHandle.getAndSet(o, i);
     }
 
     @Test
-    // TODO: 8353182
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    //@IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, Common.ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayAtomicThenAtomic(Outer[] a, Outer o) {
         Common.outerArrayVarHandle.getAndSet(a, 0, o);
         Common.outerArrayVarHandle.getAndSet(a, 0, o);


### PR DESCRIPTION
This is a very similar issue to [JDK-8343420](https://bugs.openjdk.org/browse/JDK-8343420).

A few `TestZGCBarrierElision` tests fail after [JDK-8351569](https://bugs.openjdk.org/browse/JDK-8351569). These tests check that ZGC barrier elision optimization does not elide necessary barriers and partially do so using `VarHandle::getAndSet` and checking that `GetAndSetP` nodes with barriers are created.
As found out in [JDK-8343420](https://bugs.openjdk.org/browse/JDK-8343420), [JDK-8351569](https://bugs.openjdk.org/browse/JDK-8351569) refactored `Unsafe::getAndSet` (which is used by `VarHandle::getAndSet`) to take value-classes into account, which implies that checks must be introduced to see if the target and argument objects are value-classes. This is done with a new overloaded `getAndSet` method that is now called instead of the old one. This method is not intrinsified (only inlined) and doesn't result in a `GetAndSet` node. It instead relies on the `compareAndSet` method (which gets intrinsified) and results in a `CompareAndSwap` node.

Here as well, as the goal of the test is mainly to check for ZGC barrier presence, the sensible fix for now seems to be to modify the `TestZGCBarrierElision` tests to make them check for `CompareAndSwap` instead of `GetAndSet` nodes.

Tests: Tier 1-3+