### PR TITLE
8361390: [lworld] Assert during C2 compilation because EA does not properly handle null-free arrays

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -2805,8 +2805,7 @@ int ConnectionGraph::find_init_values_phantom(JavaObjectNode* pta) {
   // "known" unless they are initialized by arraycopy/clone.
   if (alloc->is_Allocate() && !pta->arraycopy_dst()) {
     if (alloc->as_Allocate()->in(AllocateNode::InitValue) != nullptr) {
-      // Non-flat inline type arrays are initialized with
-      // an init value instead of null. Handle them here.
+      // Null-free inline type arrays are initialized with an init value instead of null
       init_val = ptnode_adr(alloc->as_Allocate()->in(AllocateNode::InitValue)->_idx);
       assert(init_val != nullptr, "init value should be registered");
     } else {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -394,7 +394,8 @@ Node *PhaseMacroExpand::value_from_mem_phi(Node *mem, BasicType ft, const Type *
         Node* init_value = alloc->in(AllocateNode::InitValue);
         if (init_value != nullptr) {
           if (val == start_mem) {
-            // TODO 8350865 Somehow we ended up with root mem and therefore walked past the alloc. Fix this. Triggered by TestGenerated::test15
+            // TODO 8350865 Scalar replacement does not work well for flat arrays.
+            // Somehow we ended up with root mem and therefore walked past the alloc. Fix this. Triggered by TestGenerated::test15
             // Don't we need field_value_by_offset?
             return nullptr;
           }
@@ -424,7 +425,8 @@ Node *PhaseMacroExpand::value_from_mem_phi(Node *mem, BasicType ft, const Type *
       } else if (val->is_Proj() && val->in(0) == alloc) {
         Node* init_value = alloc->in(AllocateNode::InitValue);
         if (init_value != nullptr) {
-          // TODO 8350865 Is this correct for non-all-zero init values? Don't we need field_value_by_offset?
+          // TODO 8350865 Scalar replacement does not work well for flat arrays.
+          // Is this correct for non-all-zero init values? Don't we need field_value_by_offset?
           values.at_put(j, init_value);
         } else {
           assert(alloc->in(AllocateNode::RawInitValue) == nullptr, "init value may not be null");

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
@@ -32,8 +32,8 @@ public class InlineTypeRegexes {
     public static final String ALLOC_G = "(.*call,static.*wrapper for: C2 Runtime new_instance" + END;
     public static final String ALLOCA_G = "(.*call,static.*wrapper for: C2 Runtime new_array" + END;
     // Inline type allocation
-    public static final String MYVALUE_ARRAY_KLASS = "\\[(precise )?compiler/valhalla/inlinetypes/MyValue";
-    public static final String ALLOC = "(.*precise compiler/valhalla/inlinetypes/MyValue.*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*C2 Runtime new_instance" + END;
+    public static final String MYVALUE_ARRAY_KLASS = "\\[(precise )?compiler/valhalla/inlinetypes/.*MyValue";
+    public static final String ALLOC = "(.*precise compiler/valhalla/inlinetypes/.*MyValue.*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*C2 Runtime new_instance" + END;
     public static final String ALLOCA = "(.*" + MYVALUE_ARRAY_KLASS + ".*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*C2 Runtime new_array" + END;
     public static final String LOAD = START + "Load(B|C|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/.*" + END;
     public static final String LOADK = START + "LoadK" + MID + END;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -3651,4 +3651,70 @@ public class TestArrays {
     public void test151_verifier() {
         Asserts.assertEquals(Test151Value.DEFAULT, test151(rI & 15));
     }
+
+    // Make sure this can't be flattened
+    static value class MyValue152Inline {
+        long l1 = rL;
+        long l2 = rL;
+    }
+
+    @LooselyConsistentValue
+    static value class MyValue152 {
+        double d = rD;
+
+        @Strict
+        @NullRestricted
+        MyValue152Inline val = new MyValue152Inline(); // Not flat
+    }
+
+    // Test that EA works for null-free arrays
+    @Test
+    // TODO 8350865 Scalar replacement does not work well for flat arrays
+    //@IR(applyIf = {"InlineTypeReturnedAsFields", "true"},
+    //    failOn = {ALLOC, ALLOCA})
+    public MyValue152 test152() {
+        MyValue152[] array = (MyValue152[])ValueClass.newNullRestrictedNonAtomicArray(MyValue152.class, 1, new MyValue152());
+        return array[0];
+    }
+
+    @Run(test = "test152")
+    public void test152_verifier() {
+        Asserts.assertEquals(test152(), new MyValue152());
+    }
+
+    @LooselyConsistentValue
+    static value class MyValue153 {
+        @Strict
+        @NullRestricted
+        MyValue152Inline val = new MyValue152Inline(); // Not flat
+    }
+
+    // Same as test152 but triggers a slightly different asserts
+    @Test
+    // TODO 8350865 Scalar replacement does not work well for flat arrays
+    //@IR(applyIf = {"InlineTypeReturnedAsFields", "true"},
+    //    failOn = {ALLOC, ALLOCA})
+    public MyValue153 test153() {
+        MyValue153[] array = (MyValue153[])ValueClass.newNullRestrictedNonAtomicArray(MyValue153.class, 1, new MyValue153());
+        return array[0];
+    }
+
+    @Run(test = "test153")
+    public void test153_verifier() {
+        Asserts.assertEquals(test153(), new MyValue153());
+    }
+
+    // Same as test152 but triggers an incorrect result
+    @Test
+    // TODO 8350865 Scalar replacement does not work well for flat arrays
+    //@IR(failOn = {ALLOC, ALLOCA_G, LOAD, STORE, TRAP})
+    public double test154() {
+        MyValue152[] array = (MyValue152[])ValueClass.newNullRestrictedNonAtomicArray(MyValue152.class, 1, new MyValue152());
+        return array[0].d;
+    }
+
+    @Run(test = "test154")
+    public void test154_verifier() {
+        Asserts.assertEquals(test154(), rD);
+    }
 }


### PR DESCRIPTION
While doing some stress testing by disabling pre-loading of value classes, I found more cases when EA does not properly handle null-free arrays. This issue is already tracked by [JDK-8350865](https://bugs.openjdk.org/browse/JDK-8350865) and I simply modified the hacky bailout code in `LoadNode::Value` to cover the newly found cases for now. I added corresponding tests that also trigger this with preloading. The full fix will be done by [JDK-8350865](https://bugs.openjdk.org/browse/JDK-8350865) (most likely I'll split that RFE into subtasks).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8361390](https://bugs.openjdk.org/browse/JDK-8361390): [lworld] Assert during C2 compilation because EA does not properly handle null-free arrays (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1501/head:pull/1501` \
`$ git checkout pull/1501`

Update a local copy of the PR: \
`$ git checkout pull/1501` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1501`

View PR using the GUI difftool: \
`$ git pr show -t 1501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1501.diff">https://git.openjdk.org/valhalla/pull/1501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1501#issuecomment-3034912112)
</details>
