### PR TITLE
8363956: [lworld] Valhalla vauetypes tests enablePreview should be per test

### DIFF
--- a/test/jdk/valhalla/valuetypes/RecursiveValueClass.java
+++ b/test/jdk/valhalla/valuetypes/RecursiveValueClass.java
@@ -23,17 +23,20 @@
 
 /*
  * @test
+ * @enablePreview
  * @run junit/othervm -Xint -Djdk.value.recursion.threshold=100000 RecursiveValueClass
  */
 
 /*
  * @ignore 8296056
+ * @enablePreview
  * @test
  * @run junit/othervm -XX:TieredStopAtLevel=1 -Djdk.value.recursion.threshold=100000 RecursiveValueClass
  */
 
 /*
  * @ignore 8296056
+ * @enablePreview
  * @test
  * @run junit/othervm -Xcomp -Djdk.value.recursion.threshold=100000 RecursiveValueClass
  */

--- a/test/jdk/valhalla/valuetypes/TEST.properties
+++ b/test/jdk/valhalla/valuetypes/TEST.properties
@@ -1,3 +1,2 @@
 modules = java.base/jdk.internal.value \
           java.base/jdk.internal.vm.annotation
-enablePreview = true


### PR DESCRIPTION
The enable for preview should be per test, not per test directory.

Remove enablePreview = true from valhalla/valuetypes/TEST.properties and add to tests as needed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8363956](https://bugs.openjdk.org/browse/JDK-8363956): [lworld] Valhalla vauetypes tests enablePreview should be per test (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1515/head:pull/1515` \
`$ git checkout pull/1515`

Update a local copy of the PR: \
`$ git checkout pull/1515` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1515`

View PR using the GUI difftool: \
`$ git pr show -t 1515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1515.diff">https://git.openjdk.org/valhalla/pull/1515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1515#issuecomment-3109135071)
</details>
