### PR TITLE
8361369: [lworld] Treating primitives as isValue() leads to vm crash

### DIFF
--- a/src/java.base/share/classes/jdk/internal/value/LayoutIteration.java
+++ b/src/java.base/share/classes/jdk/internal/value/LayoutIteration.java
@@ -63,7 +63,7 @@ public final class LayoutIteration {
      * @throws IllegalArgumentException if argument has no flat layout
      */
     public static List<MethodHandle> computeElementGetters(Class<?> flatType) {
-        if (!canHaveFlatLayout(flatType))
+        if (!isFinalValueClass(flatType))
             throw new IllegalArgumentException(flatType + " cannot be flat");
         var sink = new Sink(flatType);
         iterateFields(U.valueHeaderSize(flatType), flatType, sink);
@@ -71,8 +71,8 @@ public final class LayoutIteration {
     }
 
     // Ensures the given class has a potential a flat layout
-    private static boolean canHaveFlatLayout(Class<?> flatType) {
-        return flatType.isValue() && Modifier.isFinal(flatType.getModifiers());
+    public static boolean isFinalValueClass(Class<?> flatType) {
+        return !flatType.isPrimitive() && flatType.isValue() && Modifier.isFinal(flatType.getModifiers());
     }
 
     private static final class Sink {
@@ -94,7 +94,7 @@ public final class LayoutIteration {
 
     // Sink is good for one to many mappings
     private static void iterateFields(long enclosingOffset, Class<?> currentClass, Sink sink) {
-        assert canHaveFlatLayout(currentClass) : currentClass + " cannot be flat";
+        assert isFinalValueClass(currentClass) : currentClass + " cannot be flat";
         long memberOffsetDelta = enclosingOffset - U.valueHeaderSize(currentClass);
         for (Field f : currentClass.getDeclaredFields()) {
             if (Modifier.isStatic(f.getModifiers()))


### PR DESCRIPTION
Need to update the checking logic. Culprit is the filter in valueTypeFields. Tested by running jshell.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8361369](https://bugs.openjdk.org/browse/JDK-8361369): [lworld] Treating primitives as isValue() leads to vm crash (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1500/head:pull/1500` \
`$ git checkout pull/1500`

Update a local copy of the PR: \
`$ git checkout pull/1500` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1500`

View PR using the GUI difftool: \
`$ git pr show -t 1500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1500.diff">https://git.openjdk.org/valhalla/pull/1500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1500#issuecomment-3033395285)
</details>
