### PR TITLE
8361082: [lworld] RewriteBytecodesInlineTest fails with SIGSEGV

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6212,7 +6212,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
         // Preloading classes for nullable fields that are listed in the LoadableDescriptors attribute
         // Those classes would be required later for the flattening of nullable inline type fields
         TempNewSymbol name = Signature::strip_envelope(sig);
-        if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) { //here
+        if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) {
           log_info(class, preload)("Preloading class %s during loading of class %s. \
                                    Cause: field type in LoadableDescriptors attribute",
                                    name->as_C_string(), _class_name->as_C_string());

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6169,13 +6169,21 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
         // Pre-load classes of null-free fields that are candidate for flattening
         TempNewSymbol s = Signature::strip_envelope(sig);
         if (s == _class_name) {
-          THROW_MSG(vmSymbols::java_lang_ClassCircularityError(), err_msg("Class %s cannot have a null-free non-static field of its own type", _class_name->as_C_string()));
+          THROW_MSG(vmSymbols::java_lang_ClassCircularityError(),
+                    err_msg("Class %s cannot have a null-free non-static field of its own type", _class_name->as_C_string()));
         }
-        log_info(class, preload)("Preloading class %s during loading of class %s. Cause: a null-free non-static field is declared with this type", s->as_C_string(), _class_name->as_C_string());
-        Klass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, s, Handle(THREAD, _loader_data->class_loader()), false, THREAD);
+        log_info(class, preload)("Preloading class %s during loading of class %s. \
+                                  Cause: a null-free non-static field is declared with this type",
+                                  s->as_C_string(), _class_name->as_C_string());
+        Klass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, s,
+                                                                                    Handle(THREAD,
+                                                                                    _loader_data->class_loader()),
+                                                                                    false, THREAD);
         if (HAS_PENDING_EXCEPTION) {
-          log_warning(class, preload)("Preloading of class %s during loading of class %s (cause: null-free non-static field) failed: %s",
-                                      s->as_C_string(), _class_name->as_C_string(), PENDING_EXCEPTION->klass()->name()->as_C_string());
+          log_warning(class, preload)("Preloading of class %s during loading of class %s \
+                                      (cause: null-free non-static field) failed: %s",
+                                      s->as_C_string(), _class_name->as_C_string(),
+                                      PENDING_EXCEPTION->klass()->name()->as_C_string());
           return; // Exception is still pending
         }
         assert(klass != nullptr, "Sanity check");
@@ -6197,26 +6205,38 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
         }
         InlineKlass* vk = InlineKlass::cast(klass);
         _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(vk);
-        log_info(class, preload)("Preloading of class %s during loading of class %s (cause: null-free non-static field) succeeded", s->as_C_string(), _class_name->as_C_string());
+        log_info(class, preload)("Preloading of class %s during loading of class %s \
+                                 (cause: null-free non-static field) succeeded",
+                                 s->as_C_string(), _class_name->as_C_string());
       } else if (Signature::has_envelope(sig)) {
         // Preloading classes for nullable fields that are listed in the LoadableDescriptors attribute
         // Those classes would be required later for the flattening of nullable inline type fields
         TempNewSymbol name = Signature::strip_envelope(sig);
-        if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) {
-          log_info(class, preload)("Preloading class %s during loading of class %s. Cause: field type in LoadableDescriptors attribute", name->as_C_string(), _class_name->as_C_string());
+        if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) { //here
+          log_info(class, preload)("Preloading class %s during loading of class %s. \
+                                   Cause: field type in LoadableDescriptors attribute",
+                                   name->as_C_string(), _class_name->as_C_string());
           oop loader = loader_data()->class_loader();
-          Klass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, name, Handle(THREAD, loader), false, THREAD);
+          Klass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, name,
+                                                                                      Handle(THREAD, loader),
+                                                                                      false, THREAD);
           if (klass != nullptr) {
             if (klass->is_inline_klass()) {
               _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(InlineKlass::cast(klass));
-              log_info(class, preload)("Preloading of class %s during loading of class %s (cause: field type in LoadableDescriptors attribute) succeeded", name->as_C_string(), _class_name->as_C_string());
+              log_info(class, preload)("Preloading of class %s during loading of class %s \
+                                       (cause: field type in LoadableDescriptors attribute) succeeded",
+                                       name->as_C_string(), _class_name->as_C_string());
             } else {
               // Non value class are allowed by the current spec, but it could be an indication of an issue so let's log a warning
-              log_warning(class, preload)("Preloading class %s during loading of class %s (cause: field type in LoadableDescriptors attribute) but loaded class is not a value class", name->as_C_string(), _class_name->as_C_string());
+              log_warning(class, preload)("Preloading class %s during loading of class %s \
+                                          (cause: field type in LoadableDescriptors attribute) but loaded class is not a value class",
+                                          name->as_C_string(), _class_name->as_C_string());
             }
             } else {
-            log_warning(class, preload)("Preloading of class %s during loading of class %s (cause: field type in LoadableDescriptors attribute) failed : %s",
-                                          name->as_C_string(), _class_name->as_C_string(), PENDING_EXCEPTION->klass()->name()->as_C_string());
+            log_warning(class, preload)("Preloading of class %s during loading of class %s \
+                                        (cause: field type in LoadableDescriptors attribute) failed : %s",
+                                        name->as_C_string(), _class_name->as_C_string(),
+                                        PENDING_EXCEPTION->klass()->name()->as_C_string());
           }
           // Loads triggered by the LoadableDescriptors attribute are speculative, failures must not impact loading of current class
           if (HAS_PENDING_EXCEPTION) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6187,7 +6187,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           return; // Exception is still pending
         }
         assert(klass != nullptr, "Sanity check");
-        klass->check_null_free_field(_class_name, CHECK);
+        InstanceKlass::can_be_annotated_with_NullRestricted(klass, _class_name, CHECK);
         InlineKlass* vk = InlineKlass::cast(klass);
         _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(vk);
         log_info(class, preload)("Preloading of class %s during loading of class %s \

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6172,34 +6172,34 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           THROW_MSG(vmSymbols::java_lang_ClassCircularityError(),
                     err_msg("Class %s cannot have a null-free non-static field of its own type", _class_name->as_C_string()));
         }
-        log_info(class, preload)("Preloading class %s during loading of class %s. \
-                                  Cause: a null-free non-static field is declared with this type",
+        log_info(class, preload)("Preloading class %s during loading of class %s. "
+                                  "Cause: a null-free non-static field is declared with this type",
                                   s->as_C_string(), _class_name->as_C_string());
         InstanceKlass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, s,
-                                                                                    Handle(THREAD,
-                                                                                    _loader_data->class_loader()),
-                                                                                    false, THREAD);
+                                                                                            Handle(THREAD,
+                                                                                            _loader_data->class_loader()),
+                                                                                            false, THREAD);
         if (HAS_PENDING_EXCEPTION) {
-          log_warning(class, preload)("Preloading of class %s during loading of class %s \
-                                      (cause: null-free non-static field) failed: %s",
+          log_warning(class, preload)("Preloading of class %s during loading of class %s "
+                                      "(cause: null-free non-static field) failed: %s",
                                       s->as_C_string(), _class_name->as_C_string(),
                                       PENDING_EXCEPTION->klass()->name()->as_C_string());
           return; // Exception is still pending
         }
         assert(klass != nullptr, "Sanity check");
-        InstanceKlass::can_be_annotated_with_NullRestricted(klass, _class_name, CHECK);
+        InstanceKlass::check_can_be_annotated_with_NullRestricted(klass, _class_name, CHECK);
         InlineKlass* vk = InlineKlass::cast(klass);
         _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(vk);
-        log_info(class, preload)("Preloading of class %s during loading of class %s \
-                                 (cause: null-free non-static field) succeeded",
+        log_info(class, preload)("Preloading of class %s during loading of class %s "
+                                 "(cause: null-free non-static field) succeeded",
                                  s->as_C_string(), _class_name->as_C_string());
       } else if (Signature::has_envelope(sig)) {
         // Preloading classes for nullable fields that are listed in the LoadableDescriptors attribute
         // Those classes would be required later for the flattening of nullable inline type fields
         TempNewSymbol name = Signature::strip_envelope(sig);
         if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) {
-          log_info(class, preload)("Preloading class %s during loading of class %s. \
-                                   Cause: field type in LoadableDescriptors attribute",
+          log_info(class, preload)("Preloading class %s during loading of class %s. "
+                                   "Cause: field type in LoadableDescriptors attribute",
                                    name->as_C_string(), _class_name->as_C_string());
           oop loader = loader_data()->class_loader();
           Klass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, name,
@@ -6208,18 +6208,18 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           if (klass != nullptr) {
             if (klass->is_inline_klass()) {
               _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(InlineKlass::cast(klass));
-              log_info(class, preload)("Preloading of class %s during loading of class %s \
-                                       (cause: field type in LoadableDescriptors attribute) succeeded",
+              log_info(class, preload)("Preloading of class %s during loading of class %s "
+                                       "(cause: field type in LoadableDescriptors attribute) succeeded",
                                        name->as_C_string(), _class_name->as_C_string());
             } else {
               // Non value class are allowed by the current spec, but it could be an indication of an issue so let's log a warning
-              log_warning(class, preload)("Preloading class %s during loading of class %s \
-                                          (cause: field type in LoadableDescriptors attribute) but loaded class is not a value class",
+              log_warning(class, preload)("Preloading class %s during loading of class %s "
+                                          "(cause: field type in LoadableDescriptors attribute) but loaded class is not a value class",
                                           name->as_C_string(), _class_name->as_C_string());
             }
             } else {
-            log_warning(class, preload)("Preloading of class %s during loading of class %s \
-                                        (cause: field type in LoadableDescriptors attribute) failed : %s",
+            log_warning(class, preload)("Preloading of class %s during loading of class %s "
+                                        "(cause: field type in LoadableDescriptors attribute) failed : %s",
                                         name->as_C_string(), _class_name->as_C_string(),
                                         PENDING_EXCEPTION->klass()->name()->as_C_string());
           }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1078,24 +1078,31 @@ bool SystemDictionary::check_shared_class_super_types(InstanceKlass* ik, Handle 
 // Pre-load class referred to in non-static null-free instance field. These fields trigger MANDATORY loading
 bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
-  log_info(class, preload)("Preloading class %s during loading of shared class %s. Cause: a null-free non-static field is declared with this type",
+  log_info(class, preload)("Preloading class %s during loading of shared class %s. \
+                           Cause: a null-free non-static field is declared with this type",
                            name->as_C_string(), ik->name()->as_C_string());
   Klass* real_k = SystemDictionary::resolve_with_circularity_detection_or_fail(ik->name(), name,
                                                                                class_loader, false, CHECK_false);
   if (HAS_PENDING_EXCEPTION) {
-    log_warning(class, preload)("Preloading of class %s during loading of class %s (cause: null-free non-static field) failed: %s",
-                                name->as_C_string(), ik->name()->as_C_string(), PENDING_EXCEPTION->klass()->name()->as_C_string());
+    log_warning(class, preload)("Preloading of class %s during loading of class %s \
+                                (cause: null-free non-static field) failed: %s",
+                                name->as_C_string(), ik->name()->as_C_string(),
+                                PENDING_EXCEPTION->klass()->name()->as_C_string());
     return false; // Exception is still pending
   }
 
   Klass* k = ik->get_inline_type_field_klass_or_null(field_index);
   if (real_k != k) {
     // oops, the app has substituted a different version of k!
-    log_warning(class, preload)("Preloading of class %s during loading of shared class %s (cause: null-free non-static field) failed : app substituted a different version of %s",
-                                name->as_C_string(), ik->name()->as_C_string(), k->name()->as_C_string());
+    log_warning(class, preload)("Preloading of class %s during loading of shared class %s \
+                                (cause: null-free non-static field) failed : \
+                                app substituted a different version of %s",
+                                name->as_C_string(), ik->name()->as_C_string(),
+                                k->name()->as_C_string());
     return false;
   }
-  log_info(class, preload)("Preloading of class %s during loading of shared class %s (cause: null-free non-static field) succeeded",
+  log_info(class, preload)("Preloading of class %s during loading of shared class %s \
+                           (cause: null-free non-static field) succeeded",
                            name->as_C_string(), ik->name()->as_C_string());
 
   assert(real_k != nullptr, "Sanity check");
@@ -1138,11 +1145,15 @@ void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, 
     Klass* k = ik->get_inline_type_field_klass_or_null(field_index);
     if (real_k != k) {
       // oops, the app has substituted a different version of k!
-      log_warning(class, preload)("Preloading of class %s during loading of shared class %s (cause: field type in LoadableDescriptors attribute) failed : app substituted a different version of %s",
-                                  name->as_C_string(), ik->name()->as_C_string(), k->name()->as_C_string());
+      log_warning(class, preload)("Preloading of class %s during loading of shared class %s \
+                                  (cause: field type in LoadableDescriptors attribute) failed : \
+                                  app substituted a different version of %s",
+                                  name->as_C_string(), ik->name()->as_C_string(),
+                                  k->name()->as_C_string());
       return;
     } else if (real_k != nullptr) {
-      log_info(class, preload)("Preloading of class %s during loading of shared class %s (cause: field type in LoadableDescriptors attribute) succeeded",
+      log_info(class, preload)("Preloading of class %s during loading of shared class %s \
+                               (cause: field type in LoadableDescriptors attribute) succeeded",
                                 name->as_C_string(), ik->name()->as_C_string());
     }
   }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1075,7 +1075,7 @@ bool SystemDictionary::check_shared_class_super_types(InstanceKlass* ik, Handle 
   return true;
 }
 
-// Pre-load inline class
+// Pre-load class referred to in non-static null-free instance field. These fields trigger MANDATORY loading
 bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
   log_info(class, preload)("Preloading class %s during loading of shared class %s. Cause: a null-free non-static field is declared with this type",
@@ -1122,7 +1122,8 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
   return true;
 }
 
-
+// Tries to pre-load classes referred to in non-static nullable instance fields if they are found in the
+// loadable descriptors attribute. If loading fails, we can fail silently.
 void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
   if (name != ik->name() && ik->is_class_in_loadable_descriptors_attribute(sig)) {

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1079,14 +1079,14 @@ bool SystemDictionary::check_shared_class_super_types(InstanceKlass* ik, Handle 
 // Some pre-loading does not fail fatally
 bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
-  log_info(class, preload)("Preloading class %s during loading of shared class %s. \
-                           Cause: a null-free non-static field is declared with this type",
+  log_info(class, preload)("Preloading class %s during loading of shared class %s. "
+                           "Cause: a null-free non-static field is declared with this type",
                            name->as_C_string(), ik->name()->as_C_string());
   InstanceKlass* real_k = SystemDictionary::resolve_with_circularity_detection_or_fail(ik->name(), name,
                                                                                class_loader, false, CHECK_false);
   if (HAS_PENDING_EXCEPTION) {
-    log_warning(class, preload)("Preloading of class %s during loading of class %s \
-                                (cause: null-free non-static field) failed: %s",
+    log_warning(class, preload)("Preloading of class %s during loading of class %s "
+                                "(cause: null-free non-static field) failed: %s",
                                 name->as_C_string(), ik->name()->as_C_string(),
                                 PENDING_EXCEPTION->klass()->name()->as_C_string());
     return false; // Exception is still pending
@@ -1095,19 +1095,19 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
   InstanceKlass* k = ik->get_inline_type_field_klass_or_null(field_index);
   if (real_k != k) {
     // oops, the app has substituted a different version of k! Does not fail fatally
-    log_warning(class, preload)("Preloading of class %s during loading of shared class %s \
-                                (cause: null-free non-static field) failed : \
-                                app substituted a different version of %s",
+    log_warning(class, preload)("Preloading of class %s during loading of shared class %s "
+                                "(cause: null-free non-static field) failed : "
+                                "app substituted a different version of %s",
                                 name->as_C_string(), ik->name()->as_C_string(),
                                 name->as_C_string());
     return false;
   }
-  log_info(class, preload)("Preloading of class %s during loading of shared class %s \
-                           (cause: null-free non-static field) succeeded",
+  log_info(class, preload)("Preloading of class %s during loading of shared class %s "
+                           "(cause: null-free non-static field) succeeded",
                            name->as_C_string(), ik->name()->as_C_string());
 
   assert(real_k != nullptr, "Sanity check");
-  InstanceKlass::can_be_annotated_with_NullRestricted(real_k, ik->name(), CHECK_false);
+  InstanceKlass::check_can_be_annotated_with_NullRestricted(real_k, ik->name(), CHECK_false);
 
   return true;
 }
@@ -1117,8 +1117,8 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
 void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
   if (name != ik->name() && ik->is_class_in_loadable_descriptors_attribute(sig)) {
-    log_info(class, preload)("Preloading class %s during loading of shared class %s. \
-                             Cause: field type in LoadableDescriptors attribute",
+    log_info(class, preload)("Preloading class %s during loading of shared class %s. "
+                             "Cause: field type in LoadableDescriptors attribute",
                              name->as_C_string(), ik->name()->as_C_string());
     InstanceKlass* real_k = SystemDictionary::resolve_with_circularity_detection_or_fail(ik->name(), name,
                                                                                  class_loader, false, THREAD);
@@ -1129,15 +1129,15 @@ void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, 
     InstanceKlass* k = ik->get_inline_type_field_klass_or_null(field_index);
     if (real_k != k) {
       // oops, the app has substituted a different version of k!
-      log_warning(class, preload)("Preloading of class %s during loading of shared class %s \
-                                  (cause: field type in LoadableDescriptors attribute) failed : \
-                                  app substituted a different version of %s",
+      log_warning(class, preload)("Preloading of class %s during loading of shared class %s "
+                                  "(cause: field type in LoadableDescriptors attribute) failed : "
+                                  "app substituted a different version of %s",
                                   name->as_C_string(), ik->name()->as_C_string(),
                                   k->name()->as_C_string());
       return;
     } else if (real_k != nullptr) {
-      log_info(class, preload)("Preloading of class %s during loading of shared class %s \
-                               (cause: field type in LoadableDescriptors attribute) succeeded",
+      log_info(class, preload)("Preloading of class %s during loading of shared class %s "
+                               "(cause: field type in LoadableDescriptors attribute) succeeded",
                                 name->as_C_string(), ik->name()->as_C_string());
     }
   }
@@ -1175,6 +1175,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
       int field_index = fs.index();
 
       if (fs.is_null_free_inline_type()) {
+        // A false return means that the class didn't load for other reasons than an exception.
         bool check = preload_from_null_free_field(ik, class_loader, sig, field_index, CHECK_NULL);
         if (!check) {
           ik->set_shared_loading_failed();

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1107,7 +1107,7 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
                            name->as_C_string(), ik->name()->as_C_string());
 
   assert(real_k != nullptr, "Sanity check");
-  real_k->check_null_free_field(ik->name(), CHECK_false);
+  InstanceKlass::can_be_annotated_with_NullRestricted(real_k, ik->name(), CHECK_false);
 
   return true;
 }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1099,7 +1099,7 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
                                 (cause: null-free non-static field) failed : \
                                 app substituted a different version of %s",
                                 name->as_C_string(), ik->name()->as_C_string(),
-                                k->name()->as_C_string());
+                                name->as_C_string());
     return false;
   }
   log_info(class, preload)("Preloading of class %s during loading of shared class %s \
@@ -1107,7 +1107,7 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
                            name->as_C_string(), ik->name()->as_C_string());
 
   assert(real_k != nullptr, "Sanity check");
-  real_k->check_null_free_field(ik, CHECK_false);
+  real_k->check_null_free_field(ik->name(), CHECK_false);
 
   return true;
 }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1174,8 +1174,10 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
   if (ik->has_inline_type_fields()) {
     for (AllFieldStream fs(ik); !fs.done(); fs.next()) {
       if (fs.access_flags().is_static()) continue;
+
       Symbol* sig = fs.signature();
       int field_index = fs.index();
+
       if (fs.is_null_free_inline_type()) {
         bool check = preload_from_null_free_field(ik, class_loader, sig, field_index, CHECK_NULL);
         if (!check) {

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1134,8 +1134,9 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
 void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
   if (name != ik->name() && ik->is_class_in_loadable_descriptors_attribute(sig)) {
-    log_info(class, preload)("Preloading class %s during loading of shared class %s. Cause: field type in LoadableDescriptors attribute",
-                              name->as_C_string(), ik->name()->as_C_string());
+    log_info(class, preload)("Preloading class %s during loading of shared class %s. \
+                             Cause: field type in LoadableDescriptors attribute",
+                             name->as_C_string(), ik->name()->as_C_string());
     Klass* real_k = SystemDictionary::resolve_with_circularity_detection_or_fail(ik->name(), name,
                                                                                  class_loader, false, THREAD);
     if (HAS_PENDING_EXCEPTION) {

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -334,6 +334,8 @@ protected:
   static bool add_loader_constraint(Symbol* name, Klass* klass_being_linked,  Handle loader1,
                                     Handle loader2);
   static void post_class_load_event(EventClassLoad* event, const InstanceKlass* k, const ClassLoaderData* init_cld);
+  static bool preload_from_null_free_field(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS);
+  static void try_preload_from_loadable_descriptors(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS);
   static InstanceKlass* load_shared_class(InstanceKlass* ik,
                                           Handle class_loader,
                                           Handle protection_domain,

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3591,23 +3591,22 @@ bool InstanceKlass::find_inner_classes_attr(int* ooff, int* noff, TRAPS) const {
   return false;
 }
 
-void InstanceKlass::check_null_free_field(Symbol* container_klass_name, TRAPS) {
-  if (access_flags().is_identity_class()) {
-    assert(is_instance_klass(), "Sanity check");
+void InstanceKlass::can_be_annotated_with_NullRestricted(InstanceKlass* type, Symbol* container_klass_name, TRAPS) {
+  assert(type->is_instance_klass(), "Sanity check");
+  if (type->access_flags().is_identity_class()) {
     ResourceMark rm(THREAD);
     THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
               err_msg("Class %s expects class %s to be a value class, but it is an identity class",
               container_klass_name->as_C_string(),
-              external_name()));
+              type->external_name()));
   }
 
-  if (is_abstract()) {
-    assert(is_instance_klass(), "Sanity check");
+  if (type->is_abstract()) {
     ResourceMark rm(THREAD);
     THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
               err_msg("Class %s expects class %s to be concrete value type, but it is an abstract class",
               container_klass_name->as_C_string(),
-              external_name()));
+              type->external_name()));
   }
 }
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3591,6 +3591,26 @@ bool InstanceKlass::find_inner_classes_attr(int* ooff, int* noff, TRAPS) const {
   return false;
 }
 
+void InstanceKlass::check_null_free_field(InstanceKlass* ik, TRAPS) {
+  if (access_flags().is_identity_class()) {
+    assert(is_instance_klass(), "Sanity check");
+    ResourceMark rm(THREAD);
+    THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
+              err_msg("Class %s expects class %s to be a value class, but it is an identity class",
+              ik->name()->as_C_string(),
+              external_name()));
+  }
+
+  if (is_abstract()) {
+    assert(is_instance_klass(), "Sanity check");
+    ResourceMark rm(THREAD);
+    THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
+              err_msg("Class %s expects class %s to be concrete value type, but it is an abstract class",
+              ik->name()->as_C_string(),
+              external_name()));
+  }
+}
+
 InstanceKlass* InstanceKlass::compute_enclosing_class(bool* inner_is_member, TRAPS) const {
   InstanceKlass* outer_klass = nullptr;
   *inner_is_member = false;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3591,13 +3591,13 @@ bool InstanceKlass::find_inner_classes_attr(int* ooff, int* noff, TRAPS) const {
   return false;
 }
 
-void InstanceKlass::check_null_free_field(InstanceKlass* ik, TRAPS) {
+void InstanceKlass::check_null_free_field(Symbol* container_klass_name, TRAPS) {
   if (access_flags().is_identity_class()) {
     assert(is_instance_klass(), "Sanity check");
     ResourceMark rm(THREAD);
     THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
               err_msg("Class %s expects class %s to be a value class, but it is an identity class",
-              ik->name()->as_C_string(),
+              container_klass_name->as_C_string(),
               external_name()));
   }
 
@@ -3606,7 +3606,7 @@ void InstanceKlass::check_null_free_field(InstanceKlass* ik, TRAPS) {
     ResourceMark rm(THREAD);
     THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
               err_msg("Class %s expects class %s to be concrete value type, but it is an abstract class",
-              ik->name()->as_C_string(),
+              container_klass_name->as_C_string(),
               external_name()));
   }
 }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3591,7 +3591,7 @@ bool InstanceKlass::find_inner_classes_attr(int* ooff, int* noff, TRAPS) const {
   return false;
 }
 
-void InstanceKlass::can_be_annotated_with_NullRestricted(InstanceKlass* type, Symbol* container_klass_name, TRAPS) {
+void InstanceKlass::check_can_be_annotated_with_NullRestricted(InstanceKlass* type, Symbol* container_klass_name, TRAPS) {
   assert(type->is_instance_klass(), "Sanity check");
   if (type->access_flags().is_identity_class()) {
     ResourceMark rm(THREAD);

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -593,7 +593,7 @@ public:
   bool find_inner_classes_attr(int* ooff, int* noff, TRAPS) const;
 
   // Check if this klass can be null-free
-  void check_null_free_field(InstanceKlass* ik, TRAPS);
+  void check_null_free_field(Symbol* container_klass_name, TRAPS);
 
  private:
   // Check prohibited package ("java/" only loadable by boot or platform loaders)

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -593,7 +593,7 @@ public:
   bool find_inner_classes_attr(int* ooff, int* noff, TRAPS) const;
 
   // Check if this klass can be null-free
-  void check_null_free_field(Symbol* container_klass_name, TRAPS);
+  static void can_be_annotated_with_NullRestricted(InstanceKlass* type, Symbol* container_klass_name, TRAPS);
 
  private:
   // Check prohibited package ("java/" only loadable by boot or platform loaders)

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -593,7 +593,7 @@ public:
   bool find_inner_classes_attr(int* ooff, int* noff, TRAPS) const;
 
   // Check if this klass can be null-free
-  static void can_be_annotated_with_NullRestricted(InstanceKlass* type, Symbol* container_klass_name, TRAPS);
+  static void check_can_be_annotated_with_NullRestricted(InstanceKlass* type, Symbol* container_klass_name, TRAPS);
 
  private:
   // Check prohibited package ("java/" only loadable by boot or platform loaders)

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -592,6 +592,9 @@ public:
   // Find InnerClasses attribute and return outer_class_info_index & inner_name_index.
   bool find_inner_classes_attr(int* ooff, int* noff, TRAPS) const;
 
+  // Check if this klass can be null-free
+  void check_null_free_field(InstanceKlass* ik, TRAPS);
+
  private:
   // Check prohibited package ("java/" only loadable by boot or platform loaders)
   static void check_prohibited_package(Symbol* class_name,

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -133,7 +133,6 @@ runtime/valhalla/inlinetypes/CircularityTest.java 8349037 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java CODETOOLS-7904031 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictStaticFieldsTest.java CODETOOLS-7904031 generic-all
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java 8357785 generic-all
-runtime/cds/appcds/RewriteBytecodesInlineTest.java 8361082 generic-all
 
 # Valhalla + COH
 compiler/c2/autovectorization/TestIndexOverflowIR.java                          8348568 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -133,7 +133,6 @@ runtime/valhalla/inlinetypes/CircularityTest.java 8349037 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java CODETOOLS-7904031 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictStaticFieldsTest.java CODETOOLS-7904031 generic-all
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java 8357785 generic-all
-runtime/cds/appcds/RewriteBytecodesInlineTest.java 8361082 generic-all
 compiler/gcbarriers/TestG1BarrierGeneration.java 8361166 generic-all
 
 # Valhalla + COH


### PR DESCRIPTION
`RewriteBytecodesInlineTest` fails after # due to a new log message printing the pending exception name even though there may not be a pending exception:
`PENDING_EXCEPTION->klass()->name()->as_C_string()`

This patch refactors the loadable descriptor handling used in `SystemDictionary::load_shared_class` to better illustrate how the loadable descriptors property is handled and it corrects the log messages to be consistent with the messages used in the class file parser. Verified with tier 1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8361082](https://bugs.openjdk.org/browse/JDK-8361082): [lworld] RewriteBytecodesInlineTest fails with SIGSEGV (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1498/head:pull/1498` \
`$ git checkout pull/1498`

Update a local copy of the PR: \
`$ git checkout pull/1498` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1498`

View PR using the GUI difftool: \
`$ git pr show -t 1498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1498.diff">https://git.openjdk.org/valhalla/pull/1498.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1498#issuecomment-3028565663)
</details>
