### PR TITLE
8364321: Add JDI tests for value objects

### DIFF
--- a/test/jdk/com/sun/jdi/valhalla/FieldWatchpointsTest.java
+++ b/test/jdk/com/sun/jdi/valhalla/FieldWatchpointsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Sanity test for AccessWatchpoint/ModificationWatchpoint and InstanceFilter with value objects
+ *
+ * @library ..
+ * @enablePreview
+ * @run main/othervm FieldWatchpointsTest
+ *                   -XX:+UseArrayFlattening -XX:+UseFieldFlattening -XX:+UseAtomicValueFlattening -XX:+UseNullableValueFlattening
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlineLayout -XX:+PrintFlatArrayLayout
+ */
+import com.sun.jdi.Field;
+import com.sun.jdi.ClassType;
+import com.sun.jdi.Method;
+import com.sun.jdi.ObjectReference;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.Value;
+import com.sun.jdi.event.AccessWatchpointEvent;
+import com.sun.jdi.event.BreakpointEvent;
+import com.sun.jdi.event.ModificationWatchpointEvent;
+import com.sun.jdi.event.WatchpointEvent;
+import com.sun.jdi.request.WatchpointRequest;
+import java.util.ArrayList;
+import java.util.List;
+
+class FieldWatchpointsTarg {
+    static value class Value {
+        int v;
+        Value() {
+            this(0);
+        }
+        Value(int v) {
+            this.v = v;
+        }
+        public int getValue() {
+            return v;
+        }
+    }
+
+    static Value staticField = new Value(1);
+
+    public static void main(String[] args) {
+        System.out.println(">>Targ.main");
+        Value obj = new Value(2); // modify
+        System.out.println("obj value = " + obj.v); // access
+        System.out.println("staticField value = " + staticField.v); // access
+        System.out.println("<<Targ.main");
+    }
+}
+
+public class FieldWatchpointsTest extends TestScaffold {
+
+    FieldWatchpointsTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)      throws Exception {
+        new FieldWatchpointsTest(args).startTests();
+    }
+
+    boolean equals(ObjectReference obj1, ObjectReference obj2) throws Exception {
+        return obj1.equals(obj2);
+    }
+
+    void assertEqual(ObjectReference obj1, ObjectReference obj2) throws Exception {
+        if (!equals(obj1, obj2)) {
+            throw new RuntimeException("Values are not equal: " + obj1 + " and " + obj2);
+        }
+    }
+
+    void assertNotEqual(ObjectReference obj1, ObjectReference obj2) throws Exception {
+        if (equals(obj1, obj2)) {
+            throw new RuntimeException("Values are equal: " + obj1 + " and " + obj2);
+        }
+    }
+
+    public void fieldAccessed(AccessWatchpointEvent event) {
+        TestCase.watchpoint(event);
+    }
+
+    public void fieldModified(ModificationWatchpointEvent event) {
+        TestCase.watchpoint(event);
+    }
+
+    protected void runTests() throws Exception {
+        List<TestCase> testCases = new ArrayList<>();
+        try {
+            BreakpointEvent bpe = startToMain("FieldWatchpointsTarg");
+            ThreadReference mainThread = bpe.thread();
+            ClassType testClass = (ClassType)bpe.location().declaringType();
+            Field staticValueField = testClass.fieldByName("staticField");
+            ClassType valueClass = (ClassType)staticValueField.type();
+            ObjectReference staticFieldValue = (ObjectReference)testClass.getValue(staticValueField);
+
+            Field watchField = valueClass.fieldByName("v");
+
+            WatchpointRequest request = eventRequestManager().createModificationWatchpointRequest(watchField);
+            testCases.add(new TestCase("modify", 1, request)); // obj ctor
+
+            request = eventRequestManager().createAccessWatchpointRequest(watchField);
+            testCases.add(new TestCase("access", 2, request)); // staticField, obj
+
+            request = eventRequestManager().createAccessWatchpointRequest(watchField);
+            request.addInstanceFilter(staticFieldValue);
+            testCases.add(new TestCase("access+instanceFilter", 1, request)); // only staticField
+        } finally {
+            listenUntilVMDisconnect();
+        }
+
+        for (TestCase test: testCases) {
+            String msg = "Testcase: " + test.name
+                        + ", count = " + test.count
+                        + ", expectedCount = " + test.expectedCount;
+            System.out.println(msg);
+            if (test.count != test.expectedCount) {
+                throw new RuntimeException("FAILED " + msg);
+            }
+        }
+    }
+
+    class TestCase {
+        String name;
+        int count;
+        int expectedCount;
+        TestCase(String name, int expectedCount, WatchpointRequest request) {
+            this.name = name;
+            this.expectedCount = expectedCount;
+            request.putProperty("testcase", this);
+            request.enable();
+        }
+
+        static void watchpoint(WatchpointEvent event) {
+            TestCase test = (TestCase)event.request().getProperty("testcase");
+            test.count++;
+        }
+    }
+}

--- a/test/jdk/com/sun/jdi/valhalla/ValueArrayReferenceTest.java
+++ b/test/jdk/com/sun/jdi/valhalla/ValueArrayReferenceTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Sanity test for ArrayReference (getValue/setValue) with flat arrays
+ *
+ * @modules java.base/jdk.internal.value
+ * @library ..
+ * @enablePreview
+ * @run main/othervm ValueArrayReferenceTest
+ *                   --add-modules java.base --add-exports java.base/jdk.internal.value=ALL-UNNAMED
+ *                   -XX:+UseArrayFlattening -XX:+UseFieldFlattening -XX:+UseAtomicValueFlattening -XX:+UseNullableValueFlattening
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlineLayout -XX:+PrintFlatArrayLayout
+ */
+import com.sun.jdi.ArrayReference;
+import com.sun.jdi.Field;
+import com.sun.jdi.ReferenceType;
+import com.sun.jdi.Value;
+import com.sun.jdi.event.BreakpointEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import jdk.internal.value.ValueClass;
+
+class ValueArrayReferenceTarg {
+    static value class Value {
+        int v;
+        Value() {
+            this(0);
+        }
+        Value(int v) {
+            this.v = v;
+        }
+        public int getValue() {
+            return v;
+        }
+    }
+
+    static int ARRAY_SIZE = 5;
+    static void initArray(Value[] arr) {
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = new Value(i);
+        }
+    }
+
+    static Value[] testRegularArray;
+    static Value[] testNullableAtomicArray;
+    static Value[] testNonNullNonAtomicArray;
+    static Value[] testNonNullAtomicArray;
+
+    static Value otherValue = new Value(25);
+
+    static {
+        try {
+            testRegularArray = new Value[ARRAY_SIZE];
+            initArray(testRegularArray);
+
+            testNullableAtomicArray = (Value[])ValueClass.newNullableAtomicArray(Value.class, ARRAY_SIZE);
+            initArray(testNullableAtomicArray);
+
+            testNonNullNonAtomicArray = (Value[])ValueClass.newNullRestrictedNonAtomicArray(Value.class, ARRAY_SIZE, Value.class.newInstance());
+            initArray(testNonNullNonAtomicArray);
+
+            testNonNullAtomicArray = (Value[])ValueClass.newNullRestrictedAtomicArray(Value.class, ARRAY_SIZE, Value.class.newInstance());
+            initArray(testNonNullAtomicArray);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Hello and goodbye from main");
+    }
+}
+
+public class ValueArrayReferenceTest extends TestScaffold {
+
+    ValueArrayReferenceTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new ValueArrayReferenceTest(args).startTests();
+    }
+
+    String arrayToString(ArrayReference array) {
+        List<Value> values = array.getValues();
+        // Mirror.toString reports object type and reference id,
+        // it should be enough to see if objects are different.
+        return values.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    Value getFieldValue(ReferenceType cls, String fieldName) {
+        System.out.println("Getting value from " + fieldName);
+        Value value = cls.getValue(cls.fieldByName(fieldName));
+        System.out.println(" - " + value);
+        return value;
+    }
+
+    ArrayReference getArrayFromField(ReferenceType cls, Field field) throws Exception {
+        System.out.println("Getting array from " + field.name());
+        ArrayReference array = (ArrayReference)cls.getValue(field);
+        System.out.println(" - " + array);
+        System.out.println("   " + arrayToString(array));
+        return array;
+    }
+
+    boolean arraysEquals(ArrayReference arr1, ArrayReference arr2) throws Exception {
+        // Compare string representation of the array (contains object type and id for each element).
+        String s1 = arrayToString(arr1);
+        String s2 = arrayToString(arr2);
+        return s1.equals(s2);
+    }
+
+    void fillArrayWithOtherValue(ArrayReference arr, Value value) throws Exception {
+        for (int i = 0; i < arr.length(); i++) {
+            arr.setValue(i, value);
+        }
+    }
+
+    void verifyArraysEqual(List<ArrayReference> arrays) throws Exception {
+        for (ArrayReference arr1: arrays) {
+            for (ArrayReference arr2: arrays) {
+                if (!arraysEquals(arr1, arr2)) {
+                    System.out.println("Arrays are different (1):"
+                                     + "\n    - " + arrayToString(arr1)
+                                     + "\n    - " + arrayToString(arr2));
+                    throw new RuntimeException("Arrays are different");
+                }
+            }
+        }
+    }
+
+    protected void runTests() throws Exception {
+        try {
+            BreakpointEvent bpe = startToMain("ValueArrayReferenceTarg");
+            ReferenceType cls = bpe.location().declaringType();
+
+            // Get all arrays.
+            List<ArrayReference> arrays = new ArrayList<>();
+            List<Field> fields = cls.allFields();
+            for (Field field: fields) {
+                if (field.name().startsWith("test")) {
+                    arrays.add(getArrayFromField(cls, field));
+                }
+            }
+
+            // Ensure elements in all arrays are equal.
+            verifyArraysEqual(arrays);
+
+            // Update arrays.
+            Value otherValue = getFieldValue(cls, "otherValue");
+            for (ArrayReference arr: arrays) {
+                fillArrayWithOtherValue(arr, otherValue);
+                System.out.println("Array after update:");
+                System.out.println("   " + arrayToString(arr));
+            }
+
+            // Ensure elements in all arrays are equal.
+            verifyArraysEqual(arrays);
+        } finally {
+            // Resume the target until end.
+            listenUntilVMDisconnect();
+        }
+    }
+}

--- a/test/jdk/com/sun/jdi/valhalla/ValueClassTypeTest.java
+++ b/test/jdk/com/sun/jdi/valhalla/ValueClassTypeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Sanity test for ClassType (getValue, setValue, newInstance) with value objects
+ *
+ * @library ..
+ * @enablePreview
+ * @run main/othervm ValueClassTypeTest
+ *                   -XX:+UseArrayFlattening -XX:+UseFieldFlattening -XX:+UseAtomicValueFlattening -XX:+UseNullableValueFlattening
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlineLayout -XX:+PrintFlatArrayLayout
+ */
+import com.sun.jdi.Field;
+import com.sun.jdi.ClassType;
+import com.sun.jdi.Method;
+import com.sun.jdi.ObjectReference;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.Value;
+import com.sun.jdi.event.BreakpointEvent;
+import java.util.List;
+
+class ValueClassTypeTarg {
+    static value class Value {
+        static Value staticField = new Value(1);
+
+        int v;
+        Value() {
+            this(0);
+        }
+        Value(int v) {
+            this.v = v;
+        }
+        public int getValue() {
+            return v;
+        }
+    }
+
+    static Value staticField = new Value(2);
+
+    public static void main(String[] args) {
+        System.out.println("Hello and goodbye from main");
+    }
+}
+
+public class ValueClassTypeTest extends TestScaffold {
+
+    ValueClassTypeTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)      throws Exception {
+        new ValueClassTypeTest(args).startTests();
+    }
+
+    boolean equals(ObjectReference obj1, ObjectReference obj2) throws Exception {
+        return obj1.equals(obj2);
+    }
+
+    void assertEqual(ObjectReference obj1, ObjectReference obj2) throws Exception {
+        if (!equals(obj1, obj2)) {
+            throw new RuntimeException("Values are not equal: " + obj1 + " and " + obj2);
+        }
+    }
+
+    void assertNotEqual(ObjectReference obj1, ObjectReference obj2) throws Exception {
+        if (equals(obj1, obj2)) {
+            throw new RuntimeException("Values are equal: " + obj1 + " and " + obj2);
+        }
+    }
+
+    protected void runTests() throws Exception {
+        try {
+            BreakpointEvent bpe = startToMain("ValueClassTypeTarg");
+            ThreadReference mainThread = bpe.thread();
+            ClassType testClass = (ClassType)bpe.location().declaringType();
+            Field testField = testClass.fieldByName("staticField");
+            ObjectReference value1 = (ObjectReference)testClass.getValue(testField);
+
+            ClassType valueClass = (ClassType)value1.type();
+            Field valueField = valueClass.fieldByName("staticField");
+            ObjectReference value2 = (ObjectReference)valueClass.getValue(valueField);
+
+            Method valueCtor = valueClass.concreteMethodByName("<init>", "(I)V");
+
+            ObjectReference newValue1 = valueClass.newInstance(mainThread, valueCtor, List.of(vm().mirrorOf(10)), 0);
+            ObjectReference newValue2 = valueClass.newInstance(mainThread, valueCtor, List.of(vm().mirrorOf(11)), 0);
+            // sanity check for enableCollection/disableCollection
+            newValue1.disableCollection();
+            newValue2.disableCollection();
+
+            testClass.setValue(testField, newValue1);
+            valueClass.setValue(valueField, newValue2);
+
+            ObjectReference updatedValue1 = (ObjectReference)testClass.getValue(testField);
+            ObjectReference updatedValue2 = (ObjectReference)valueClass.getValue(valueField);
+
+            assertEqual(updatedValue1, newValue1);
+            assertNotEqual(value1, newValue1);
+            assertEqual(updatedValue2, newValue2);
+            assertNotEqual(value2, newValue2);
+
+            // sanity check for enableCollection/disableCollection
+            newValue1.enableCollection();
+            newValue2.enableCollection();
+        } finally {
+            // Resume the target until end
+            listenUntilVMDisconnect();
+        }
+    }
+}


### PR DESCRIPTION
The fix adds sanity tests for JDI classes with value objects

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8364321](https://bugs.openjdk.org/browse/JDK-8364321): Add JDI tests for value objects (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1519/head:pull/1519` \
`$ git checkout pull/1519`

Update a local copy of the PR: \
`$ git checkout pull/1519` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1519`

View PR using the GUI difftool: \
`$ git pr show -t 1519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1519.diff">https://git.openjdk.org/valhalla/pull/1519.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1519#issuecomment-3134246259)
</details>
