### PR TITLE
8364483: [lworld] Pre-register migrated classes in class loaders

### DIFF
--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -173,6 +173,30 @@
   do_klass(Long_klass,                                  java_lang_Long                                        ) \
   do_klass(Void_klass,                                  java_lang_Void                                        ) \
                                                                                                                 \
+  /* Other valhalla migrated klasses. */                                                                        \
+  do_klass(Number_klass,                                java_lang_Number                                      ) \
+  do_klass(Optional_klass,                              java_util_Optional                                    ) \
+  do_klass(OptionalInt_klass,                           java_util_OptionalInt                                 ) \
+  do_klass(OptionalLong_klass,                          java_util_OptionalLong                                ) \
+  do_klass(OptionalDouble_klass,                        java_util_OptionalDouble                              ) \
+  do_klass(LocalDate_klass,                             java_time_LocalDate                                   ) \
+  do_klass(LocalDateTime_klass,                         java_time_LocalDateTime                               ) \
+  do_klass(LocalTime_klass,                             java_time_LocalTime                                   ) \
+  do_klass(Duration_klass,                              java_time_Duration                                    ) \
+  do_klass(Instant_klass,                               java_time_Instant                                     ) \
+  do_klass(MonthDay_klass,                              java_time_MonthDay                                    ) \
+  do_klass(ZonedDateTime_klass,                         java_time_ZonedDateTime                               ) \
+  do_klass(OffsetDateTime_klass,                        java_time_OffsetDateTime                              ) \
+  do_klass(OffsetTime_klass,                            java_time_OffsetTime                                  ) \
+  do_klass(YearMonth_klass,                             java_time_YearMonth                                   ) \
+  do_klass(Year_klass,                                  java_time_Year                                        ) \
+  do_klass(Period_klass,                                java_time_Period                                      ) \
+  do_klass(chrono_ChronoLocalDateImpl_klass,            java_time_chrono_ChronoLocalDateImpl                  ) \
+  do_klass(chrono_MinguoDate_klass,                     java_time_chrono_MinguoDate                           ) \
+  do_klass(chrono_HijrahDate_klass,                     java_time_chrono_HijrahDate                           ) \
+  do_klass(chrono_JapaneseDate_klass,                   java_time_chrono_JapaneseDate                         ) \
+  do_klass(chrono_ThaiBuddhistDate_klass,               java_time_chrono_ThaiBuddhistDate                     ) \
+                                                                                                                \
   /* force inline of iterators */                                                                               \
   do_klass(Iterator_klass,                              java_util_Iterator                                    ) \
                                                                                                                 \

--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -110,6 +110,8 @@ void vmSymbols::initialize() {
 #endif
   }
 
+  initialize_migrated_class_names();
+
 #ifdef ASSERT
   // Check for duplicates:
 
@@ -295,4 +297,44 @@ vmSymbolID vmSymbols::find_sid(const char* symbol_name) {
   Symbol* symbol = SymbolTable::probe(symbol_name, (int) strlen(symbol_name));
   if (symbol == nullptr)  return vmSymbolID::NO_SID;
   return find_sid(symbol);
+}
+
+// The list of these migrated value classes is in
+// open/make/modules/java.base/gensrc/GensrcValueClasses.gmk.
+
+Symbol* vmSymbols::_migrated_class_names[_migrated_class_names_length];
+
+void vmSymbols::initialize_migrated_class_names() {
+  int i = 0;
+  _migrated_class_names[i++] = java_lang_Byte();
+  _migrated_class_names[i++] = java_lang_Short();
+  _migrated_class_names[i++] = java_lang_Integer();
+  _migrated_class_names[i++] = java_lang_Long();
+  _migrated_class_names[i++] = java_lang_Float();
+  _migrated_class_names[i++] = java_lang_Double();
+  _migrated_class_names[i++] = java_lang_Boolean();
+  _migrated_class_names[i++] = java_lang_Character();
+  _migrated_class_names[i++] = java_lang_Number();
+  _migrated_class_names[i++] = java_lang_Record();
+  _migrated_class_names[i++] = java_util_Optional();
+  _migrated_class_names[i++] = java_util_OptionalInt();
+  _migrated_class_names[i++] = java_util_OptionalLong();
+  _migrated_class_names[i++] = java_util_OptionalDouble();
+  _migrated_class_names[i++] = java_time_LocalDate();
+  _migrated_class_names[i++] = java_time_LocalDateTime();
+  _migrated_class_names[i++] = java_time_LocalTime();
+  _migrated_class_names[i++] = java_time_Duration();
+  _migrated_class_names[i++] = java_time_Instant();
+  _migrated_class_names[i++] = java_time_MonthDay();
+  _migrated_class_names[i++] = java_time_ZonedDateTime();
+  _migrated_class_names[i++] = java_time_OffsetDateTime();
+  _migrated_class_names[i++] = java_time_OffsetTime();
+  _migrated_class_names[i++] = java_time_YearMonth();
+  _migrated_class_names[i++] = java_time_Year();
+  _migrated_class_names[i++] = java_time_Period();
+  _migrated_class_names[i++] = java_time_chrono_ChronoLocalDateImpl();
+  _migrated_class_names[i++] = java_time_chrono_MinguoDate();
+  _migrated_class_names[i++] = java_time_chrono_HijrahDate();
+  _migrated_class_names[i++] = java_time_chrono_JapaneseDate();
+  _migrated_class_names[i++] = java_time_chrono_ThaiBuddhistDate();
 }

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -91,6 +91,31 @@ class SerializeClosure;
   template(java_lang_Long_LongCache,                  "java/lang/Long$LongCache")                 \
   template(java_lang_Void,                            "java/lang/Void")                           \
                                                                                                   \
+  /* Valhalla migrated classes. */                                                                \
+  template(java_lang_Number,                          "java/lang/Number")                         \
+  template(java_lang_Record,                          "java/lang/Record")                         \
+  template(java_util_Optional,                        "java/util/Optional")                       \
+  template(java_util_OptionalInt,                     "java/util/OptionalInt")                    \
+  template(java_util_OptionalLong,                    "java/util/OptionalLong")                   \
+  template(java_util_OptionalDouble,                  "java/util/OptionalDouble")                 \
+  template(java_time_LocalDate,                       "java/time/LocalDate")                      \
+  template(java_time_LocalDateTime,                   "java/time/LocalDateTime")                  \
+  template(java_time_LocalTime,                       "java/time/LocalTime")                      \
+  template(java_time_Duration,                        "java/time/Duration")                       \
+  template(java_time_Instant,                         "java/time/Instant")                        \
+  template(java_time_MonthDay,                        "java/time/MonthDay")                       \
+  template(java_time_ZonedDateTime,                   "java/time/ZonedDateTime")                  \
+  template(java_time_OffsetDateTime,                  "java/time/OffsetDateTime")                 \
+  template(java_time_OffsetTime,                      "java/time/OffsetTime")                     \
+  template(java_time_YearMonth,                       "java/time/YearMonth")                      \
+  template(java_time_Year,                            "java/time/Year")                           \
+  template(java_time_Period,                          "java/time/Period")                         \
+  template(java_time_chrono_ChronoLocalDateImpl,      "java/time/chrono/ChronoLocalDateImpl")     \
+  template(java_time_chrono_MinguoDate,               "java/time/chrono/MinguoDate")              \
+  template(java_time_chrono_HijrahDate,               "java/time/chrono/HijrahDate")              \
+  template(java_time_chrono_JapaneseDate,             "java/time/chrono/JapaneseDate")            \
+  template(java_time_chrono_ThaiBuddhistDate,         "java/time/chrono/ThaiBuddhistDate")        \
+                                                                                                  \
   template(jdk_internal_vm_vector_VectorSupport,      "jdk/internal/vm/vector/VectorSupport")     \
   template(jdk_internal_vm_vector_Float16Math,        "jdk/internal/vm/vector/Float16Math")       \
   template(jdk_internal_vm_vector_VectorPayload,      "jdk/internal/vm/vector/VectorSupport$VectorPayload") \
@@ -137,7 +162,6 @@ class SerializeClosure;
   template(java_lang_AssertionStatusDirectives,       "java/lang/AssertionStatusDirectives")      \
   template(jdk_internal_vm_PostVMInitHook,            "jdk/internal/vm/PostVMInitHook")           \
   template(java_util_Iterator,                        "java/util/Iterator")                       \
-  template(java_lang_Record,                          "java/lang/Record")                         \
   template(sun_instrument_InstrumentationImpl,        "sun/instrument/InstrumentationImpl")       \
   template(sun_invoke_util_ValueConversions,          "sun/invoke/util/ValueConversions")         \
                                                                                                   \
@@ -830,6 +854,10 @@ class vmSymbols: AllStatic {
 
   // Field signatures indexed by BasicType.
   static Symbol* _type_signatures[T_VOID+1];
+  static void initialize_migrated_class_names();
+
+  static const int _migrated_class_names_length = 31;
+  static Symbol* _migrated_class_names[_migrated_class_names_length];
 
  public:
   // Initialization
@@ -865,6 +893,14 @@ class vmSymbols: AllStatic {
   // No need for this in the product:
   static const char* name_for(vmSymbolID sid);
 #endif //PRODUCT
+
+  template<typename Function>
+  static void migrated_class_names_do(Function f) {
+     for (int i = 0; i < _migrated_class_names_length; i++) {
+       //f->do_symbol(&_migrated_class_names[i]);
+       f(_migrated_class_names[i]);
+     }
+  }
 };
 
 #endif // SHARE_CLASSFILE_VMSYMBOLS_HPP

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 #include "memory/iterator.inline.hpp"
 #include "oops/inlineKlass.inline.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/copy.hpp"
 
 template <DecoratorSet decorators, typename BarrierSetT>
 template <DecoratorSet expected>


### PR DESCRIPTION
This change preloads and preregisters all classes in the migrated classes lists, in all class loaders.
Tested with tier1 locally and with -XX:+PrintSystemDictionaryAtExit.