### PR TITLE
8357785: [lworld] TestResolvedJavaType fails due to unexpected getInstanceFields order

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -471,13 +471,6 @@ ciField* ciInstanceKlass::get_field_by_name(ciSymbol* name, ciSymbol* signature,
   return field;
 }
 
-#if 0
-static int sort_field_by_offset(ciField** a, ciField** b) {
-  return (*a)->offset_in_bytes() - (*b)->offset_in_bytes();
-  // (no worries about 32-bit overflow...)
-}
-#endif
-
 const GrowableArray<ciField*> empty_field_array(0, MemTag::mtCompiler);
 
 void ciInstanceKlass::compute_nonstatic_fields() {

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -471,10 +471,12 @@ ciField* ciInstanceKlass::get_field_by_name(ciSymbol* name, ciSymbol* signature,
   return field;
 }
 
+#if 0
 static int sort_field_by_offset(ciField** a, ciField** b) {
   return (*a)->offset_in_bytes() - (*b)->offset_in_bytes();
   // (no worries about 32-bit overflow...)
 }
+#endif
 
 const GrowableArray<ciField*> empty_field_array(0, MemTag::mtCompiler);
 
@@ -559,7 +561,6 @@ void ciInstanceKlass::compute_nonstatic_fields_impl(const GrowableArray<ciField*
 
     if (fd.is_flat()) {
       // Flat fields are embedded
-      int field_offset = fd.offset();
       Klass* k = get_instanceKlass()->get_inline_type_field_klass(fd.index());
       ciInlineKlass* vk = CURRENT_ENV->get_klass(k)->as_inline_klass();
       // Iterate over fields of the flat inline type and copy them to 'this'
@@ -581,7 +582,6 @@ void ciInstanceKlass::compute_nonstatic_fields_impl(const GrowableArray<ciField*
   if (tmp_declared_fields != nullptr) {
     assert(tmp_declared_fields->length() == declared_field_num, "sanity check failed for class: %s, number of declared fields: %d, expected: %d",
            name()->as_utf8(), tmp_declared_fields->length(), declared_field_num);
-    tmp_declared_fields->sort(sort_field_by_offset);
     _declared_nonstatic_fields = tmp_declared_fields;
   } else {
     _declared_nonstatic_fields = super_declared_fields;
@@ -590,7 +590,6 @@ void ciInstanceKlass::compute_nonstatic_fields_impl(const GrowableArray<ciField*
   if (tmp_fields != nullptr) {
     assert(tmp_fields->length() == field_num, "sanity check failed for class: %s, number of fields: %d, expected: %d",
            name()->as_utf8(), tmp_fields->length(), field_num);
-    tmp_fields->sort(sort_field_by_offset);
     _nonstatic_fields = tmp_fields;
   } else {
     _nonstatic_fields = super_fields;

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -427,8 +427,6 @@ ciField* ciInstanceKlass::get_non_flat_field_by_offset(int field_offset) {
     int field_off = field->offset_in_bytes();
     if (field_off == field_offset) {
       return field;
-    } else if (field_off > field_offset) {
-      break;
     }
   }
   return nullptr;

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -68,13 +68,17 @@ private:
 
   ciConstantPoolCache*   _field_cache;  // cached map index->field
 
-  // Fields declared in the bytecode (without nested fields in flat fields), ordered by
-  // offset.
+  // Fields declared in the bytecode (without nested fields in flat fields),
+  // ordered in JavaFieldStream order, with superclasses first (i.e. from lang.java.Object
+  // to most derived class).
   const GrowableArray<ciField*>* _declared_nonstatic_fields;
 
   // Fields laid out in memory (flat fields are expanded into their components). The ciField object
   // for each primitive component has the holder being this ciInstanceKlass or one of its
-  // superclasses, ordered by offset.
+  // superclasses.
+  // Fields are in the same order as in _declared_nonstatic_fields, but flat fields are replaced by
+  // the list of their own fields, ordered the same way (hierarchy traversed top-down, in
+  // JavaFieldStream order).
   const GrowableArray<ciField*>* _nonstatic_fields;
 
   int                    _has_injected_fields; // any non static injected fields? lazily initialized.

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3837,7 +3837,7 @@ void nmethod::print_nmethod_labels(outputStream* stream, address block_begin, bo
     } else {
       bool did_name = false;
       if (is_reference_type(t)) {
-        Symbol* name = (*sig)._symbol;
+        Symbol* name = (*sig)._name;
         name->print_value_on(stream);
         did_name = true;
       }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3843,7 +3843,6 @@ void nmethod::print_nmethod_labels(outputStream* stream, address block_begin, bo
       }
       if (!did_name)
         stream->print("%s", type2name(t));
-      // If the entry has a non-default sort_offset, it must be a null marker
       if ((*sig)._null_marker) {
         stream->print(" (null marker)");
       }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3844,7 +3844,7 @@ void nmethod::print_nmethod_labels(outputStream* stream, address block_begin, bo
       if (!did_name)
         stream->print("%s", type2name(t));
       // If the entry has a non-default sort_offset, it must be a null marker
-      if ((*sig)._sort_offset != (*sig)._offset) {
+      if ((*sig)._null_marker) {
         stream->print(" (null marker)");
       }
     }

--- a/src/hotspot/share/oops/fieldStreams.hpp
+++ b/src/hotspot/share/oops/fieldStreams.hpp
@@ -206,9 +206,8 @@ class AllFieldStream : public FieldStreamBase {
  */
 template<typename FieldStreamType>
 class HierarchicalFieldStreamBase : public StackObj {
-protected:
-  virtual FieldStreamType& current_stream () = 0;
-  virtual const FieldStreamType& current_stream () const = 0;
+  virtual FieldStreamType& current_stream() = 0;
+  virtual const FieldStreamType& current_stream() const = 0;
 
 public:
   // bridge functions from FieldStreamBase
@@ -274,7 +273,7 @@ public:
  * at the end.
  */
 template<typename FieldStreamType>
-class HierarchicalFieldStream : public HierarchicalFieldStreamBase<FieldStreamType>  {
+class HierarchicalFieldStream final : public HierarchicalFieldStreamBase<FieldStreamType>  {
  private:
   const Array<InstanceKlass*>* _interfaces;
   InstanceKlass* _next_klass; // null indicates no more type to visit
@@ -312,12 +311,11 @@ class HierarchicalFieldStream : public HierarchicalFieldStreamBase<FieldStreamTy
     }
   }
 
- protected:
   FieldStreamType& current_stream() override { return _current_stream; }
   const FieldStreamType& current_stream() const override { return _current_stream; }
 
  public:
-  HierarchicalFieldStream(InstanceKlass* klass) :
+  explicit HierarchicalFieldStream(InstanceKlass* klass) :
     _interfaces(klass->transitive_interfaces()),
     _next_klass(klass),
     _current_stream(FieldStreamType(klass)),
@@ -339,7 +337,7 @@ class HierarchicalFieldStream : public HierarchicalFieldStreamBase<FieldStreamTy
  * wouldn't get all the static fields, and since the current use-case of this stream does not
  * care about static fields, we restrict it to regular non-static fields.
  */
-class TopDownHierarchicalNonStaticFieldStreamBase : public HierarchicalFieldStreamBase<JavaFieldStream> {
+class TopDownHierarchicalNonStaticFieldStreamBase final : public HierarchicalFieldStreamBase<JavaFieldStream> {
   GrowableArray<InstanceKlass*>* _super_types;  // Self and super type, bottom up
   int _current_stream_index;
   JavaFieldStream _current_stream;
@@ -374,7 +372,6 @@ class TopDownHierarchicalNonStaticFieldStreamBase : public HierarchicalFieldStre
     }
   }
 
- protected:
   JavaFieldStream& current_stream() override { return _current_stream; }
   const JavaFieldStream& current_stream() const override { return _current_stream; }
 

--- a/src/hotspot/share/oops/fieldStreams.hpp
+++ b/src/hotspot/share/oops/fieldStreams.hpp
@@ -333,7 +333,7 @@ class HierarchicalFieldStream final : public HierarchicalFieldStreamBase<FieldSt
 
 /* Iterates on the fields of a class and its super-class top-down (java.lang.Object first)
  * Doesn't traverse interfaces for now, because it's not clear which order would make sense
- * Let's decide how  when/if the needs appear. Since we are not traversing interfaces, we
+ * Let's decide when or if the need arises. Since we are not traversing interfaces, we
  * wouldn't get all the static fields, and since the current use-case of this stream does not
  * care about static fields, we restrict it to regular non-static fields.
  */

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -448,7 +448,7 @@ void InlineKlass::initialize_calling_convention(TRAPS) {
         ttyLocker ttyl;
         tty->print_cr("Fields of InlineKlass: %s", class_name_str);
         for (const SigEntry& entry : sig_vk) {
-          tty->print("  %s: %s+%d", entry._symbol->as_C_string(), type2name(entry._bt), entry._offset);
+          tty->print("  %s: %s+%d", entry._name->as_C_string(), type2name(entry._bt), entry._offset);
           if (entry._null_marker) {
             tty->print(" (null marker)");
           }

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -396,11 +396,6 @@ FlatArrayKlass* InlineKlass::flat_array_klass_or_null(LayoutKind lk) {
 // Value classes could also have fields in abstract super value classes.
 // Use a HierarchicalFieldStream to get them as well.
 int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off, int null_marker_offset) {
-#if 0
-  if (PrintInlineKlassFields) {
-    tty->print_cr("ENTER: %s", _name->as_C_string());
-  }
-#endif
   int count = 0;
   SigEntry::add_entry(sig, T_METADATA, name(), base_off);
   for (TopDownHierarchicalFieldStreamBase<JavaFieldStream> fs(this); !fs.done(); fs.next()) {
@@ -435,31 +430,7 @@ int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off, int 
     count++;
   }
   SigEntry::add_entry(sig, T_VOID, name(), offset);
-#if 0
-  if (PrintInlineKlassFields) {
-    ttyLocker ttyl;
-    tty->print_cr("collect_field: %s", _name->as_C_string());
-    for (const SigEntry& entry: *sig) {
-      tty->print_cr("  %s: %s(%d:%f)", entry._symbol->as_C_string(), type2name(entry._bt), entry._offset, entry._sort_offset);
-    }
-  }
-  if (base_off == 0) {
-    sig->sort(SigEntry::compare);
-  }
-  if (PrintInlineKlassFields) {
-    ttyLocker ttyl;
-    tty->print_cr("collect_field: %s", _name->as_C_string());
-    for (const SigEntry& entry: *sig) {
-      tty->print_cr("  %s: %s(%d)", entry._symbol->as_C_string(), type2name(entry._bt), entry._offset);
-    }
-  }
-#endif
   assert(sig->at(0)._bt == T_METADATA && sig->at(sig->length()-1)._bt == T_VOID, "broken structure");
-#if 0
-  if (PrintInlineKlassFields) {
-    tty->print_cr("LEAVE: %s", _name->as_C_string());
-  }
-#endif
   return count;
 }
 

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -398,8 +398,8 @@ FlatArrayKlass* InlineKlass::flat_array_klass_or_null(LayoutKind lk) {
 int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off, int null_marker_offset) {
   int count = 0;
   SigEntry::add_entry(sig, T_METADATA, name(), base_off);
-  for (TopDownHierarchicalFieldStreamBase<JavaFieldStream> fs(this); !fs.done(); fs.next()) {
-    if (fs.access_flags().is_static()) continue;
+  for (TopDownHierarchicalNonStaticFieldStreamBase fs(this); !fs.done(); fs.next()) {
+    assert(!fs.access_flags().is_static(), "TopDownHierarchicalNonStaticFieldStreamBase should not let static fields pass.");
     int offset = base_off + fs.offset() - (base_off > 0 ? payload_offset() : 0);
     InstanceKlass* field_holder = fs.field_descriptor().field_holder();
     // TODO 8284443 Use different heuristic to decide what should be scalarized in the calling convention

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -164,7 +164,7 @@ class InlineKlass: public InstanceKlass {
   int payload_offset() const {
     int offset = *(int*)adr_payload_offset();
     assert(offset != 0, "Must be initialized before use");
-    return *(int*)adr_payload_offset();
+    return offset;
   }
 
   void set_payload_offset(int offset) { *(int*)adr_payload_offset() = offset; }
@@ -220,7 +220,7 @@ class InlineKlass: public InstanceKlass {
 #endif
 
  private:
-  int collect_fields(GrowableArray<SigEntry>* sig, float& max_offset, int base_off = 0, int null_marker_offset = -1);
+  int collect_fields(GrowableArray<SigEntry>* sig, int base_off = 0, int null_marker_offset = -1);
 
   void cleanup_blobs();
 

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -832,6 +832,8 @@
           "used dead by replacing them with a Halt node. Turning this off " \
           "could corrupt the graph in rare cases and should be used with "  \
           "care.")                                                          \
+  develop(ccstrlist, PrintInlineKlassFields, "",                            \
+          "Print fields collected by InlineKlass::collect_fields")          \
 
 // end of C2_FLAGS
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1515,11 +1515,6 @@ public:
   ReassignedField() : _offset(0), _type(T_ILLEGAL), _klass(nullptr), _is_flat(false), _is_null_free(false) { }
 };
 
-static int compare(ReassignedField* left, ReassignedField* right) {
-  return left->_offset - right->_offset;
-}
-
-
 // Gets the fields of `klass` that are eliminated by escape analysis and need to be reassigned
 static GrowableArray<ReassignedField>* get_reassigned_fields(InstanceKlass* klass, GrowableArray<ReassignedField>* fields, bool is_jvmci) {
   InstanceKlass* super = klass->superklass();
@@ -1547,8 +1542,6 @@ static GrowableArray<ReassignedField>* get_reassigned_fields(InstanceKlass* klas
 // compiler when it scalarizes an object at safepoints.
 static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap* reg_map, ObjectValue* sv, int svIndex, oop obj, bool is_jvmci, int base_offset, TRAPS) {
   GrowableArray<ReassignedField>* fields = get_reassigned_fields(klass, new GrowableArray<ReassignedField>(), is_jvmci);
-  fields->sort(compare);
-
   for (int i = 0; i < fields->length(); i++) {
     BasicType type = fields->at(i)._type;
     int offset = base_offset + fields->at(i)._offset;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2865,8 +2865,7 @@ void CompiledEntrySignature::compute_calling_conventions(bool init) {
             _sig_cc->appendAll(vk->extended_sig());
             _sig_cc_ro->appendAll(vk->extended_sig());
             if (bt == T_OBJECT) {
-              // Nullable inline type argument, insert InlineTypeNode::NullMarker field right after T_METADATA delimiter
-              // Set the sort_offset so that the field is detected as null marker by nmethod::print_nmethod_labels.
+              // Nullable inline type argument, insert InlineTypeNode::NullMarker field right after T_METADATA delimite
               _sig_cc->insert_before(last+1, SigEntry(T_BOOLEAN, -1, nullptr, true));
               _sig_cc_ro->insert_before(last_ro+1, SigEntry(T_BOOLEAN, -1, nullptr, true));
             }

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2867,8 +2867,8 @@ void CompiledEntrySignature::compute_calling_conventions(bool init) {
             if (bt == T_OBJECT) {
               // Nullable inline type argument, insert InlineTypeNode::NullMarker field right after T_METADATA delimiter
               // Set the sort_offset so that the field is detected as null marker by nmethod::print_nmethod_labels.
-              _sig_cc->insert_before(last+1, SigEntry(T_BOOLEAN, -1, 0));
-              _sig_cc_ro->insert_before(last_ro+1, SigEntry(T_BOOLEAN, -1, 0));
+              _sig_cc->insert_before(last+1, SigEntry(T_BOOLEAN, -1, nullptr, true));
+              _sig_cc_ro->insert_before(last_ro+1, SigEntry(T_BOOLEAN, -1, nullptr, true));
             }
           }
         } else {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2865,7 +2865,7 @@ void CompiledEntrySignature::compute_calling_conventions(bool init) {
             _sig_cc->appendAll(vk->extended_sig());
             _sig_cc_ro->appendAll(vk->extended_sig());
             if (bt == T_OBJECT) {
-              // Nullable inline type argument, insert InlineTypeNode::NullMarker field right after T_METADATA delimite
+              // Nullable inline type argument, insert InlineTypeNode::NullMarker field right after T_METADATA delimiter
               _sig_cc->insert_before(last+1, SigEntry(T_BOOLEAN, -1, nullptr, true));
               _sig_cc_ro->insert_before(last_ro+1, SigEntry(T_BOOLEAN, -1, nullptr, true));
             }

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -680,14 +680,14 @@ ssize_t SignatureVerifier::is_valid_type(const char* type, ssize_t limit) {
 #endif // ASSERT
 
 // Adds an argument to the signature
-void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol, int offset) {
-  sig->append(SigEntry(bt, offset, symbol, false));
+void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* name, int offset) {
+  sig->append(SigEntry(bt, offset, name, false));
   if (bt == T_LONG || bt == T_DOUBLE) {
-    sig->append(SigEntry(T_VOID, offset, symbol, false)); // Longs and doubles take two stack slots
+    sig->append(SigEntry(T_VOID, offset, name, false)); // Longs and doubles take two stack slots
   }
 }
-void SigEntry::add_null_marker(GrowableArray<SigEntry>* sig, Symbol* symbol, int offset) {
-  sig->append(SigEntry(T_BOOLEAN, offset, symbol, true));
+void SigEntry::add_null_marker(GrowableArray<SigEntry>* sig, Symbol* name, int offset) {
+  sig->append(SigEntry(T_BOOLEAN, offset, name, true));
 }
 
 // Returns true if the argument at index 'i' is not an inline type delimiter

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -680,14 +680,14 @@ ssize_t SignatureVerifier::is_valid_type(const char* type, ssize_t limit) {
 #endif // ASSERT
 
 // Adds an argument to the signature
-void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol, int offset, float sort_offset) {
-  if (sort_offset == -1) {
-    sort_offset = offset;
-  }
-  sig->append(SigEntry(bt, offset, sort_offset, symbol));
+void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol, int offset) {
+  sig->append(SigEntry(bt, offset, symbol, false));
   if (bt == T_LONG || bt == T_DOUBLE) {
-    sig->append(SigEntry(T_VOID, offset, sort_offset, symbol)); // Longs and doubles take two stack slots
+    sig->append(SigEntry(T_VOID, offset, symbol, false)); // Longs and doubles take two stack slots
   }
+}
+void SigEntry::add_null_marker(GrowableArray<SigEntry>* sig, Symbol* symbol, int offset) {
+  sig->append(SigEntry(T_BOOLEAN, offset, symbol, true));
 }
 
 // Returns true if the argument at index 'i' is not an inline type delimiter

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -579,8 +579,8 @@ class SigEntry {
  public:
   BasicType _bt;      // Basic type of the argument
   int _offset;        // Offset of the field in its value class holder for scalarized arguments (-1 otherwise). Used for packing and unpacking.
-  Symbol* _name;    // Symbol for printing
-  bool _null_marker;   // Is it a null marker? For printing
+  Symbol* _name;      // Symbol for printing
+  bool _null_marker;  // Is it a null marker? For printing
 
   SigEntry()
     : _bt(T_ILLEGAL), _offset(-1), _name(nullptr) {}

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -588,36 +588,6 @@ class SigEntry {
   SigEntry(BasicType bt, int offset, Symbol* symbol, bool null_marker)
     : _bt(bt), _offset(offset), _symbol(symbol), _null_marker(null_marker) {}
 
-#if 0
-  static int compare(SigEntry* e1, SigEntry* e2) {
-    if (e1->_sort_offset < e2->_sort_offset) {
-      return -1;
-    } else if (e1->_sort_offset > e2->_sort_offset) {
-      return 1;
-    }
-
-    if (e1->_offset != e2->_offset) {
-      return e1->_offset - e2->_offset;
-    }
-    assert((e1->_bt == T_LONG && (e2->_bt == T_LONG || e2->_bt == T_VOID)) ||
-           (e1->_bt == T_DOUBLE && (e2->_bt == T_DOUBLE || e2->_bt == T_VOID)) ||
-           e1->_bt == T_METADATA || e2->_bt == T_METADATA || e1->_bt == T_VOID || e2->_bt == T_VOID, "bad bt");
-    if (e1->_bt == e2->_bt) {
-      assert(e1->_bt == T_METADATA || e1->_bt == T_VOID, "only ones with duplicate offsets");
-      return 0;
-    }
-    if (e1->_bt == T_VOID ||
-        e2->_bt == T_METADATA) {
-      return 1;
-    }
-    if (e1->_bt == T_METADATA ||
-        e2->_bt == T_VOID) {
-      return -1;
-    }
-    ShouldNotReachHere();
-    return 0;
-  }
-#endif
   static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol = nullptr, int offset = -1);
   static void add_null_marker(GrowableArray<SigEntry>* sig, Symbol* symbol, int offset);
   static bool skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i);

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -579,15 +579,16 @@ class SigEntry {
  public:
   BasicType _bt;      // Basic type of the argument
   int _offset;        // Offset of the field in its value class holder for scalarized arguments (-1 otherwise). Used for packing and unpacking.
-  float _sort_offset; // Offset used for sorting
   Symbol* _symbol;    // Symbol for printing
+  bool _null_marker;   // Is it a null marker? For printing
 
   SigEntry()
-    : _bt(T_ILLEGAL), _offset(-1), _sort_offset(-1), _symbol(nullptr) {}
+    : _bt(T_ILLEGAL), _offset(-1), _symbol(nullptr) {}
 
-  SigEntry(BasicType bt, int offset = -1, float sort_offset = -1, Symbol* symbol = nullptr)
-    : _bt(bt), _offset(offset), _sort_offset(sort_offset), _symbol(symbol) {}
+  SigEntry(BasicType bt, int offset, Symbol* symbol, bool null_marker)
+    : _bt(bt), _offset(offset), _symbol(symbol), _null_marker(null_marker) {}
 
+#if 0
   static int compare(SigEntry* e1, SigEntry* e2) {
     if (e1->_sort_offset < e2->_sort_offset) {
       return -1;
@@ -616,7 +617,9 @@ class SigEntry {
     ShouldNotReachHere();
     return 0;
   }
-  static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol = nullptr, int offset = -1, float sort_offset = -1);
+#endif
+  static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol = nullptr, int offset = -1);
+  static void add_null_marker(GrowableArray<SigEntry>* sig, Symbol* symbol, int offset);
   static bool skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i);
   static int fill_sig_bt(const GrowableArray<SigEntry>* sig, BasicType* sig_bt);
   static TempNewSymbol create_symbol(const GrowableArray<SigEntry>* sig);

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -579,17 +579,17 @@ class SigEntry {
  public:
   BasicType _bt;      // Basic type of the argument
   int _offset;        // Offset of the field in its value class holder for scalarized arguments (-1 otherwise). Used for packing and unpacking.
-  Symbol* _symbol;    // Symbol for printing
+  Symbol* _name;    // Symbol for printing
   bool _null_marker;   // Is it a null marker? For printing
 
   SigEntry()
-    : _bt(T_ILLEGAL), _offset(-1), _symbol(nullptr) {}
+    : _bt(T_ILLEGAL), _offset(-1), _name(nullptr) {}
 
-  SigEntry(BasicType bt, int offset, Symbol* symbol, bool null_marker)
-    : _bt(bt), _offset(offset), _symbol(symbol), _null_marker(null_marker) {}
+  SigEntry(BasicType bt, int offset, Symbol* name, bool null_marker)
+    : _bt(bt), _offset(offset), _name(name), _null_marker(null_marker) {}
 
-  static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol = nullptr, int offset = -1);
-  static void add_null_marker(GrowableArray<SigEntry>* sig, Symbol* symbol, int offset);
+  static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* name = nullptr, int offset = -1);
+  static void add_null_marker(GrowableArray<SigEntry>* sig, Symbol* name, int offset);
   static bool skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i);
   static int fill_sig_bt(const GrowableArray<SigEntry>* sig, BasicType* sig_bt);
   static TempNewSymbol create_symbol(const GrowableArray<SigEntry>* sig);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -67,7 +67,6 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
 
     private static final HotSpotResolvedJavaField[] NO_FIELDS = new HotSpotResolvedJavaField[0];
     private static final int METHOD_CACHE_ARRAY_CAPACITY = 8;
-    private static final SortByOffset fieldSortingMethod = new SortByOffset();
 
     /**
      * The {@code Klass*} of this type.
@@ -782,12 +781,6 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
         }
     }
 
-    static class SortByOffset implements Comparator<ResolvedJavaField> {
-        public int compare(ResolvedJavaField a, ResolvedJavaField b) {
-            return a.getOffset() - b.getOffset();
-        }
-    }
-
     @Override
     public ResolvedJavaField[] getInstanceFields(boolean includeSuperclasses) {
         if (instanceFields == null) {
@@ -817,7 +810,6 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
                         result[i++] = f;
                     }
                 }
-                Arrays.sort(result, fieldSortingMethod);
                 return result;
             } else {
                 // The super classes of this class do not have any instance fields.
@@ -876,7 +868,6 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
                 result[resultIndex++] = resolvedJavaField;
             }
         }
-        Arrays.sort(result, fieldSortingMethod);
         return result;
     }
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -132,7 +132,6 @@ runtime/AccModule/ConstModule.java 8294051 generic-all
 runtime/valhalla/inlinetypes/CircularityTest.java 8349037 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java CODETOOLS-7904031 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictStaticFieldsTest.java CODETOOLS-7904031 generic-all
-compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java 8357785 generic-all
 runtime/cds/appcds/RewriteBytecodesInlineTest.java 8361082 generic-all
 
 # Valhalla + COH

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -132,7 +132,6 @@ runtime/AccModule/ConstModule.java 8294051 generic-all
 runtime/valhalla/inlinetypes/CircularityTest.java 8349037 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java CODETOOLS-7904031 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictStaticFieldsTest.java CODETOOLS-7904031 generic-all
-runtime/cds/appcds/RewriteBytecodesInlineTest.java 8361082 generic-all
 
 # Valhalla + COH
 compiler/c2/autovectorization/TestIndexOverflowIR.java                          8348568 generic-all

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
@@ -71,6 +71,36 @@ public class VirtualObjectDebugInfoTest extends DebugInfoTest {
         }
 
         @Override
+        public String toString() {
+            var builder = new StringBuilder()
+                    .append("{l: ")
+                    .append(longField)
+                    .append("; ")
+                    .append("i: ")
+                    .append(intField)
+                    .append("; ")
+                    .append("f: ")
+                    .append(floatField)
+                    .append("; ")
+                    .append("a[")
+                    .append(arrayField.length)
+                    .append("]: ");
+            for (int i = 0; i < arrayField.length; ++i) {
+                if(i != 0) {
+                    builder.append("; ");
+                }
+                builder.append("[").append(i).append("]=");
+                if (arrayField[i] == this) {
+                    builder.append("this");
+                } else {
+                    builder.append(arrayField[i]);
+                }
+            }
+            builder.append("}");
+            return builder.toString();
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (!(o instanceof TestClass)) {
                 return false;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java
@@ -86,7 +86,7 @@ public class VirtualObjectDebugInfoTest extends DebugInfoTest {
                     .append(arrayField.length)
                     .append("]: ");
             for (int i = 0; i < arrayField.length; ++i) {
-                if(i != 0) {
+                if (i != 0) {
                     builder.append("; ");
                 }
                 builder.append("[").append(i).append("]=");


### PR DESCRIPTION
It's all a matter of order. In short, mainline doesn't sort objects fields by offset, but just take them as they come from the stream. The order can be arbitrary, but in some places, it matters it's the same everywhere. Valhalla is sorting too much for mainline's taste, a merge caused clashes.

But maybe, a bit of archeology:
- Mainline [JDK-8350892: [JVMCI] Align ResolvedJavaType.getInstanceFields with Class.getDeclaredFields](https://bugs.openjdk.org/browse/JDK-8350892): it removed some sorting of fields, keeping it consistent between `reassign_fields_by_klass` and `ciInstanceKlass::compute_nonstatic_fields()`: they both had fields offset-sorted, now they are both stream-sorted. Most of HotSpot agrees with this new order. This change also add a new test checking the order is consistent: `compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java`.

- Valhalla: [#1429](https://github.com/openjdk/valhalla/pull/1429) brings [JDK-8350892](https://bugs.openjdk.org/browse/JDK-8350892) in Valhalla. This merge is a bit mysterious to me,  how some sorting reappeared in Valhalla-untouched code. For instance, [JDK-8350892](https://bugs.openjdk.org/browse/JDK-8350892) removed the function `
static int sort_field_by_offset(ciField** a, ciField** b)` and
  ```cpp
  // Now sort them by offset, 
  // (In principle, they could mix with superclass fields.)
  fields->sort(sort_field_by_offset);
  ```
  from `int ciInstanceKlass::compute_nonstatic_fields()` (in `ciInstanceKlass.cpp`), but the merge only removes the comment, but leave the `->sort()` and `sort_field_by_offset`. My guess is that it was a tentative fix for some failing tests after merge. Nevertheless `compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java` is ProblemListed.

- Valhalla: After this merge, Valhalla continues to assume some ordering, as one can see in [JDK-8355076: [lworld] Incorrect declared_nonstatic_fields computation](https://bugs.openjdk.org/browse/JDK-8355076) that (among other things), makes a new occurrence of `->sort(sort_field_by_offset)`, to be consistent with `InlineKlass::collect_fields`. But now, everything is different! The new test introduced by [JDK-8350892](https://bugs.openjdk.org/browse/JDK-8350892) connects more things together, and enforce the same order in `ciInstanceKlass::compute_nonstatic_fields` and in `Class.getDeclaredFields` (reflexion related, I think. I don't know that so well). Moreover `ciInstanceKlass::compute_nonstatic_fields` has to agree with deoptimization code. In Valhalla, the calling convention has to agree with the layout wrt field ordering. Basically, it makes a big chain of things that needs to agree on the order of fields.

- Valhalla: [JDK-8354366: [lworld] VirtualObjectDebugInfoTest fails after merging jdk-25+16](https://bugs.openjdk.org/browse/JDK-8354366) partially reverts [JDK-8350892: [JVMCI] Align ResolvedJavaType.getInstanceFields with Class.getDeclaredFields](https://bugs.openjdk.org/browse/JDK-8350892) by reintroducing sorting. This allowed to un-ProblemList `compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java`, but made `compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java` fail because now, and that's where I start.

Overall, it's a clash in the order of fields. First question is naturally: does the order really has to agree, or do we put some interfaces, pipes and curtains to adapt between potentially different order? I think we should keep a consistent order, as much as possible. It makes everything simpler, possibly more efficient as we don't have to search if we want to work on two lists... Efforts were made in mainline to keep the order consistent, let's not break that.

Second question is which order. Here, same, I'll invoke mainline that decided to go with stream order. It has also the benefit not to require sorting: get the field stream, ready to use. Lighter, easier, more efficient...

Let's define more precisely the order in which the fields should show up. Given a class `Derived`, that extends the class `Base`.
1. superclass first: for any transitive field `b` of `Base`, and any proper field `d` of `Derived`, `b` should appear before `d`,
2. consistent ordering: the list of (transitive) fields of `Base` must be a subsequence of the list of (transitive) fields of `Derived`. In other words, the order of the fields of `Base` in the list of fields of `Base` is the same as the order of the fields of `Base` in the list of fields of `Derived`.
3. proper field ordering: the proper fields of `Derived`, must appear in the order provided by `JavaFieldStream` (which happens to be the declaration order, but is not guaranteed).

This is enough to define the list of declared fields. It implies in particular that the fields of the super class form a prefix of the whole list of declared fields. It makes possible to isolate the proper fields by removing this prefix (and it's done somewhere). It also is cheap to compute as we can just push fields in the order the stream gives, starting with a recursive call to traverse the supertype's fields.

If we are interested in the list of actual fields, as present in the layout, we simply insert the fields of each flatten field instead of them. The null marker of each field, if it exists, appears immediately after.

Which changes need to be made? Mostly removing sorting
- remove sorting in `ciInstanceKlass::compute_nonstatic_fields_impl`.
- remove member variable `float _sort_offset` from `SigEntry` but add `bool _null_marker` for printing in `nmethod::print_nmethod_labels`.
- remove sorting from `InlineKlass::collect_fields`, but also, change the iterator: use the new `TopDownHierarchicalFieldStreamBase` that will travese the super classes first.
- remove sorting from `get_reassigned_fields`, seems to be a merge accident? The code around comes from [JDK-8350892](https://bugs.openjdk.org/browse/JDK-8350892) without the sort, but [#1429](https://github.com/openjdk/valhalla/pull/1429) introduced sorting.
- revert [JDK-8354366: [lworld] VirtualObjectDebugInfoTest fails after merging jdk-25+16](https://bugs.openjdk.org/browse/JDK-8354366), bringing back the changes of [JDK-8350892: [JVMCI] Align ResolvedJavaType.getInstanceFields with Class.getDeclaredFields](https://bugs.openjdk.org/browse/JDK-8350892).

Bonus:
- Added a printer for `VirtualObjectDebugInfoTest$TestClass` because the test failure message being "this `TestClass` is not equal to this other `TestClass`" is not so helpful.
- Added a flag to print fields collected in `InlineKlass::initialize_calling_convention`. It seems it was deemed useful but missing, and not only by me right now! The flag is called `PrintInlineKlassFields` and takes a comma-separated list of class name patterns to print. Feel free to suggest a better name.
- I've tried to print fields in `ciInstanceKlass::compute_nonstatic_fields` to compare. It works, but this function is called way too many times for each class (not sure why, didn't look into that), so not great to leave a flag for that.

Wow, what a wall of text. But for once, it comes with non-trivial changes.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8357785](https://bugs.openjdk.org/browse/JDK-8357785): [lworld] TestResolvedJavaType fails due to unexpected getInstanceFields order (**Bug** - P4)
 * [JDK-8357186](https://bugs.openjdk.org/browse/JDK-8357186): [lworld] Clean up InlineKlass::collect_fields (**Enhancement** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer) ⚠️ Review applies to [7cb1c3fc](https://git.openjdk.org/valhalla/pull/1511/files/7cb1c3fcb396d8c3ab418d46c721de4caf1f1ffc)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [7cb1c3fc](https://git.openjdk.org/valhalla/pull/1511/files/7cb1c3fcb396d8c3ab418d46c721de4caf1f1ffc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1511/head:pull/1511` \
`$ git checkout pull/1511`

Update a local copy of the PR: \
`$ git checkout pull/1511` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1511`

View PR using the GUI difftool: \
`$ git pr show -t 1511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1511.diff">https://git.openjdk.org/valhalla/pull/1511.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1511#issuecomment-3083844125)
</details>
