### PR TITLE
[lworld] Remove redundant DTraceAlloc/Method probes

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -214,8 +214,8 @@ void InterpreterMacroAssembler::allocate_instance(Register klass, Register new_o
                                                   Register t1, Register t2,
                                                   bool clear_fields, Label& alloc_failed) {
   MacroAssembler::allocate_instance(klass, new_obj, t1, t2, clear_fields, alloc_failed);
-  if (DTraceMethodProbes) {
-      // Trigger dtrace event for fastpath
+  if (DTraceAllocProbes) {
+    // Trigger dtrace event for fastpath
     push(atos);
     call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), new_obj);
     pop(atos);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5798,8 +5798,6 @@ void MacroAssembler::allocate_instance(Register klass, Register new_obj,
       mov(t2, klass);                // preserve klass
       store_klass(new_obj, t2);      // src klass reg is potentially compressed
     }
-    // TODO: Valhalla removed SharedRuntime::dtrace_object_alloc from here ?
-
     b(done);
   }
 

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3878,14 +3878,6 @@ void TemplateTable::_new() {
   __ clinit_barrier(r4, rscratch1, nullptr /*L_fast_path*/, &slow_case);
 
   __ allocate_instance(r4, r0, r3, r1, true, slow_case);
-    if (DTraceAllocProbes) {
-      // Trigger dtrace event for fastpath
-      __ push(atos); // save the return value
-      __ call_VM_leaf(
-           CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), r0);
-      __ pop(atos); // restore the return value
-
-    }
   __ b(done);
 
   // slow case

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1039,7 +1039,7 @@ void InterpreterMacroAssembler::allocate_instance(Register klass, Register new_o
                                                   Register t1, Register t2,
                                                   bool clear_fields, Label& alloc_failed) {
   MacroAssembler::allocate_instance(klass, new_obj, t1, t2, clear_fields, alloc_failed);
-  if (DTraceMethodProbes) {
+  if (DTraceAllocProbes) {
     // Trigger dtrace event for fastpath
     push(atos);
     call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), new_obj);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3826,13 +3826,6 @@ void TemplateTable::_new() {
   __ clinit_barrier(rcx, nullptr /*L_fast_path*/, &slow_case);
 
   __ allocate_instance(rcx, rax, rdx, rbx, true, slow_case);
-    if (DTraceAllocProbes) {
-      // Trigger dtrace event for fastpath
-      __ push(atos);
-      __ call_VM_leaf(
-           CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), rax);
-      __ pop(atos);
-    }
   __ jmp(done);
 
   // slow case


### PR DESCRIPTION
Looking through this code, I found this discrepancy.  Tested with some tier1 testing.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1521/head:pull/1521` \
`$ git checkout pull/1521`

Update a local copy of the PR: \
`$ git checkout pull/1521` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1521`

View PR using the GUI difftool: \
`$ git pr show -t 1521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1521.diff">https://git.openjdk.org/valhalla/pull/1521.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1521#issuecomment-3144943598)
</details>
