### PR TITLE
8361496: [lworld] Treating interfaces as isValue() leads to failed assert

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -333,18 +333,20 @@ public final class Class<T> implements java.io.Serializable,
                 if (isAnnotation()) {
                     sb.append('@');
                 }
-                if (isValue()) {
-                    sb.append("value ");
-                }
                 if (isInterface()) { // Note: all annotation interfaces are interfaces
                     sb.append("interface");
                 } else {
                     if (isEnum())
                         sb.append("enum");
-                    else if (isRecord())
-                        sb.append("record");
-                    else
-                        sb.append("class");
+                    else {
+                        if (isValue()) {
+                            sb.append("value ");
+                        }
+                        if (isRecord())
+                            sb.append("record");
+                        else
+                            sb.append("class");
+                    }
                 }
                 sb.append(' ');
                 sb.append(getName());

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -638,9 +638,7 @@ public final class Class<T> implements java.io.Serializable,
         if (!PreviewFeatures.isEnabled()) {
             return false;
         }
-         if (isPrimitive() || isArray() || isInterface())
-             return false;
-        return ((getModifiers() & Modifier.IDENTITY) == 0);
+        return !isIdentity();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import jdk.internal.constant.ClassOrInterfaceDescImpl;
 import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.misc.CDS;
 import jdk.internal.util.ClassFileDumper;
+import jdk.internal.value.ValueClass;
 import sun.invoke.util.VerifyAccess;
 
 import java.io.Serializable;
@@ -596,7 +597,7 @@ import sun.invoke.util.Wrapper;
         }
 
         boolean requiresLoadableDescriptors(Class<?> cls) {
-            return cls.isValue() && cls.accessFlags().contains(AccessFlag.FINAL);
+            return ValueClass.isValueObjectInstance(cls);
         }
 
         boolean isEmpty() {

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -50,6 +50,7 @@ import java.util.stream.Stream;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.value.LayoutIteration;
+import jdk.internal.value.ValueClass;
 import sun.invoke.util.Wrapper;
 
 import static java.lang.invoke.MethodHandles.constant;
@@ -135,7 +136,7 @@ final class ValueObjectMethods {
         private static List<Class<?>> valueTypeFields(Class<?> type) {
             return LayoutIteration.ELEMENTS.get(type).stream()
                     .<Class<?>>map(mh -> mh.type().returnType())
-                    .filter(cl -> !cl.isPrimitive() && cl.isValue())
+                    .filter(ValueClass::isValueObjectInstance)
                     .distinct()
                     .toList();
         }
@@ -169,7 +170,7 @@ final class ValueObjectMethods {
          * fields of the two value objects are substitutable. The method type is (V, V)boolean
          */
         static MethodHandle valueTypeEquals(Class<?> type, List<MethodHandle> getters) {
-            assert LayoutIteration.isFinalValueClass(type);
+            assert ValueClass.isValueObjectInstance(type);
 
             MethodType mt = methodType(boolean.class, type, type);
             MethodHandle instanceTrue = dropArguments(TRUE, 0, type, Object.class).asType(mt);
@@ -197,7 +198,7 @@ final class ValueObjectMethods {
          * The method type is (V)int.
          */
         static MethodHandle valueTypeHashCode(Class<?> type, List<MethodHandle> getters) {
-            assert LayoutIteration.isFinalValueClass(type);
+            assert ValueClass.isValueObjectInstance(type);
 
             MethodHandle target = dropArguments(constant(int.class, SALT), 0, type);
             MethodHandle classHasher = dropArguments(hashCodeForType(Class.class).bindTo(type), 0, type);
@@ -366,7 +367,7 @@ final class ValueObjectMethods {
         }
 
         static MethodHandleBuilder newBuilder(Class<?> type) {
-            assert LayoutIteration.isFinalValueClass(type);
+            assert ValueClass.isValueObjectInstance(type);
 
             Deque<Class<?>> deque = new ArrayDeque<>();
             deque.add(type);
@@ -415,7 +416,7 @@ final class ValueObjectMethods {
          * @param visited a map of a visited type to a builder
          */
         private MethodHandleBuilder(Class<?> type, Deque<Class<?>> path, Map<Class<?>, MethodHandleBuilder> visited) {
-            assert LayoutIteration.isFinalValueClass(type) : type;
+            assert ValueClass.isValueObjectInstance(type) : type;
             this.type = type;
             this.fieldValueTypes = valueTypeFields(type);
             this.path = path;
@@ -1169,7 +1170,7 @@ final class ValueObjectMethods {
         if (type.isPrimitive()) {
             return MethodHandleBuilder.builtinPrimitiveSubstitutable(type);
         }
-        if (type.isValue()) {
+        if (ValueClass.isValueObjectInstance(type)) {
             return SUBST_TEST_METHOD_HANDLES.get(type);
         }
         return MethodHandleBuilder.referenceTypeEquals(type);

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -3507,7 +3507,7 @@ public final class Arrays {
     public static <T,U> T[] copyOf(U[] original, int newLength, Class<? extends T[]> newType) {
         Class<?> componentType = newType.getComponentType();
         Object tmp = null;
-        if (original.getClass() == newType && componentType.isValue()) {
+        if (original.getClass() == newType && ValueClass.isValueObjectInstance(componentType)) {
             tmp = ValueClass.copyOfSpecialArray((Object[])original, 0, newLength);
         } else {
             tmp = ((Object)newType == (Object)Object[].class)
@@ -3813,7 +3813,7 @@ public final class Arrays {
         }
         Class<?> componentType = newType.getComponentType();
         Object tmp = null;
-        if (original.getClass() == newType && componentType.isValue()) {
+        if (original.getClass() == newType && ValueClass.isValueObjectInstance(componentType)) {
             tmp = ValueClass.copyOfSpecialArray((Object[])original, from, to);
         } else {
             tmp = ((Object)newType == (Object)Object[].class)

--- a/src/java.base/share/classes/jdk/internal/value/LayoutIteration.java
+++ b/src/java.base/share/classes/jdk/internal/value/LayoutIteration.java
@@ -63,16 +63,11 @@ public final class LayoutIteration {
      * @throws IllegalArgumentException if argument has no flat layout
      */
     public static List<MethodHandle> computeElementGetters(Class<?> flatType) {
-        if (!isFinalValueClass(flatType))
+        if (!ValueClass.isValueObjectInstance(flatType))
             throw new IllegalArgumentException(flatType + " cannot be flat");
         var sink = new Sink(flatType);
         iterateFields(U.valueHeaderSize(flatType), flatType, sink);
         return List.copyOf(sink.getters);
-    }
-
-    // Ensures the given class has a potential a flat layout
-    public static boolean isFinalValueClass(Class<?> flatType) {
-        return !flatType.isPrimitive() && flatType.isValue() && Modifier.isFinal(flatType.getModifiers());
     }
 
     private static final class Sink {
@@ -94,7 +89,7 @@ public final class LayoutIteration {
 
     // Sink is good for one to many mappings
     private static void iterateFields(long enclosingOffset, Class<?> currentClass, Sink sink) {
-        assert isFinalValueClass(currentClass) : currentClass + " cannot be flat";
+        assert ValueClass.isValueObjectInstance(currentClass) : currentClass + " cannot be flat";
         long memberOffsetDelta = enclosingOffset - U.valueHeaderSize(currentClass);
         for (Field f : currentClass.getDeclaredFields()) {
             if (Modifier.isStatic(f.getModifiers()))

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -29,14 +29,26 @@ import jdk.internal.access.JavaLangReflectAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 /**
  * Utilities to access package private methods of java.lang.Class and related reflection classes.
  */
-public class ValueClass {
+public final class ValueClass {
     private static final JavaLangReflectAccess JLRA = SharedSecrets.getJavaLangReflectAccess();
+
+    /// {@return whether this field type may store value objects}
+    /// This excludes primitives and includes Object.
+    public static boolean isValueObjectCompatible(Class<?> fieldType) {
+        return !fieldType.isPrimitive() && (!fieldType.isIdentity() || fieldType == Object.class);
+    }
+
+    /// {@return whether an object of this exact class is a value object}
+    /// This excludes abstract value classes and primitives.
+    public static boolean isValueObjectInstance(Class<?> clazz) {
+        return clazz.isValue() && !Modifier.isAbstract(clazz.getModifiers());
+    }
 
     /**
      * {@return {@code true} if the field is NullRestricted}

--- a/test/jdk/valhalla/valuetypes/ValueClassTest.java
+++ b/test/jdk/valhalla/valuetypes/ValueClassTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test jdk.internal.value.ValueClass
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @run junit/othervm ValueClassTest
+ */
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import static jdk.internal.value.ValueClass.isValueObjectCompatible;
+import static jdk.internal.value.ValueClass.isValueObjectInstance;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValueClassTest {
+    @Test
+    void testIsValueObjectCompatible() {
+        assertFalse(isValueObjectCompatible(int.class), "primitive");
+        assertTrue(isValueObjectCompatible(Object.class), "Object");
+        assertTrue(isValueObjectCompatible(Number.class), "abstract value class");
+        assertTrue(isValueObjectCompatible(Integer.class), "final value class");
+        assertFalse(isValueObjectCompatible(ClassValue.class), "abstract identity class");
+        assertFalse(isValueObjectCompatible(ArrayList.class), "identity class");
+        assertFalse(isValueObjectCompatible(String.class), "final identity class");
+        assertTrue(isValueObjectCompatible(Comparable.class), "interface");
+        assertFalse(isValueObjectCompatible(int[].class), "array class");
+        assertFalse(isValueObjectCompatible(Object[].class), "array class");
+        assertFalse(isValueObjectCompatible(Number[].class), "array class");
+        assertFalse(isValueObjectCompatible(Integer[].class), "array class");
+        assertFalse(isValueObjectCompatible(ClassValue[].class), "array class");
+        assertFalse(isValueObjectCompatible(ArrayList[].class), "array class");
+        assertFalse(isValueObjectCompatible(String[].class), "array class");
+        assertFalse(isValueObjectCompatible(Comparable[].class), "array class");
+    }
+
+    @Test
+    void testIsValueObjectInstance() {
+        assertFalse(isValueObjectInstance(int.class), "primitive");
+        assertFalse(isValueObjectInstance(Object.class), "Object");
+        assertFalse(isValueObjectInstance(Number.class), "abstract value class");
+        assertTrue(isValueObjectInstance(Integer.class), "final value class");
+        assertFalse(isValueObjectInstance(ClassValue.class), "abstract identity class");
+        assertFalse(isValueObjectInstance(ArrayList.class), "identity class");
+        assertFalse(isValueObjectInstance(String.class), "final identity class");
+        assertFalse(isValueObjectInstance(Comparable.class), "interface");
+        assertFalse(isValueObjectInstance(int[].class), "array class");
+        assertFalse(isValueObjectInstance(Object[].class), "array class");
+        assertFalse(isValueObjectInstance(Number[].class), "array class");
+        assertFalse(isValueObjectInstance(Integer[].class), "array class");
+        assertFalse(isValueObjectInstance(ClassValue[].class), "array class");
+        assertFalse(isValueObjectInstance(ArrayList[].class), "array class");
+        assertFalse(isValueObjectInstance(String[].class), "array class");
+        assertFalse(isValueObjectInstance(Comparable[].class), "array class");
+    }
+}


### PR DESCRIPTION
Reviewed a few sites of isValue() usages that cause immediate trouble with bootstrap and basic tests. Factor out `ValueClass::isValueObjectCompatible` and `isValueObjectInstance` to represent the two states of value classes: field types that can hold value objects, and field types that definitely hold value objects.

I think we still need a more throughout review for all `isValue` usages, such as those in MethodHandle or VarHandle. Preliminary testing hasn't revealed anything yet.

Testing: tier 1-3, seems to have no new failures