### PR TITLE
8362181: [lworld] Include verification for strict fields in ClassFile API

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
@@ -24,6 +24,9 @@
  */
 package java.lang.classfile.attribute;
 
+import java.lang.classfile.AttributeMapper;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.constant.ClassDesc;
 import java.util.Arrays;
@@ -32,18 +35,31 @@ import java.util.List;
 import java.lang.classfile.Attribute;
 import java.lang.classfile.ClassElement;
 import java.lang.classfile.constantpool.ClassEntry;
+
+import jdk.internal.classfile.impl.AbstractPoolEntry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
- *  <p><b>This is NOT part of any supported API.
- *  If you write code that depends on this, you do so at your own risk.
- *  This code and its internal interfaces are subject to change or
- *  deletion without notice.</b>
+ * Models the {@link Attributes#loadableDescriptors() LoadableDescriptors}
+ * attribute (JVMS {@jvms 4.7.32}), which suggests the JVM may load mentioned
+ * types before the {@code class} file carrying this attribute is loaded.
+ * <p>
+ * This attribute only appears on classes, and does not permit {@linkplain
+ * AttributeMapper#allowMultiple multiple instances} in a class.  It has a
+ * data dependency on the {@linkplain AttributeMapper.AttributeStability#CP_REFS
+ * constant pool}.
+ * <p>
+ * The attribute was introduced in the Java SE Platform version XX, major
+ * version {@value ClassFile#JAVA_25_VERSION}. (FIXME)
+ *
+ * @see Attributes#loadableDescriptors()
+ * @jvms 4.7.32 The {@code LoadableDescriptors} Attribute
+ * @since Valhalla
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
+@PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 public sealed interface LoadableDescriptorsAttribute
         extends Attribute<LoadableDescriptorsAttribute>, ClassElement
         permits BoundAttribute.BoundLoadableDescriptorsAttribute, UnboundAttribute.UnboundLoadableDescriptorsAttribute {
@@ -52,6 +68,13 @@ public sealed interface LoadableDescriptorsAttribute
      * {@return the list of loadable descriptors}
      */
     List<Utf8Entry> loadableDescriptors();
+
+    /**
+     * {@return the list of loadable descriptors, as nominal descriptors}
+     */
+    default List<ClassDesc> loadableDescriptorSymbols() {
+        return Util.mappedList(loadableDescriptors(), Util::fieldTypeSymbol);
+    }
 
     /**
      * {@return a {@code LoadableDescriptors} attribute}

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -35,6 +35,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static java.lang.classfile.ClassFile.PREVIEW_MINOR_VERSION;
+import static java.lang.classfile.ClassFile.latestMajorVersion;
 import static java.util.Objects.requireNonNull;
 
 public final class DirectClassBuilder
@@ -195,7 +197,12 @@ public final class DirectClassBuilder
         // The tail consists of fields and methods, and attributes
         // This should trigger all the CP/BSM mutation
         Util.writeList(tail, fields, fieldsCount);
-        var strictInstanceFields = WritableField.filterStrictInstanceFields(constantPool, fields, fieldsCount);
+        WritableField.UnsetField[] strictInstanceFields;
+        if (minorVersion == PREVIEW_MINOR_VERSION && majorVersion >= Util.VALUE_OBJECTS_MAJOR) {
+            strictInstanceFields = WritableField.filterStrictInstanceFields(constantPool, fields, fieldsCount);
+        } else {
+            strictInstanceFields = WritableField.UnsetField.EMPTY_ARRAY;
+        }
         tail.setStrictInstanceFields(strictInstanceFields);
         Util.writeList(tail, methods, methodsCount);
         int attributesOffset = tail.size();

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
@@ -121,6 +121,8 @@ public class StackMapDecoder {
     private static List<NameAndTypeEntry> initFrameUnsets(ClassModel clazz, Utf8Entry methodName) {
         if (!methodName.equalsString(ConstantDescs.INIT_NAME))
             return List.of();
+        if (clazz.minorVersion() != PREVIEW_MINOR_VERSION || clazz.majorVersion() < Util.VALUE_OBJECTS_MAJOR)
+            return List.of();
         var l = new ArrayList<NameAndTypeEntry>(clazz.fields().size());
         for (var field : clazz.fields()) {
             if ((field.flags().flagsMask() & (ACC_STATIC | ACC_STRICT_INIT)) == ACC_STRICT_INIT) { // instance strict

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -62,6 +62,8 @@ import static jdk.internal.constant.PrimitiveClassDescImpl.CD_void;
  */
 public class Util {
 
+    public static final int VALUE_OBJECTS_MAJOR = ClassFile.latestMajorVersion();
+
     private Util() {
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationFrame.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationFrame.java
@@ -24,7 +24,12 @@
  */
 package jdk.internal.classfile.impl.verifier;
 
+import java.lang.classfile.constantpool.NameAndTypeEntry;
+import java.lang.classfile.constantpool.Utf8Entry;
 import java.util.Arrays;
+import java.util.Set;
+
+import jdk.internal.classfile.impl.TemporaryConstantPool;
 
 /// From `stackMapFrame.cpp`.
 class VerificationFrame {
@@ -37,9 +42,11 @@ class VerificationFrame {
     private final int _max_locals, _max_stack;
     private int _flags;
     private final VerificationType[] _locals, _stack;
+    private Set<NameAndTypeEntry> _assert_unset_fields;
     private final VerifierImpl _verifier;
 
-    public VerificationFrame(int offset, int flags, int locals_size, int stack_size, int max_locals, int max_stack, VerificationType[] locals, VerificationType[] stack, VerifierImpl v) {
+    public VerificationFrame(int offset, int flags, int locals_size, int stack_size, int max_locals, int max_stack,
+                             VerificationType[] locals, VerificationType[] stack, Set<NameAndTypeEntry> assert_unset_fields, VerifierImpl v) {
         this._offset = offset;
         this._locals_size = locals_size;
         this._stack_size = stack_size;
@@ -49,6 +56,7 @@ class VerificationFrame {
         this._flags = flags;
         this._locals = locals;
         this._stack = stack;
+        this._assert_unset_fields = assert_unset_fields;
         this._verifier = v;
     }
 
@@ -107,6 +115,50 @@ class VerificationFrame {
 
     boolean flag_this_uninit() {
         return (_flags & FLAG_THIS_UNINIT) == FLAG_THIS_UNINIT;
+    }
+
+    Set<NameAndTypeEntry> assert_unset_fields() {
+        return _assert_unset_fields;
+    }
+
+    void set_assert_unset_fields(Set<NameAndTypeEntry> table) {
+        _assert_unset_fields = table;
+    }
+
+    // Called when verifying putfields to mark strict instance fields as satisfied
+    boolean satisfy_unset_field(Utf8Entry name, Utf8Entry signature) {
+        var nat = TemporaryConstantPool.INSTANCE.nameAndTypeEntry(name, signature);
+        return _assert_unset_fields.remove(nat);
+    }
+
+    // Verify that all strict fields have been initialized
+    // Strict fields must be initialized before the super constructor is called
+    boolean verify_unset_fields_satisfied() {
+        return _assert_unset_fields.isEmpty();
+    }
+
+    // Merge incoming unset strict fields from StackMapTable with
+    // initial strict instance fields
+    Set<NameAndTypeEntry> merge_unset_fields(Set<NameAndTypeEntry> new_fields) {
+        // ClassFile API: We track all strict fields in another structure, noop here
+        return new_fields;
+    }
+
+    boolean verify_unset_fields_compatibility(Set<NameAndTypeEntry> target_table) {
+        for (var e : _assert_unset_fields) {
+            if (!target_table.contains(e))
+                return false;
+        }
+        return true;
+    }
+
+    void unsatisfied_strict_fields_error(VerificationWrapper klass, int bci) {
+        _verifier.verifyError("All strict final fields must be initialized before super(): %d field(s), %s"
+                .formatted(_assert_unset_fields.size(), _assert_unset_fields));
+    }
+
+    void print_strict_fields(Set<NameAndTypeEntry> table) {
+        // ignore, we don't do stdout/err
     }
 
     void reset() {
@@ -181,7 +233,7 @@ class VerificationFrame {
         pop_stack_ex(type2);
     }
 
-    VerificationFrame(int max_locals, int max_stack, VerifierImpl verifier) {
+    VerificationFrame(int max_locals, int max_stack, Set<NameAndTypeEntry> initial_strict_fields, VerifierImpl verifier) {
         _offset = 0;
         _locals_size = 0;
         _stack_size = 0;
@@ -198,12 +250,13 @@ class VerificationFrame {
         for (int i = 0; i < max_stack; i++) {
             _stack[i] = VerificationType.bogus_type;
         }
+        _assert_unset_fields = initial_strict_fields;
     }
 
     VerificationFrame frame_in_exception_handler(int flags) {
         return new VerificationFrame(_offset, flags, _locals_size, 0,
                 _max_locals, _max_stack, _locals, new VerificationType[1],
-                _verifier);
+                _assert_unset_fields, _verifier);
     }
 
     void initialize_object(VerificationType old_object, VerificationType new_object) {
@@ -297,6 +350,16 @@ class VerificationFrame {
         mismatch_loc = is_assignable_to(_stack, target.stack(), _stack_size);
         if (mismatch_loc != _stack_size) {
             _verifier.verifyError("Bad type", this, target);
+        }
+
+        // Check that assert unset fields are compatible
+        boolean compatible = verify_unset_fields_compatibility(target.assert_unset_fields());
+        if (!compatible) {
+            print_strict_fields(assert_unset_fields());
+            print_strict_fields(target.assert_unset_fields());
+            _verifier.verifyError("Strict fields mismatch from %s to %s".formatted(
+                    assert_unset_fields(), target.assert_unset_fields()), this, target);
+            return false;
         }
 
         if ((_flags | target.flags()) == target.flags()) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationWrapper.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationWrapper.java
@@ -27,6 +27,7 @@ package jdk.internal.classfile.impl.verifier;
 
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.FieldModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.attribute.LocalVariableInfo;
 import java.lang.classfile.constantpool.ClassEntry;
@@ -45,7 +46,7 @@ import jdk.internal.classfile.impl.CodeImpl;
 import jdk.internal.classfile.impl.Util;
 
 public final class VerificationWrapper {
-    private final ClassModel clm;
+    final ClassModel clm;
     private final ConstantPoolWrapper cp;
 
     public VerificationWrapper(ClassModel clm) {
@@ -73,11 +74,11 @@ public final class VerificationWrapper {
         return clm.methods().stream().map(m -> new MethodWrapper(m)).toList();
     }
 
-    boolean findField(String name, String sig) {
+    FieldModel findField(String name, String sig) {
         for (var f : clm.fields())
             if (f.fieldName().stringValue().equals(name) && f.fieldType().stringValue().equals(sig))
-                return true;
-        return false;
+                return f;
+        return null;
     }
 
     class MethodWrapper {
@@ -161,7 +162,7 @@ public final class VerificationWrapper {
 
     static class ConstantPoolWrapper {
 
-        private final ConstantPool cp;
+        final ConstantPool cp;
 
         ConstantPoolWrapper(ConstantPool cp) {
             this.cp = cp;
@@ -199,6 +200,10 @@ public final class VerificationWrapper {
 
         int refClassIndexAt(int index) {
             return cp.entryByIndex(index, MemberRefEntry.class).owner().index();
+        }
+
+        boolean is_within_bounds(int i) {
+            return i >= 1 && i <= cp.size();
         }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
@@ -44,6 +44,7 @@ import java.util.function.Consumer;
 import jdk.internal.classfile.impl.ClassHierarchyImpl;
 import jdk.internal.classfile.impl.RawBytecodeHelper;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.classfile.impl.verifier.VerificationSignature.BasicType;
 import jdk.internal.classfile.impl.verifier.VerificationWrapper.ConstantPoolWrapper;
 
@@ -115,6 +116,7 @@ public final class VerifierImpl {
     static final int STACKMAP_ATTRIBUTE_MAJOR_VERSION = 50;
     static final int INVOKEDYNAMIC_MAJOR_VERSION = 51;
     static final int NOFAILOVER_MAJOR_VERSION = 51;
+    static final int VALUE_TYPES_MAJOR_VERSION = Util.VALUE_OBJECTS_MAJOR;
     static final int MAX_CODE_SIZE = 65535;
 
     public static List<VerifyError> verify(ClassModel classModel, Consumer<String> logger) {
@@ -254,7 +256,8 @@ public final class VerifierImpl {
 
     static boolean supports_strict_fields(VerificationWrapper klass) {
         int ver = klass.majorVersion();
-        return ver >= 67 && klass.clm.minorVersion() == ClassFile.PREVIEW_MINOR_VERSION;
+        return ver > VALUE_TYPES_MAJOR_VERSION ||
+                (ver == VALUE_TYPES_MAJOR_VERSION && klass.clm.minorVersion() == ClassFile.PREVIEW_MINOR_VERSION);
     }
 
     List<VerifyError> verify_class() {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
@@ -24,16 +24,26 @@
  */
 package jdk.internal.classfile.impl.verifier;
 
+import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassHierarchyResolver;
 import java.lang.classfile.ClassModel;
 import jdk.internal.classfile.components.ClassPrinter;
+
+import java.lang.classfile.FieldModel;
+import java.lang.classfile.constantpool.NameAndTypeEntry;
+import java.lang.constant.ConstantDescs;
+import java.lang.reflect.AccessFlag;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import jdk.internal.classfile.impl.ClassHierarchyImpl;
 import jdk.internal.classfile.impl.RawBytecodeHelper;
+import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.verifier.VerificationSignature.BasicType;
 import jdk.internal.classfile.impl.verifier.VerificationWrapper.ConstantPoolWrapper;
 
@@ -242,6 +252,11 @@ public final class VerifierImpl {
         return VerificationType.reference_type(java_lang_Object);
     }
 
+    static boolean supports_strict_fields(VerificationWrapper klass) {
+        int ver = klass.majorVersion();
+        return ver >= 67 && klass.clm.minorVersion() == ClassFile.PREVIEW_MINOR_VERSION;
+    }
+
     List<VerifyError> verify_class() {
         log_info("Verifying class %s with new format", _klass.thisClassName());
         var errors = new ArrayList<VerifyError>();
@@ -303,7 +318,19 @@ public final class VerifierImpl {
         byte[] stackmap_data = m.stackMapTableRawData();
         var cp = m.constantPool();
         if (!VerificationSignature.isValidMethodSignature(m.descriptor())) verifyError("Invalid method signature");
-        VerificationFrame current_frame = new VerificationFrame(max_locals, max_stack, this);
+
+        // Collect the initial strict instance fields
+        Set<NameAndTypeEntry> strict_fields = new HashSet<>();
+        if (m.name().equals(ConstantDescs.INIT_NAME)) {
+            for (var fs : current_class().clm.fields()) {
+                if (fs.flags().has(AccessFlag.STRICT_INIT) && !fs.flags().has(AccessFlag.STATIC)) {
+                    var new_field = TemporaryConstantPool.INSTANCE.nameAndTypeEntry(fs.fieldName(), fs.fieldType());
+                    strict_fields.add(new_field);
+                }
+            }
+        }
+
+        VerificationFrame current_frame = new VerificationFrame(max_locals, max_stack, strict_fields, this);
         VerificationType return_type = current_frame.set_locals_from_arg(m, current_type());
         int stackmap_index = 0;
         int code_length = m.codeLength();
@@ -317,7 +344,7 @@ public final class VerifierImpl {
         verify_local_variable_table(code_length, code_data);
 
         var reader = new VerificationTable.StackMapReader(stackmap_data, code_data, code_length, current_frame,
-                (char) max_locals, (char) max_stack, cp, this);
+                (char) max_locals, (char) max_stack, strict_fields, cp, this);
         VerificationTable stackmap_table = new VerificationTable(reader, cp, this);
 
         var bcs = code.start();
@@ -1497,10 +1524,24 @@ public final class VerifierImpl {
                     current_frame.pop_stack(field_type[i]);
                 }
                 stack_object_type = current_frame.pop_stack();
-                if (stack_object_type.is_uninitialized_this(this) &&
-                        target_class_type.equals(current_type()) &&
-                        _klass.findField(field_name, field_sig)) {
-                    stack_object_type = current_type();
+                FieldModel fd = _klass.findField(field_name, field_sig);
+                boolean is_local_field = fd != null &&
+                        target_class_type.equals(current_type());
+                if (stack_object_type.is_uninitialized_this(this)) {
+                    if (is_local_field) {
+                        // Set the type to the current type so the is_assignable check passes.
+                        stack_object_type = current_type();
+
+                        if (fd.flags().has(AccessFlag.STRICT_INIT)) {
+                            current_frame.satisfy_unset_field(fd.fieldName(), fd.fieldType());
+                        }
+                    }
+                } else if (supports_strict_fields(_klass)) {
+                    // `strict` fields are not writable, but only local fields produce verification errors
+                    if (is_local_field && fd.flags().has(AccessFlag.STRICT_INIT) && fd.flags().has(AccessFlag.FINAL)) {
+                        verifyError("Bad code %d %s".formatted(bci,
+                                "Illegal use of putfield on a strict field: %s:%s".formatted(fd.fieldName(), fd.fieldType())));
+                    }
                 }
                 is_assignable = target_class_type.is_assignable_from(stack_object_type, this);
                 if (!is_assignable) {
@@ -1528,6 +1569,11 @@ public final class VerifierImpl {
             if (!current_class().thisClassName().equals(ref_class_type.name()) &&
                     !superk_name.equals(ref_class_type.name())) {
                 verifyError("Bad <init> method call");
+            } else if (ref_class_type.name().equals(superk_name)) {
+                // Strict final fields must be satisfied by this point
+                if (!current_frame.verify_unset_fields_satisfied()) {
+                    current_frame.unsatisfied_strict_fields_error(current_class(), bci);
+                }
             }
             if (in_try_block) {
                 for(var exhandler : _method.exceptionTable()) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictStaticTests.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictStaticTests.java
@@ -148,6 +148,7 @@ public class StrictStaticTests {
             System.out.println(vererrs);
             var cm = ClassFile.of().parse(classBytes);
             System.out.println(cm.toDebugString());
+            throw new AssertionError();
         }
         ++COUNT;
         try {

--- a/test/jdk/jdk/classfile/StrictStackMapsTest.java
+++ b/test/jdk/jdk/classfile/StrictStackMapsTest.java
@@ -88,6 +88,42 @@ class StrictStackMapsTest {
     }
 
     @Test
+    void noEarlyFrameInOldTest() {
+        var className = "Test";
+        var classDesc = ClassDesc.of(className);
+        var classBytes = ClassFile.of().build(classDesc, clb -> clb
+                .withVersion(JAVA_26_VERSION, 0)
+                .withFlags(ACC_PUBLIC | ACC_SUPER)
+                .withField("fs", CD_int, ACC_STRICT) // spurious meaningless flags in 70.0
+                .withField("fsf", CD_int, ACC_STRICT | ACC_FINAL)
+                .withMethodBody(INIT_NAME, MTD_void, 0, cob -> cob
+                        .aload(0)
+                        .iconst_5()
+                        .putfield(classDesc, "fs", CD_int)
+                        .aload(0)
+                        .iconst_0()
+                        .ifThenElse(thb -> thb
+                                .iconst_3()
+                                .putfield(classDesc, "fsf", CD_int), elb -> elb
+                                .iconst_2()
+                                .putfield(classDesc, "fsf", CD_int))
+                        .aload(0)
+                        .invokespecial(CD_Object, INIT_NAME, MTD_void)
+                        .return_()));
+        runtimeVerify(className, classBytes);
+        var classModel = ClassFile.of().parse(classBytes);
+        var ctorModel = classModel.methods().getFirst();
+        var stackMaps = ctorModel.code().orElseThrow().findAttribute(Attributes.stackMapTable()).orElseThrow();
+        assertEquals(2, stackMaps.entries().size(), "if -> else, then -> end");
+        var elseFrame = stackMaps.entries().get(0);
+        assertNotEquals(246, elseFrame.frameType(), "if -> else");
+        assertEquals(List.of(), elseFrame.unsetFields());
+        var mergedFrame = stackMaps.entries().get(1);
+        assertNotEquals(246, mergedFrame.frameType(), "then -> merge");
+        assertEquals(List.of(), mergedFrame.unsetFields());
+    }
+
+    @Test
     void skipUnnecessaryUnsetFramesTest() throws Throwable {
         var className = "Test";
         var classDesc = ClassDesc.of(className);

--- a/test/jdk/jdk/classfile/StrictStackMapsTest.java
+++ b/test/jdk/jdk/classfile/StrictStackMapsTest.java
@@ -360,5 +360,7 @@ class StrictStackMapsTest {
         var clazz = assertDoesNotThrow(() -> ByteCodeLoader.load(className, classBytes));
         var lookup = assertDoesNotThrow(() -> MethodHandles.privateLookupIn(clazz, MethodHandles.lookup()));
         assertDoesNotThrow(() -> lookup.ensureInitialized(clazz)); // forces verification
+        var errors = ClassFile.of().verify(classBytes);
+        assertEquals(List.of(), errors, "Errors detected");
     }
 }

--- a/test/jdk/jdk/classfile/VerifierSelfTest.java
+++ b/test/jdk/jdk/classfile/VerifierSelfTest.java
@@ -26,6 +26,7 @@
  * @summary Testing ClassFile Verifier.
  * @bug 8333812 8361526
  * @run junit VerifierSelfTest
+ * @run junit/othervm --enable-preview VerifierSelfTest
  */
 import java.io.IOException;
 import java.lang.classfile.constantpool.PoolEntry;
@@ -216,7 +217,6 @@ class VerifierSelfTest {
                                 cob.iconst_0()
                                    .ifThen(CodeBuilder::nop)
                                    .return_()
-                                   .with(new CloneAttribute(StackMapTableAttribute.of(List.of())))
                                    .with(new CloneAttribute(CharacterRangeTableAttribute.of(List.of())))
                                    .with(new CloneAttribute(LineNumberTableAttribute.of(List.of())))
                                    .with(new CloneAttribute(LocalVariableTableAttribute.of(List.of())))
@@ -336,12 +336,10 @@ class VerifierSelfTest {
                 Wrong Signature attribute length in method ParserVerificationTestClass::m()
                 Wrong Synthetic attribute length in method ParserVerificationTestClass::m()
                 Code attribute in native or abstract method ParserVerificationTestClass::m()
-                Wrong StackMapTable attribute length in Code attribute for method ParserVerificationTestClass::m()
                 Wrong CharacterRangeTable attribute length in Code attribute for method ParserVerificationTestClass::m()
                 Wrong LineNumberTable attribute length in Code attribute for method ParserVerificationTestClass::m()
                 Wrong LocalVariableTable attribute length in Code attribute for method ParserVerificationTestClass::m()
                 Wrong LocalVariableTypeTable attribute length in Code attribute for method ParserVerificationTestClass::m()
-                Multiple StackMapTable attributes in Code attribute for method ParserVerificationTestClass::m()
                 Multiple Signature attributes in Record component c of class ParserVerificationTestClass
                 Wrong Signature attribute length in Record component c of class ParserVerificationTestClass
                 Multiple RuntimeVisibleAnnotations attributes in Record component c of class ParserVerificationTestClass


### PR DESCRIPTION
The lack of classfile verifier recognition of strict fields is the only part of class file API support left for strict fields.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8362181](https://bugs.openjdk.org/browse/JDK-8362181): [lworld] Include verification for strict fields in ClassFile API (**Sub-task** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer) ⚠️ Review applies to [327013e6](https://git.openjdk.org/valhalla/pull/1506/files/327013e6537585aed553d5c0615b04186d79890d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1506/head:pull/1506` \
`$ git checkout pull/1506`

Update a local copy of the PR: \
`$ git checkout pull/1506` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1506`

View PR using the GUI difftool: \
`$ git pr show -t 1506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1506.diff">https://git.openjdk.org/valhalla/pull/1506.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1506#issuecomment-3069970875)
</details>
