### PR TITLE
8364034: [lworld] Pre-register boxing classes in class loaders

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6229,7 +6229,6 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           }
         } else {
           // Just poking the system dictionary to see if the class has already be loaded
-          // TODO FIXME: Need logging here?
           oop loader = loader_data()->class_loader();
           InstanceKlass* klass = SystemDictionary::find_instance_klass(THREAD, name, Handle(THREAD, loader));
           if (UseNewCode) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6227,7 +6227,18 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           if (HAS_PENDING_EXCEPTION) {
             CLEAR_PENDING_EXCEPTION;
           }
-        }
+        } else {
+          // Just poking the system dictionary to see if the class has already be loaded
+          // TODO FIXME: Need logging here?
+          oop loader = loader_data()->class_loader();
+          InstanceKlass* klass = SystemDictionary::find_instance_klass(THREAD, name, Handle(THREAD, loader));
+          if (UseNewCode) {
+            assert(!name->equals("java/lang/Integer") || klass != nullptr, "Integer should be loaded");
+          }
+          if (klass != nullptr && klass->is_inline_klass()) {
+            _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(InlineKlass::cast(klass));
+          }
+	      }
       }
     }
   }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6231,9 +6231,6 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           // Just poking the system dictionary to see if the class has already be loaded
           oop loader = loader_data()->class_loader();
           InstanceKlass* klass = SystemDictionary::find_instance_klass(THREAD, name, Handle(THREAD, loader));
-          if (UseNewCode) {
-            assert(!name->equals("java/lang/Integer") || klass != nullptr, "Integer should be loaded");
-          }
           if (klass != nullptr && klass->is_inline_klass()) {
             _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(InlineKlass::cast(klass));
           }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6238,7 +6238,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           if (klass != nullptr && klass->is_inline_klass()) {
             _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(InlineKlass::cast(klass));
           }
-	      }
+        }
       }
     }
   }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -191,12 +191,11 @@ inline ClassLoaderData* class_loader_data(Handle class_loader) {
   return ClassLoaderData::class_loader_data(class_loader());
 }
 
-#define ADD_WRAPPER_CLASS(name)                                                      \
-  {                                                                                  \
-    InstanceKlass* ik = SystemDictionary::find_instance_klass(Thread::current(), vmSymbols::java_lang_##name(), Handle(Thread::current(), nullptr)); \
-    assert(ik != nullptr, "Must exist");                                             \
-    SystemDictionary::add_to_initiating_loader(JavaThread::current(), ik, cld);      \
-  }
+static void add_wrapper_class(JavaThread* current, ClassLoaderData* cld, Symbol* classname) {
+  InstanceKlass* ik = SystemDictionary::find_instance_klass(current, classname, Handle(current, nullptr));
+  assert(ik != nullptr, "Must exist");
+  SystemDictionary::add_to_initiating_loader(current, ik, cld);
+}
 
 ClassLoaderData* SystemDictionary::register_loader(Handle class_loader, bool create_mirror_cld) {
   ClassLoaderData* cld = nullptr;
@@ -209,19 +208,18 @@ ClassLoaderData* SystemDictionary::register_loader(Handle class_loader, bool cre
   }
   if (class_loader() != nullptr && cld->dictionary() != nullptr) {
     MonitorLocker mu1(SystemDictionary_lock);
-    ADD_WRAPPER_CLASS(Boolean);
-    ADD_WRAPPER_CLASS(Byte);
-    ADD_WRAPPER_CLASS(Character);
-    ADD_WRAPPER_CLASS(Short);
-    ADD_WRAPPER_CLASS(Integer);
-    ADD_WRAPPER_CLASS(Long);
-    ADD_WRAPPER_CLASS(Float);
-    ADD_WRAPPER_CLASS(Double);
+    JavaThread* current = JavaThread::current();
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Boolean());
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Byte());
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Character());
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Short());
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Integer());
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Long());
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Float());
+    add_wrapper_class(current, cld, vmSymbols::java_lang_Double());
   }
   return cld;
 }
-
-#undef ADD_WRAPPER_CLASS
 
 void SystemDictionary::set_system_loader(ClassLoaderData *cld) {
   assert(_java_system_loader.is_empty(), "already set!");

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -191,15 +191,37 @@ inline ClassLoaderData* class_loader_data(Handle class_loader) {
   return ClassLoaderData::class_loader_data(class_loader());
 }
 
+#define ADD_WRAPPER_CLASS(name)                                                      \
+  {                                                                                  \
+    InstanceKlass* ik = SystemDictionary::find_instance_klass(Thread::current(), vmSymbols::java_lang_##name(), Handle(Thread::current(), nullptr)); \
+    assert(ik != nullptr, "Must exist");                                             \
+    SystemDictionary::add_to_initiating_loader(JavaThread::current(), ik, cld);      \
+  }
+
 ClassLoaderData* SystemDictionary::register_loader(Handle class_loader, bool create_mirror_cld) {
+  ClassLoaderData* cld = nullptr;
   if (create_mirror_cld) {
     // Add a new class loader data to the graph.
-    return ClassLoaderDataGraph::add(class_loader, true);
+    cld = ClassLoaderDataGraph::add(class_loader, true);
   } else {
-    return (class_loader() == nullptr) ? ClassLoaderData::the_null_class_loader_data() :
+    cld = (class_loader() == nullptr) ? ClassLoaderData::the_null_class_loader_data() :
                                       ClassLoaderDataGraph::find_or_create(class_loader);
   }
+  if (class_loader() != nullptr && cld->dictionary() != nullptr) {
+    MonitorLocker mu1(SystemDictionary_lock);
+    ADD_WRAPPER_CLASS(Boolean);
+    ADD_WRAPPER_CLASS(Byte);
+    ADD_WRAPPER_CLASS(Character);
+    ADD_WRAPPER_CLASS(Short);
+    ADD_WRAPPER_CLASS(Integer);
+    ADD_WRAPPER_CLASS(Long);
+    ADD_WRAPPER_CLASS(Float);
+    ADD_WRAPPER_CLASS(Double);
+  }
+  return cld;
 }
+
+#undef ADD_WRAPPER_CLASS
 
 void SystemDictionary::set_system_loader(ClassLoaderData *cld) {
   assert(_java_system_loader.is_empty(), "already set!");
@@ -1746,23 +1768,23 @@ void SystemDictionary::update_dictionary(JavaThread* current,
   mu1.notify_all();
 }
 
-#if INCLUDE_CDS
 // Indicate that loader_data has initiated the loading of class k, which
 // has already been defined by a parent loader.
-// This API should be used only by AOTLinkedClassBulkLoader
+// This API is used by AOTLinkedClassBulkLoader and to register boxing
+// classes from java.lang in all class loaders to enable more value
+// classes optimizations
 void SystemDictionary::add_to_initiating_loader(JavaThread* current,
                                                 InstanceKlass* k,
                                                 ClassLoaderData* loader_data) {
-  assert(CDSConfig::is_using_aot_linked_classes(), "must be");
   assert_locked_or_safepoint(SystemDictionary_lock);
   Symbol* name  = k->name();
   Dictionary* dictionary = loader_data->dictionary();
   assert(k->is_loaded(), "must be");
   assert(k->class_loader_data() != loader_data, "only for classes defined by a parent loader");
-  assert(dictionary->find_class(current, name) == nullptr, "sanity");
-  dictionary->add_klass(current, name, k);
+  if (dictionary->find_class(current, name) == nullptr) {
+    dictionary->add_klass(current, name, k);
+  }
 }
-#endif
 
 // Try to find a class name using the loader constraints.  The
 // loader constraints might know about a class that isn't fully loaded

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -211,19 +211,18 @@ static void add_wrapper_classes(ClassLoaderData* cld) {
 }
 
 ClassLoaderData* SystemDictionary::register_loader(Handle class_loader, bool create_mirror_cld) {
-  ClassLoaderData* cld = nullptr;
   if (create_mirror_cld) {
     // Add a new class loader data to the graph.
-    cld = ClassLoaderDataGraph::add(class_loader, true);
+    return ClassLoaderDataGraph::add(class_loader, true);
   } else {
     if (class_loader() == nullptr) {
-      cld = ClassLoaderData::the_null_class_loader_data();
+      return ClassLoaderData::the_null_class_loader_data();
     } else {
-      cld = ClassLoaderDataGraph::find_or_create(class_loader);
+      ClassLoaderData* cld = ClassLoaderDataGraph::find_or_create(class_loader);
       add_wrapper_classes(cld);
+      return cld;
     }
   }
-  return cld;
 }
 
 void SystemDictionary::set_system_loader(ClassLoaderData *cld) {

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -287,7 +287,7 @@ public:
   static const char* find_nest_host_error(const constantPoolHandle& pool, int which);
 
   static void add_to_initiating_loader(JavaThread* current, InstanceKlass* k,
-                                       ClassLoaderData* loader_data) NOT_CDS_RETURN;
+                                       ClassLoaderData* loader_data);
 
   static OopHandle  _java_system_loader;
   static OopHandle  _java_platform_loader;


### PR DESCRIPTION
Add pre-registration of boxing classes when a class loader is registered by the VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8364034](https://bugs.openjdk.org/browse/JDK-8364034): [lworld] Pre-register boxing classes in class loaders (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1517/head:pull/1517` \
`$ git checkout pull/1517`

Update a local copy of the PR: \
`$ git checkout pull/1517` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1517`

View PR using the GUI difftool: \
`$ git pr show -t 1517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1517.diff">https://git.openjdk.org/valhalla/pull/1517.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1517#issuecomment-3114159414)
</details>
