### PR TITLE
8363846: [lworld] Make Class.isIdentityClass() non-native

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3593,7 +3593,7 @@ bool InstanceKlass::find_inner_classes_attr(int* ooff, int* noff, TRAPS) const {
 
 void InstanceKlass::check_can_be_annotated_with_NullRestricted(InstanceKlass* type, Symbol* container_klass_name, TRAPS) {
   assert(type->is_instance_klass(), "Sanity check");
-  if (type->access_flags().is_identity_class()) {
+  if (type->is_identity_class()) {
     ResourceMark rm(THREAD);
     THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
               err_msg("Class %s expects class %s to be a value class, but it is an identity class",

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -729,7 +729,7 @@ public:
   bool is_interface() const             { return _access_flags.is_interface(); }
   bool is_abstract() const              { return _access_flags.is_abstract(); }
   bool is_synthetic() const             { return _access_flags.is_synthetic(); }
-  bool is_identity_class() const        { return _access_flags.is_identity_class(); }
+  bool is_identity_class() const        { assert(is_instance_klass(), "only for instanceKlass"); return _access_flags.is_identity_class(); }
   void set_is_synthetic()               { _access_flags.set_is_synthetic(); }
   bool has_finalizer() const            { return _misc_flags.has_finalizer(); }
   void set_has_finalizer()              { _misc_flags.set_has_finalizer(true); }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -419,7 +419,7 @@ static void validate_array_arguments(Klass* elmClass, jint len, TRAPS) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Array length is negative");
   }
   elmClass->initialize(CHECK);
-  if (elmClass->is_identity_class()) {
+  if (elmClass->is_array_klass() || elmClass->is_identity_class()) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not a value class");
   }
   if (elmClass->is_abstract()) {
@@ -1387,19 +1387,6 @@ JVM_ENTRY(jboolean, JVM_IsHiddenClass(JNIEnv *env, jclass cls))
   }
   Klass* k = java_lang_Class::as_Klass(mirror);
   return k->is_hidden();
-JVM_END
-
-JVM_ENTRY(jboolean, JVM_IsIdentityClass(JNIEnv *env, jclass cls))
-  oop mirror = JNIHandles::resolve_non_null(cls);
-  if (java_lang_Class::is_primitive(mirror)) {
-    return JNI_FALSE;
-  }
-  Klass* k = java_lang_Class::as_Klass(mirror);
-  if (EnableValhalla) {
-    return k->is_array_klass() || k->is_identity_class();
-  } else {
-    return k->is_interface() ? JNI_FALSE : JNI_TRUE;
-  }
 JVM_END
 
 class ScopedValueBindingsResolver {

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -413,7 +413,7 @@ UNSAFE_ENTRY(jarray, Unsafe_NewSpecialArray(JNIEnv *env, jobject unsafe, jclass 
   if (len < 0) {
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Array length is negative");
   }
-  if (klass->is_identity_class()) {
+  if (klass->is_array_klass() || klass->is_identity_class()) {
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not a value class");
   }
   if (klass->is_abstract()) {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -624,7 +624,15 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
-    public native boolean isIdentity();
+    public boolean isIdentity() {
+        if (isPrimitive()) {
+            return false;
+        } else if (PreviewFeatures.isEnabled()) {
+           return isArray() || Modifier.isIdentity(modifiers);
+        } else {
+            return !isInterface();
+        }
+    }
 
     /**
      * {@return {@code true} if this {@code Class} object represents a value

--- a/src/java.base/share/native/libjava/Class.c
+++ b/src/java.base/share/native/libjava/Class.c
@@ -57,7 +57,6 @@ static JNINativeMethod methods[] = {
     {"getSuperclass",    "()" CLS,          NULL},
     {"getInterfaces0",   "()[" CLS,         (void *)&JVM_GetClassInterfaces},
     {"isHidden",         "()Z",             (void *)&JVM_IsHiddenClass},
-    {"isIdentity",       "()Z",             (void *)&JVM_IsIdentityClass},
     {"getDeclaredFields0","(Z)[" FLD,       (void *)&JVM_GetClassDeclaredFields},
     {"getDeclaredMethods0","(Z)[" MHD,      (void *)&JVM_GetClassDeclaredMethods},
     {"getDeclaredConstructors0","(Z)[" CTR, (void *)&JVM_GetClassDeclaredConstructors},

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -59,7 +59,7 @@ public class IsIdentityClassTest {
         int imod = Integer.class.getModifiers();
         assertFalseIfPreview(Modifier.isIdentity(imod), "Modifier of Integer should not have IDENTITY set");
         int amod = Integer[].class.getModifiers();
-        assertTrue(Modifier.isIdentity(amod), "Modifier of array of inline types should have IDENTITY set");
+        assertEquals(PreviewFeatures.isPreviewEnabled(), Modifier.isIdentity(amod), "Modifier of array should have IDENTITY set");
     }
 
     @Test

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Test that IsIdentityClass and modifiers return true for arrays that can be flattened.
  * @library /test/lib
+ * @enablePreview false
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.value
  * @run junit/othervm IsIdentityClassTest
@@ -38,7 +39,6 @@ import java.lang.reflect.Modifier;
 import java.util.Set;
 
 import jdk.internal.misc.PreviewFeatures;
-import jdk.internal.value.ValueClass;
 
 import static jdk.test.lib.Asserts.*;
 

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -23,22 +23,18 @@
 
 /*
  * @test
- * @summary Test that IsIdentityClass and modifiers return true for flattened arrays.
+ * @summary Test that IsIdentityClass and modifiers return true for arrays that can be flattened.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.value
  * @run junit/othervm IsIdentityClassTest
- * @run junit/othervm --enable-preview -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening IsIdentityClassTest
- * @run junit/othervm --enable-preview -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening IsIdentityClassTest
+ * @run junit/othervm --enable-preview IsIdentityClassTest
  */
 
 import org.junit.jupiter.api.Test;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Modifier;
-import java.util.List;
 import java.util.Set;
 
 import jdk.internal.misc.PreviewFeatures;
@@ -49,26 +45,11 @@ import static jdk.test.lib.Asserts.*;
 public class IsIdentityClassTest {
 
     private static void assertFalseIfPreview(boolean condition, String msg) {
-        if (PreviewFeatures.isEnabled()) {
-            assertFalse(condition, msg);
-        } else {
-            assertTrue(condition, msg);
-        }
+        assertEquals(!PreviewFeatures.isEnabled(), condition, msg);
     }
 
     @Test
     void testIsIdentityClass() {
-        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
-        List<String> arguments = runtimeMxBean.getInputArguments();
-        boolean UseArrayFlattening = !arguments.contains("-XX:-UseArrayFlattening");
-        System.out.println("UseArrayFlattening: " + UseArrayFlattening);
-
-        Integer[] array0 = new Integer[200];
-        if (UseArrayFlattening) {
-            // NYI assertTrue(ValueClass.isFlatArray(array0));
-        } else {
-            assertFalse(ValueClass.isFlatArray(array0));
-        }
         assertFalseIfPreview(Integer.class.isIdentity(), "Integer is not an IDENTITY type");
         assertTrue(Integer[].class.isIdentity(), "Arrays of inline types are IDENTITY types");
     }

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -72,8 +72,8 @@ public class IsIdentityClassTest {
             Set<AccessFlag> iacc = Integer.class.accessFlags();
             assertFalse(iacc.contains(AccessFlag.IDENTITY), "Access flags should not contain IDENTITY");
         }
-        // AccessFlags for arrays are not set.
+        // AccessFlags for arrays set the IDENTITY accessflag.
         Set<AccessFlag> aacc = Integer[].class.accessFlags();
-        assertFalse(aacc.contains(Modifier.IDENTITY), "Access flags of array of inline types should not contain IDENTITY");
+        assertEquals(PreviewFeatures.isEnabled(), aacc.contains(AccessFlag.IDENTITY), "Access flags of array of inline types should contain IDENTITY");
     }
 }

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -44,32 +44,36 @@ import static jdk.test.lib.Asserts.*;
 
 public class IsIdentityClassTest {
 
-    private static void assertFalseIfPreview(boolean condition, String msg) {
-        assertEquals(!PreviewFeatures.isEnabled(), condition, msg);
-    }
-
     @Test
     void testIsIdentityClass() {
-        assertFalseIfPreview(Integer.class.isIdentity(), "Integer is not an IDENTITY type");
+        assertEquals(!PreviewFeatures.isEnabled(), Integer.class.isIdentity(), "Integer is not an IDENTITY type");
         assertTrue(Integer[].class.isIdentity(), "Arrays of inline types are IDENTITY types");
     }
 
     @Test
     void testModifiers() {
-        int imod = Integer.class.getModifiers();
-        assertFalseIfPreview(Modifier.isIdentity(imod), "Modifier of Integer should not have IDENTITY set");
+        // Without --enable-preview (before Valhalla), there was no IDENTITY modifier.
+        // With --enable-preview, Integer still should not have the IDENTITY modifier.
+        // So only verify this in preview mode.
+        if (PreviewFeatures.isEnabled()) {
+            int imod = Integer.class.getModifiers();
+            assertFalse(Modifier.isIdentity(imod), "Modifier of Integer should not have IDENTITY set");
+        }
         int amod = Integer[].class.getModifiers();
-        assertEquals(PreviewFeatures.isPreviewEnabled(), Modifier.isIdentity(amod), "Modifier of array should have IDENTITY set");
+        assertEquals(PreviewFeatures.isEnabled(), Modifier.isIdentity(amod), "Modifier of array should have IDENTITY set");
     }
 
     @Test
     void testAccessFlags() {
+        // Without --enable-preview (before Valhalla), there was no IDENTITY accessflag.
+        // With --enable-preview, Integer still should not have the IDENTITY accessflag.
+        // So only verify this in preview mode.
         if (PreviewFeatures.isEnabled()) {
             Set<AccessFlag> iacc = Integer.class.accessFlags();
             assertFalse(iacc.contains(AccessFlag.IDENTITY), "Access flags should not contain IDENTITY");
         }
-Without --enable-preview (before Valhalla), there was no IDENTITY accessflag.
+        // AccessFlags for arrays are not set.
         Set<AccessFlag> aacc = Integer[].class.accessFlags();
-        assertFalse(aacc.contains(Modifier.IDENTITY), "Access flags of array of inline types should contain IDENTITY");
+        assertFalse(aacc.contains(Modifier.IDENTITY), "Access flags of array of inline types should not contain IDENTITY");
     }
 }

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -30,6 +30,13 @@
  * @run main/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening IsIdentityClassTest
  */
 
+/*
+ * @test
+ * @summary Test that IsIdentityClass and modifiers return true for arrays not in preview.
+ * @library /test/lib
+ * @run main/othervm IsIdentityClassTest
+ */
+
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.AccessFlag;

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test that IsIdentityClass and modifiers return true for flattened arrays.
+ * @library /test/lib
+ * @enablePreview
+ * @run main/othervm -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening IsIdentityClassTest
+ * @run main/othervm -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening IsIdentityClassTest
+ */
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.lang.reflect.AccessFlag;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Set;
+
+import jdk.internal.value.ValueClass;
+
+import static jdk.test.lib.Asserts.*;
+
+public class IsIdentityClassTest {
+
+    static boolean UseArrayFlattening = false;
+    static {
+        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+        List<String> arguments = runtimeMxBean.getInputArguments();
+        UseArrayFlattening = !arguments.contains("-XX:-UseArrayFlattening");
+        System.out.println("UseArrayFlattening: " + UseArrayFlattening);
+    }
+
+    static void testIsIdentityClass() {
+        Integer[] array0 = new Integer[200];
+        if (UseArrayFlattening) {
+            // NYI assertTrue(ValueClass.isFlatArray(array0));
+        } else {
+            assertFalse(ValueClass.isFlatArray(array0));
+        }
+        assertFalse(Integer.class.isIdentity(), "Integer is not an IDENTITY type");
+        assertTrue(Integer[].class.isIdentity(), "Arrays of inline types are IDENTITY types");
+    }
+
+    static void testModifiers() {
+        int imod = Integer.class.getModifiers();
+        assertFalse(Modifier.isIdentity(imod), "Modifier of Integer should not have IDENTITY set");
+        int amod = Integer[].class.getModifiers();
+        assertTrue(Modifier.isIdentity(amod), "Modifier of array of inline types should have IDENTITY set");
+    }
+
+    static void testAccessFlags() {
+        Set<AccessFlag> iacc = Integer.class.accessFlags();
+        assertFalse(iacc.contains(Modifier.IDENTITY), "Access flags should not contain IDENTITY");
+        Set<AccessFlag> aacc = Integer[].class.accessFlags();
+        assertFalse(aacc.contains(Modifier.IDENTITY), "Access flags of array of inline types should contain IDENTITY");
+    }
+
+    public static void main(String[] args) throws Exception {
+        testIsIdentityClass();
+        testModifiers();
+        testAccessFlags();
+    }
+}

--- a/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
+++ b/test/jdk/valhalla/valuetypes/IsIdentityClassTest.java
@@ -64,8 +64,11 @@ public class IsIdentityClassTest {
 
     @Test
     void testAccessFlags() {
-        Set<AccessFlag> iacc = Integer.class.accessFlags();
-        assertFalseIfPreview(iacc.contains(Modifier.IDENTITY), "Access flags should not contain IDENTITY");
+        if (PreviewFeatures.isEnabled()) {
+            Set<AccessFlag> iacc = Integer.class.accessFlags();
+            assertFalse(iacc.contains(AccessFlag.IDENTITY), "Access flags should not contain IDENTITY");
+        }
+Without --enable-preview (before Valhalla), there was no IDENTITY accessflag.
         Set<AccessFlag> aacc = Integer[].class.accessFlags();
         assertFalse(aacc.contains(Modifier.IDENTITY), "Access flags of array of inline types should contain IDENTITY");
     }


### PR DESCRIPTION
This moves isIdentityClass() implementation to Class.java, and checks within the JVM that is_identity_class() doesn't check the access flags for an ArrayKlass, since AccessFlags aren't initialized in ArrayKlasses.  The AccessFlags should be moved from Klass.hpp to InstanceKlass.cpp in mainline but that's a more complicated change and has several pieces.
Added a test.
Tested with tier1 locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8363846](https://bugs.openjdk.org/browse/JDK-8363846): [lworld] Make Class.isIdentityClass() non-native (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1514/head:pull/1514` \
`$ git checkout pull/1514`

Update a local copy of the PR: \
`$ git checkout pull/1514` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1514`

View PR using the GUI difftool: \
`$ git pr show -t 1514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1514.diff">https://git.openjdk.org/valhalla/pull/1514.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1514#issuecomment-3104078637)
</details>
