### PR TITLE
8361352: [lworld] Weird interaction between OSR and value class instances

### DIFF
--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -504,8 +504,8 @@ public:
   void dump_compile_data(outputStream* out);
   void dump_replay_data_version(outputStream* out);
 
-  ciWrapper* make_larval_wrapper(ciType* type) {
-    return _factory->make_larval_wrapper(type);
+  ciWrapper* make_early_larval_wrapper(ciType* type) {
+    return _factory->make_early_larval_wrapper(type);
   }
 
   ciWrapper* make_null_free_wrapper(ciType* type) {

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -504,6 +504,10 @@ public:
   void dump_compile_data(outputStream* out);
   void dump_replay_data_version(outputStream* out);
 
+  ciWrapper* make_larval_wrapper(ciType* type) {
+    return _factory->make_larval_wrapper(type);
+  }
+
   ciWrapper* make_null_free_wrapper(ciType* type) {
     return _factory->make_null_free_wrapper(type);
   }

--- a/src/hotspot/share/ci/ciMetadata.hpp
+++ b/src/hotspot/share/ci/ciMetadata.hpp
@@ -60,7 +60,7 @@ class ciMetadata: public ciBaseObject {
   virtual bool is_flat_array_klass() const  { return false; }
   virtual bool is_obj_array_klass() const   { return false; }
   virtual bool is_type_array_klass() const  { return false; }
-  virtual bool is_larval() const            { return false; }
+  virtual bool is_early_larval() const      { return false; }
   virtual bool maybe_flat_in_array() const  { return false; }
   virtual void dump_replay_data(outputStream* st) { /* do nothing */ }
 

--- a/src/hotspot/share/ci/ciMetadata.hpp
+++ b/src/hotspot/share/ci/ciMetadata.hpp
@@ -60,7 +60,7 @@ class ciMetadata: public ciBaseObject {
   virtual bool is_flat_array_klass() const  { return false; }
   virtual bool is_obj_array_klass() const   { return false; }
   virtual bool is_type_array_klass() const  { return false; }
-  virtual bool is_wrapper() const           { return false; }
+  virtual bool is_larval() const            { return false; }
   virtual bool maybe_flat_in_array() const  { return false; }
   virtual void dump_replay_data(outputStream* st) { /* do nothing */ }
 
@@ -111,10 +111,6 @@ class ciMetadata: public ciBaseObject {
   ciInlineKlass*           as_inline_klass() {
     assert(is_inlinetype(), "bad cast");
     return (ciInlineKlass*)this;
-  }
-  ciWrapper*               as_wrapper() {
-    assert(is_wrapper(), "bad cast");
-    return (ciWrapper*)this;
   }
 
   Metadata* constant_encoding() { return _metadata; }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -632,8 +632,14 @@ ciReturnAddress* ciObjectFactory::get_return_address(int bci) {
   return new_ret_addr;
 }
 
+ciWrapper* ciObjectFactory::make_larval_wrapper(ciType* type) {
+  ciWrapper* wrapper = new (arena()) ciWrapper(type, ciWrapper::Larval);
+  init_ident_of(wrapper);
+  return wrapper;
+}
+
 ciWrapper* ciObjectFactory::make_null_free_wrapper(ciType* type) {
-  ciWrapper* wrapper = new (arena()) ciWrapper(type);
+  ciWrapper* wrapper = new (arena()) ciWrapper(type, ciWrapper::NullFree);
   init_ident_of(wrapper);
   return wrapper;
 }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -632,8 +632,8 @@ ciReturnAddress* ciObjectFactory::get_return_address(int bci) {
   return new_ret_addr;
 }
 
-ciWrapper* ciObjectFactory::make_larval_wrapper(ciType* type) {
-  ciWrapper* wrapper = new (arena()) ciWrapper(type, ciWrapper::Larval);
+ciWrapper* ciObjectFactory::make_early_larval_wrapper(ciType* type) {
+  ciWrapper* wrapper = new (arena()) ciWrapper(type, ciWrapper::EarlyLarval);
   init_ident_of(wrapper);
   return wrapper;
 }

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -138,6 +138,7 @@ public:
 
   ciReturnAddress* get_return_address(int bci);
 
+  ciWrapper* make_larval_wrapper(ciType* type);
   ciWrapper* make_null_free_wrapper(ciType* type);
 
   GrowableArray<ciMetadata*>* get_ci_metadata() { return &_ci_metadata; }

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -138,7 +138,7 @@ public:
 
   ciReturnAddress* get_return_address(int bci);
 
-  ciWrapper* make_larval_wrapper(ciType* type);
+  ciWrapper* make_early_larval_wrapper(ciType* type);
   ciWrapper* make_null_free_wrapper(ciType* type);
 
   GrowableArray<ciMetadata*>* get_ci_metadata() { return &_ci_metadata; }

--- a/src/hotspot/share/ci/ciType.cpp
+++ b/src/hotspot/share/ci/ciType.cpp
@@ -148,7 +148,7 @@ ciWrapper::ciWrapper(ciType* type, int properties)
   assert(!type->is_wrapper(), "Thou shall not double wrap!");
   assert(type->is_inlinetype()
              // An abstract value type is an instance_klass
-             || (type->is_instance_klass() && type->as_instance_klass()->flags().is_abstract() && !type->as_instance_klass()->flags().is_identity())
+             || (type->is_instance_klass() && !type->as_instance_klass()->flags().is_identity())
              // An unloaded inline type is an instance_klass (see ciEnv::get_klass_by_name_impl())
              || (type->is_instance_klass() && !type->is_loaded()),
          "should only be used for inline types");

--- a/src/hotspot/share/ci/ciType.cpp
+++ b/src/hotspot/share/ci/ciType.cpp
@@ -140,3 +140,16 @@ void ciReturnAddress::print_impl(outputStream* st) {
 ciReturnAddress* ciReturnAddress::make(int bci) {
   GUARDED_VM_ENTRY(return CURRENT_ENV->get_return_address(bci);)
 }
+
+ciWrapper::ciWrapper(ciType* type, int properties)
+    : ciType(type->basic_type()),
+      _type(type),
+      _properties(properties) {
+  assert(!type->is_wrapper(), "Thou shall not double wrap!");
+  assert(type->is_inlinetype()
+             // An abstract value type is an instance_klass
+             || (type->is_instance_klass() && type->as_instance_klass()->flags().is_abstract() && !type->as_instance_klass()->flags().is_identity())
+             // An unloaded inline type is an instance_klass (see ciEnv::get_klass_by_name_impl())
+             || (type->is_instance_klass() && !type->is_loaded()),
+         "should only be used for inline types");
+}

--- a/src/hotspot/share/ci/ciType.hpp
+++ b/src/hotspot/share/ci/ciType.hpp
@@ -121,7 +121,7 @@ private:
   ciType* _type;
   enum Property {
     NullFree = 1,
-    Larval = NullFree << 1,
+    EarlyLarval = NullFree << 1,
   };
   int _properties;
 
@@ -136,14 +136,14 @@ private:
           "should only be used for inline types");
   }
 
-  const char* type_string() { return "ciWrapper"; }
+  const char* type_string() override { return "ciWrapper"; }
 
-  void print_impl(outputStream* st) { _type->print_impl(st); }
+  void print_impl(outputStream* st) override { _type->print_impl(st); }
 
 public:
-  ciType* unwrap()          { return _type; }
-  bool is_null_free() const { return (_properties & (NullFree | Larval)) != 0; }
-  bool is_larval() const { return (_properties & Larval) != 0; }
+  ciType* unwrap() override { return _type; }
+  bool is_null_free() const override { return (_properties & (NullFree | EarlyLarval)) != 0; }
+  bool is_early_larval() const override { return (_properties & EarlyLarval) != 0; }
   bool is_wrapper() const override { return true; }
 };
 

--- a/src/hotspot/share/ci/ciType.hpp
+++ b/src/hotspot/share/ci/ciType.hpp
@@ -125,16 +125,7 @@ private:
   };
   int _properties;
 
-  ciWrapper(ciType* type, int properties)
-      : ciType(type->basic_type()),
-        _type(type),
-        _properties(properties) {
-    assert(!type->is_wrapper(), "Thou shall not double wrap!");
-    assert(type->is_inlinetype()
-          // An unloaded inline type is an instance_klass (see ciEnv::get_klass_by_name_impl())
-          || (type->is_instance_klass() && !type->is_loaded()),
-          "should only be used for inline types");
-  }
+  ciWrapper(ciType* type, int properties);
 
   const char* type_string() override { return "ciWrapper"; }
 

--- a/src/hotspot/share/ci/ciType.hpp
+++ b/src/hotspot/share/ci/ciType.hpp
@@ -71,6 +71,7 @@ public:
   // What kind of ciObject is this?
   bool is_type() const                      { return true; }
   bool is_classless() const                 { return is_primitive_type(); }
+  virtual bool is_wrapper() const           { return false; }
 
   virtual ciType* unwrap()                  { return this; }
   virtual bool is_null_free() const         { return false; }
@@ -113,19 +114,26 @@ public:
 // ciWrapper
 //
 // This class wraps another type to carry additional information.
-// Currently it is only used to mark inline klasses as null-free.
 class ciWrapper : public ciType {
   CI_PACKAGE_ACCESS
 
 private:
   ciType* _type;
+  enum Property {
+    NullFree = 1,
+    Larval = NullFree << 1,
+  };
+  int _properties;
 
-  ciWrapper(ciType* type) : ciType(type->basic_type()) {
+  ciWrapper(ciType* type, int properties)
+      : ciType(type->basic_type()),
+        _type(type),
+        _properties(properties) {
+    assert(!type->is_wrapper(), "Thou shall not double wrap!");
     assert(type->is_inlinetype()
           // An unloaded inline type is an instance_klass (see ciEnv::get_klass_by_name_impl())
           || (type->is_instance_klass() && !type->is_loaded()),
           "should only be used for inline types");
-    _type = type;
   }
 
   const char* type_string() { return "ciWrapper"; }
@@ -133,9 +141,10 @@ private:
   void print_impl(outputStream* st) { _type->print_impl(st); }
 
 public:
-  bool is_wrapper()   const { return true; }
   ciType* unwrap()          { return _type; }
-  bool is_null_free() const { return true; }
+  bool is_null_free() const { return (_properties & (NullFree | Larval)) != 0; }
+  bool is_larval() const { return (_properties & Larval) != 0; }
+  bool is_wrapper() const override { return true; }
 };
 
 #endif // SHARE_CI_CITYPE_HPP

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -417,11 +417,11 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
   state->set_stack_size(-max_locals());
   if (!method()->is_static()) {
     ciType* holder = method()->holder();
-    if (holder->is_inlinetype()) {
-      if (method()->is_object_constructor()) {
-        // The receiver is larval (so also null-free)
+    if (method()->is_object_constructor()) {
+      if (holder->is_inlinetype() || (holder->is_instance_klass() && holder->as_instance_klass()->flags().is_abstract() && !holder->as_instance_klass()->flags().is_identity())) {
+        // The receiver is early larval (so also null-free)
 #if 0
-        tty->print("This is larval! ");
+        tty->print("This is early larval! ");
         method()->dump_name_as_ascii(tty);
         tty->print_cr("");
         tty->print("    ");
@@ -429,7 +429,9 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
         tty->print_cr("");
 #endif
         holder = mark_as_early_larval(holder);
-      } else {
+      }
+    } else {
+      if (holder->is_inlinetype()) {
         // The receiver is null-free
         holder = mark_as_null_free(holder);
       }

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -420,14 +420,6 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
     if (method()->is_object_constructor()) {
       if (holder->is_inlinetype() || (holder->is_instance_klass() && holder->as_instance_klass()->flags().is_abstract() && !holder->as_instance_klass()->flags().is_identity())) {
         // The receiver is early larval (so also null-free)
-#if 0
-        tty->print("This is early larval! ");
-        method()->dump_name_as_ascii(tty);
-        tty->print_cr("");
-        tty->print("    ");
-        holder->print(tty);
-        tty->print_cr("");
-#endif
         holder = mark_as_early_larval(holder);
       }
     } else {
@@ -742,34 +734,16 @@ void ciTypeFlow::StateVector::do_invoke(ciBytecodeStream* str,
       pop();
     }
     if (has_receiver) {
-      // Check this?
       if (type_at_tos()->is_early_larval()) {
         // Call with larval receiver accepted by verifier
         // => this is <init> and the receiver is no longer larval after that.
-#if 0
-        tty->print_cr("Larval found :) max_locals:%d", outer()->max_locals());
-        tty->print("    ");
-        type_at_tos()->print(tty);
-        tty->print_cr("");
-        tty->print("    ");
-        type_at_tos()->unwrap()->print(tty);
-        tty->print_cr("");
-        tty->print("    Callee: ");
-        callee->dump_name_as_ascii(tty);
-        tty->print_cr("");
-#endif
         Cell limit = limit_cell();
         for (Cell c = start_cell(); c < limit; c = next_cell(c)) {
           if (type_at(c)->ident() == type_at_tos()->ident()) {
             assert(type_at(c) == type_at_tos(), "Sin! Abomination!");
-#if 0
-            tty->print_cr("    Larval in cell %d removed", c);
-#endif
             set_type_at(c, type_at_tos()->unwrap());
           }
         }
-
-        // TODO now we can remove the larval state from all locals
       }
       pop_object();
     }
@@ -879,8 +853,6 @@ void ciTypeFlow::StateVector::do_new(ciBytecodeStream* str) {
     trap(str, klass, str->get_klass_index());
   } else {
     if (klass->is_inlinetype()) {
-      // Larval state
-      // TODO could we get larvals from somewhere else? Calls to constructors or something?
       push(outer()->mark_as_early_larval(klass));
       return;
     }

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -420,12 +420,14 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
     if (holder->is_inlinetype()) {
       if (method()->is_object_constructor()) {
         // The receiver is larval (so also null-free)
+#if 0
         tty->print("This is larval! ");
         method()->dump_name_as_ascii(tty);
         tty->print_cr("");
         tty->print("    ");
         holder->print(tty);
         tty->print_cr("");
+#endif
         holder = mark_as_early_larval(holder);
       } else {
         // The receiver is null-free
@@ -742,7 +744,7 @@ void ciTypeFlow::StateVector::do_invoke(ciBytecodeStream* str,
       if (type_at_tos()->is_early_larval()) {
         // Call with larval receiver accepted by verifier
         // => this is <init> and the receiver is no longer larval after that.
-#if 1
+#if 0
         tty->print_cr("Larval found :) max_locals:%d", outer()->max_locals());
         tty->print("    ");
         type_at_tos()->print(tty);
@@ -758,7 +760,7 @@ void ciTypeFlow::StateVector::do_invoke(ciBytecodeStream* str,
         for (Cell c = start_cell(); c < limit; c = next_cell(c)) {
           if (type_at(c)->ident() == type_at_tos()->ident()) {
             assert(type_at(c) == type_at_tos(), "Sin! Abomination!");
-#if 1
+#if 0
             tty->print_cr("    Larval in cell %d removed", c);
 #endif
             set_type_at(c, type_at_tos()->unwrap());

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -418,7 +418,7 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
   if (!method()->is_static()) {
     ciType* holder = method()->holder();
     if (method()->is_object_constructor()) {
-      if (holder->is_inlinetype() || (holder->is_instance_klass() && holder->as_instance_klass()->flags().is_abstract() && !holder->as_instance_klass()->flags().is_identity())) {
+      if (holder->is_inlinetype() || (holder->is_instance_klass() && !holder->as_instance_klass()->flags().is_identity())) {
         // The receiver is early larval (so also null-free)
         holder = mark_as_early_larval(holder);
       }

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -853,7 +853,7 @@ public:
                                       return _block_map[rpo]; }
   int inc_next_pre_order()          { return _next_pre_order++; }
 
-  ciType* mark_as_larval(ciType* type);
+  ciType* mark_as_early_larval(ciType* type);
   ciType* mark_as_null_free(ciType* type);
 
 private:

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -853,6 +853,7 @@ public:
                                       return _block_map[rpo]; }
   int inc_next_pre_order()          { return _next_pre_order++; }
 
+  ciType* mark_as_larval(ciType* type);
   ciType* mark_as_null_free(ciType* type);
 
 private:

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -445,7 +445,7 @@ class Parse : public GraphKit {
 
   // OSR helpers
   Node* fetch_interpreter_state(int index, const Type* type, Node* local_addrs, Node* local_addrs_base);
-  Node* check_interpreter_type(Node* l, const Type* type, SafePointNode* &bad_type_exit);
+  Node* check_interpreter_type(Node* l, const Type* type, SafePointNode* &bad_type_exit, bool is_larval);
   void  load_interpreter_state(Node* osr_buf);
 
   // Functions for managing basic blocks:

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -153,7 +153,7 @@ Node* Parse::fetch_interpreter_state(int index,
 // not a general type, but can only come from Type::get_typeflow_type.
 // The safepoint is a map which will feed an uncommon trap.
 Node* Parse::check_interpreter_type(Node* l, const Type* type,
-                                    SafePointNode* &bad_type_exit, bool is_larval) {
+                                    SafePointNode* &bad_type_exit, bool is_early_larval) {
   const TypeOopPtr* tp = type->isa_oopptr();
 
   // TypeFlow may assert null-ness if a type appears unloaded.
@@ -184,7 +184,7 @@ Node* Parse::check_interpreter_type(Node* l, const Type* type,
       bad_type_exit->control()->add_req(bad_type_ctrl);
     }
 
-    l = gen_checkcast(l, makecon(tp->as_klass_type()->cast_to_exactness(true)), &bad_type_ctrl, false, is_larval);
+    l = gen_checkcast(l, makecon(tp->as_klass_type()->cast_to_exactness(true)), &bad_type_ctrl, false, is_early_larval);
     bad_type_exit->control()->add_req(bad_type_ctrl);
   }
 
@@ -375,8 +375,8 @@ void Parse::load_interpreter_state(Node* osr_buf) {
       // value and the expected type is a constant.
       continue;
     }
-    bool is_larval = osr_block->flow()->local_type_at(index)->is_larval();
-    set_local(index, check_interpreter_type(l, type, bad_type_exit, is_larval));
+    bool is_early_larval = osr_block->flow()->local_type_at(index)->is_early_larval();
+    set_local(index, check_interpreter_type(l, type, bad_type_exit, is_early_larval));
   }
 
   for (index = 0; index < sp(); index++) {
@@ -384,8 +384,8 @@ void Parse::load_interpreter_state(Node* osr_buf) {
     Node* l = stack(index);
     if (l->is_top())  continue;  // nothing here
     const Type *type = osr_block->stack_type_at(index);
-    bool is_larval = osr_block->flow()->stack_type_at(index)->is_larval();
-    set_stack(index, check_interpreter_type(l, type, bad_type_exit, is_larval));
+    bool is_early_larval = osr_block->flow()->stack_type_at(index)->is_early_larval();
+    set_stack(index, check_interpreter_type(l, type, bad_type_exit, is_early_larval));
   }
 
   if (bad_type_exit->control()->req() > 1) {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -625,13 +625,9 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
     Node* parm = local(i);
     const Type* t = _gvn.type(parm);
     if (t->is_inlinetypeptr()) {
-      // If the parameter is a value object, try to scalarize it if we know that it is not larval.
-      // There are 2 cases when a parameter may be larval:
-      // - In an OSR compilation, we do not know if a value object in the incoming state is larval
-      //   or not. We must be conservative and not eagerly scalarize them.
-      // - In a normal compilation, all parameters are non-larval except the receiver of a
-      //   constructor, which must be a larval object.
-      if (!is_osr_parse() && !(method()->is_object_constructor() && i == 0)) {
+      // If the parameter is a value object, try to scalarize it if we know that it is unrestricted (not early larval)
+      // Parameters are non-larval except the receiver of a constructor, which must be an early larval object.
+      if (!(method()->is_object_constructor() && i == 0)) {
         // Create InlineTypeNode from the oop and replace the parameter
         Node* vt = InlineTypeNode::make_from_oop(this, parm, t->inline_klass());
         replace_in_map(parm, vt);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
@@ -27,7 +27,7 @@
  * @summary In OSR compilation, we must correctly determine the initialization
  * state of value objects coming from above the OSR start, and not consider
  * everything as potentially early larval. Value objects that are known to be
- * unrestricted (late larval of fully initialized) are immutable, and can be
+ * unrestricted (late larval or fully initialized) are immutable, and can be
  * scalarized.
  * @library /test/jdk/java/lang/invoke/common
  * @enablePreview

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8361352
+ * @summary In OSR compilation, value objects coming from above the OSR start
+ * must be correctly found to be early larval so we know they are
+ * immutable, and they can be scalarized.
+ * @library /test/jdk/java/lang/invoke/common
+ * @enablePreview
+ * @run main compiler.valhalla.inlinetypes.LarvalDetectionAboveOSR
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import test.java.lang.invoke.lib.InstructionHelper;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.lang.classfile.Label;
+import java.lang.classfile.TypeKind;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.ByteBuffer;
+import java.nio.file.FileSystems;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
+
+public class LarvalDetectionAboveOSR {
+    public static ArrayList<String> runInSeparateVM(String scenario, String compile_pattern) throws Throwable {
+        String separator = FileSystems.getDefault().getSeparator();
+        String path = System.getProperty("java.home") + separator + "bin" + separator + "java";
+
+        String javaFile = LarvalDetectionAboveOSR.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        String classpath = javaFile.replace("LarvalDetectionAboveOSR.java", "");
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                path, "-cp", classpath,
+                "--enable-preview", "-XX:-TieredCompilation",
+                "-XX:CompileCommand=compileonly," + compile_pattern,
+                "-XX:CompileCommand=printcompilation,*::*",
+                "-XX:CompileCommand=PrintIdealPhase,*::*,BEFORE_MACRO_EXPANSION",
+                "-XX:+PrintEliminateAllocations",
+                LarvalDetectionAboveOSR.class.getCanonicalName(), scenario
+        );
+        Process process = processBuilder.start();
+        processBuilder.redirectErrorStream(true);
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        BufferedReader error_reader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+        var lines = new ArrayList<String>();
+        var error_lines = new ArrayList<String>();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            lines.add(line);
+        }
+        while ((line = error_reader.readLine()) != null) {
+            error_lines.add(line);
+        }
+        process.waitFor();
+
+        if (process.exitValue() != 0) {
+            System.out.println("stdout:");
+            System.out.println(String.join("\n", lines));
+            System.out.println("stderr:");
+            System.out.println(String.join("\n", error_lines));
+            throw new RuntimeException("Process exited with status: " + process.exitValue());
+        }
+
+        return lines;
+    }
+
+    static class CompilationBlock {
+        public boolean is_osr;
+        public ArrayList<String> lines = new ArrayList<>();
+
+        CompilationBlock(boolean osr) {
+            is_osr = osr;
+        }
+    }
+
+    static Pattern print_compilation_regex = Pattern.compile("\\d+\\s+\\d+\\s+(%\\s+)?compiler\\.valhalla\\.inlinetypes\\.\\S*::[a-zA-Z0-9_]* (@ \\d+ )?\\(\\d+ bytes\\)");
+    static Pattern allocate_elimination_regex = Pattern.compile("\\+{4} Eliminated: \\d+ Allocate");
+    static Pattern allocate_regex = Pattern.compile("\\s*\\d+ {2}Allocate {2}={3}.*");
+
+    static ArrayList<CompilationBlock> splitLines(ArrayList<String> lines) {
+        var blocks = new ArrayList<CompilationBlock>();
+        for (String line : lines) {
+            Matcher m = print_compilation_regex.matcher(line);
+            if (m.matches()) {
+                blocks.add(new CompilationBlock(line.contains("%")));
+            } else if (!blocks.isEmpty()) {
+                blocks.getLast().lines.add(line);
+            }
+        }
+        return blocks;
+    }
+
+    static void analyzeLines(ArrayList<String> lines) {
+        var blocks = splitLines(lines);
+        int blocks_actually_checked = 0;
+        for (CompilationBlock block : blocks) {
+            if (checkBlock(block)) {
+                blocks_actually_checked++;
+            }
+        }
+        if (blocks_actually_checked == 0) {
+            throw new RuntimeException("Found no OSR logging block to check.");
+        }
+    }
+
+    static boolean checkBlock(CompilationBlock block) {
+        if (!block.is_osr) return false;  // It's about OSR here!
+
+        int eliminated_allocations = 0;
+        int i = 0;
+        while (i < block.lines.size()) {
+            String line = block.lines.get(i);
+            i++;
+            if (line.equals("AFTER: BEFORE_MACRO_EXPANSION")) {
+                break;
+            }
+            if (allocate_elimination_regex.matcher(line).matches()) {
+                eliminated_allocations++;
+            }
+        }
+        if (eliminated_allocations == 0) {
+            throw new RuntimeException("No allocation elimination found, there should be some.");
+        }
+        if (i >= block.lines.size()) {
+            throw new RuntimeException("Cannot find BEFORE_MACRO_EXPANSION printout");
+        }
+        while (i < block.lines.size()) {
+            if (allocate_regex.matcher(block.lines.get(i)).matches()) {
+                throw new RuntimeException("Found allocation in line: " + block.lines.get(i));
+            }
+            i++;
+        }
+        return true;
+    }
+
+    public static short test() {
+        ByteBuffer bf = ByteBuffer.allocate(8);
+        return bf.getShort(0);
+    }
+
+    public static void main(String[] args) throws Throwable {
+        if (args.length != 0) {
+            switch (args[0]) {
+                case "without_new" -> MyNumber.main_without_new();
+                case "with_new" -> MyNumber.main_with_new();
+                case "bytecode" -> Bytecode.test();
+                default -> throw new RuntimeException("Wrong scenario: " + args[0]);
+            }
+            return;
+        }
+        analyzeLines(runInSeparateVM("without_new", "compiler.valhalla.inlinetypes.MyNumber::loop*"));
+        analyzeLines(runInSeparateVM("with_new", "compiler.valhalla.inlinetypes.MyNumber::loop*"));
+        analyzeLines(runInSeparateVM("bytecode", "compiler.valhalla.inlinetypes.Bytecode$Code_0::meth"));
+    }
+}
+
+value class MyNumber {
+    public long l;
+    static int MANY = 1_000_000_000;
+
+    MyNumber(long l) {
+        this.l = l;
+    }
+
+    MyNumber add(long v) {
+        return new MyNumber(l + v);
+    }
+
+    static long loop_without_new(MyNumber dec) {
+        for (int i = 0; i < MANY; ++i) {
+            dec = dec.add(i);
+        }
+        return dec.l;
+    }
+
+    public static void main_without_new() {
+        for (int i = 0; i < 10; ++i) {
+            MyNumber dec = new MyNumber(123);
+            loop_without_new(dec);
+        }
+    }
+
+    static long loop_with_new() {
+        MyNumber dec = new MyNumber(123);
+        for (int i = 0; i < MANY; ++i) {
+            dec = dec.add(i);
+        }
+        return dec.l;
+    }
+
+    public static void main_with_new() {
+        for (int i = 0; i < 10; ++i) {
+            loop_with_new();
+        }
+    }
+}
+
+class Bytecode {
+    static MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+    static void test() throws Throwable {
+        var myNumber = MyNumber.class;
+        final ClassDesc myNumberDesc = classDesc(myNumber);
+
+        MethodHandle meth = InstructionHelper.buildMethodHandle(
+                LOOKUP,
+                "meth",
+                MethodType.methodType(myNumber, int.class),
+                CODE -> {
+                    Label loop = CODE.newLabel();
+                    CODE
+                            .new_(myNumberDesc)
+                            .dup()
+                            // stack: early larval (this one we init), early larval (this one we store in local 10)
+                            .astore(10)
+                            .iconst_0()
+                            .i2l()
+                            .invokespecial(myNumberDesc, "<init>", MethodTypeDesc.ofDescriptor("(J)V"))
+                            // local 10 should also be initialized, it is now not early larval, so scalarization is allowed
+
+                            // local(11) = 0
+                            .iconst_0()
+                            .istore(11)
+
+                            .labelBinding(loop)
+                            // local(10) = local(10).add((long)local(11))
+                            .aload(10)
+                            .iload(11)
+                            .i2l()
+                            .invokevirtual(myNumberDesc, "add", MethodTypeDesc.ofDescriptor("(J)Lcompiler/valhalla/inlinetypes/MyNumber;"))
+                            .astore(10)
+
+                            // local(11)++
+                            .iload(11)
+                            .iconst_1()
+                            .iadd()
+                            .dup()
+                            // if local(11) < param(0) goto loop
+                            .istore(11)
+                            .iload(0)
+                            .if_icmplt(loop)
+
+                            .aload(10)
+                            .return_(TypeKind.from(myNumberDesc));
+                });
+        var _ = (MyNumber)meth.invokeExact(MyNumber.MANY);
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
@@ -24,9 +24,11 @@
 /**
  * @test
  * @bug 8361352
- * @summary In OSR compilation, value objects coming from above the OSR start
- * must be correctly found to be early larval so we know they are
- * immutable, and they can be scalarized.
+ * @summary In OSR compilation, we must correctly determine the initialization
+ * state of value objects coming from above the OSR start, and not consider
+ * everything as potentially early larval. Value objects that are known to be
+ * unrestricted (late larval of fully initialized) are immutable, and can be
+ * scalarized.
  * @library /test/jdk/java/lang/invoke/common
  * @enablePreview
  * @requires vm.debug

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/LarvalDetectionAboveOSR.java
@@ -29,6 +29,7 @@
  * immutable, and they can be scalarized.
  * @library /test/jdk/java/lang/invoke/common
  * @enablePreview
+ * @requires vm.debug
  * @run main compiler.valhalla.inlinetypes.LarvalDetectionAboveOSR
  */
 

--- a/test/micro/org/openjdk/bench/valhalla/loops/osr/LarvalDetectionAboveOSR.java
+++ b/test/micro/org/openjdk/bench/valhalla/loops/osr/LarvalDetectionAboveOSR.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package org.openjdk.bench.valhalla.loops.osr;
 
 import java.util.concurrent.TimeUnit;

--- a/test/micro/org/openjdk/bench/valhalla/loops/osr/LarvalDetectionAboveOSR.java
+++ b/test/micro/org/openjdk/bench/valhalla/loops/osr/LarvalDetectionAboveOSR.java
@@ -1,0 +1,39 @@
+package org.openjdk.bench.valhalla.loops.osr;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
+@Warmup(iterations = 0)
+@Measurement(iterations = 5)
+public class LarvalDetectionAboveOSR {
+    @Benchmark
+    public long test() {
+        return MyNumber.loop();
+    }
+}
+
+value class MyNumber {
+    static int MANY = 1_000_000_000;
+    private long d0;
+
+    MyNumber(long d0) {
+        this.d0 = d0;
+    }
+
+    MyNumber add(long v) {
+        return new MyNumber(d0 + v);
+    }
+
+    public static long loop() {
+        MyNumber dec = new MyNumber(123);
+        for (int i = 0; i < MANY; ++i) {
+            dec = dec.add(i);
+        }
+        return dec.d0;
+    }
+}
+

--- a/test/micro/org/openjdk/bench/valhalla/loops/osr/LarvalDetectionAboveOSR.java
+++ b/test/micro/org/openjdk/bench/valhalla/loops/osr/LarvalDetectionAboveOSR.java
@@ -4,11 +4,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
 @Warmup(iterations = 0)
-@Measurement(iterations = 5)
+@Measurement(iterations = 10)
 public class LarvalDetectionAboveOSR {
     @Benchmark
     public long test() {


### PR DESCRIPTION
First, credit to @TobiHartmann for the diagnostic, and a lot of the solution.

# Diagnostic

According to [Strict Field Initialization JEP](https://openjdk.org/jeps/8350458), when a strict field is being initialized, it is not quite immutable, but observally immutable: at first, the field can be only set (during the early larval phase), then it can be only read (late larval or initialized phase), so the last set is the actual value one can ever observe.

The interesting part is that in early larval phase, a field can be subject to some side effects. When applied to a value object, that means that until it reaches the unrestricted state, it is not yet immutable. While being not theoretically necessary, avoiding scalarization and keeping the value object behind a reference is a convenient way to make sure that side effects are correctly applied. This strategy means that we shouldn't scalarized before reaching the unrestricted state. Normally, in C2, finding out what is early larval or not is the job of bytecode parsing, but in OSR compilation, everything about the StartOSR is not parsed, and thus some objects are soundly assumed that they might be larval, when they actually aren't. In the reported example, that leads to drastic performance difference between OSR and non OSR compilation: the second one is able to eliminate allocations since it knows more precisely when the value object can be scalarized.

In the original example:
```java
public value class MyNumber {
    private long d0;
    private MyNumber(long d0) { this.d0 = d0; }
    public MyNumber add(long v) { return new MyNumber(d0 + v); }

    private static void loop() {
        MyNumber dec = new MyNumber(123);
        for (int i = 0; i < 1_000_000_000; ++i) {
            dec = dec.add(i);
        }
    }

    public static void main(String[] args) {
        for (int i = 0; i < 10; ++i) {
            loop();
        }
    }
}
```
OSR happens in the loop in `loop`, but here `dec` is not detected to be unrestricted (so immutable, so scalarizable), so the allocation in inlined `add` still needs to happen because we need the buffer for the new `dec`. The first iteration traps at the exit of the loop (unstable if), OSR happens again, followed by a non-OSR compilation, finding correctly that `dec` can be scalarized in the loop, making the third iteration fast.

# Solution

Overall, the solution requires to improve our detection of early larval values. Since we keep parsing as-is, let's do that in `ciTypeFlow`. The logic is quite simple: `ciInlineKlass` can be wrapped in `ciWrapper` to mark when they are known to be non-null. We extend `ciWrapper` to also be able to tell when a value is early larval (which also implies non-null since early larval means that `new` happened).

Then, it's almost a state machine! How is "early larval" introduced:
- `new` bytecode
- receiver of a constructor

How larval is removed:
- call to constructor

Other ways to obtain values are safe (I've experimented and it seems the verifier was keeping me from doing something bad):
- returned values are not early larval
- parameters are not early larval
- receiver of everything but constructor are not early larval

And other guarantees:
- calling twice the constructor is not legal
- merging paths with inconsistent state (early larval vs. unrestricted) is also disallowed

Let's detail how to remove the early larval state on a `ciInlineKlass`. When invoking a method on a receiver, we know that the receiver is not early larval after: either it's a constructor (which initialize the object), or it's a regular method, and the verifier makes sure the receiver was already not early larval before. The tricky part is to remove the larval state on all the copies of the reference: when doing something such as
```
new SomeValueClass
dup
dup
astore 1
invokespecial <init>
```
we still have a copy of the same reference in local 1 and on the stack. All of them now refers to a non-larval value. To take that into account, one must scan all the cells (locals and stack), and remove the early larval wrapper to all the types sharing the same ident  (see `void ciBaseObject::set_ident(uint id)` and `void ciObjectFactory::init_ident_of(ciBaseObject* obj)`). That is enough since early larval values cannot be contained in another object (since we can't make use of them before reaching unrestricted state, see also [Flexible Constructor Bodies](https://openjdk.org/jeps/513)).

Another trick is about the super constructor invocation in a constructor: is that different from a constructor invocation outside of a constructor. Well yes, but actually no:
- outside a constructor, a constructor invocation leaves the object initialized
- in a constructor, a constructor invocation doesn't make the object initialized because the all constructor is not done. But, calling the base class' constructor ensures that `Object.<init>` is being called, climbing up the hierarchy. Once `Object`'s constructor has been reached, the object is late larval.

In both case, after a constructor invocation, the object is unrestricted (late larval or initialized), and in the case of a value object, immutable, so scalarizable, which is what matters here.

The case of an abstract value class needs a bit of hack. An abstract value class is an `InstanceKlass` and a `ciInstanceKlass`, so we should take care of not doing the aforementioned logic only for `ciInlineKlass`, but also for `ciInstanceKlass` that are not identity classes.

# Tests

Testing is not quite easy. First, there is a microbenchmark.

Running
```
make test TEST="micro:org.openjdk.bench.valhalla.loops.osr.LarvalDetectionAboveOSR" CONF_NAME=linux-x64
```
before the fix would give
```
Iteration   1: 1874.498 ms/op
Iteration   2: 1662.409 ms/op
Iteration   3: 204.573 ms/op
Iteration   4: 201.177 ms/op
Iteration   5: 201.526 ms/op
Iteration   6: 200.718 ms/op
Iteration   7: 198.127 ms/op
Iteration   8: 200.535 ms/op
Iteration   9: 201.079 ms/op
Iteration  10: 203.341 ms/op
```
and now
```
Iteration   1: 212.941 ms/op
Iteration   2: 225.214 ms/op
Iteration   3: 204.319 ms/op
Iteration   4: 199.884 ms/op
Iteration   5: 201.875 ms/op
Iteration   6: 202.331 ms/op
Iteration   7: 200.829 ms/op
Iteration   8: 200.794 ms/op
Iteration   9: 200.428 ms/op
Iteration  10: 203.278 ms/op
```
That's better! For this microbench, we need to do everything that we shouldn't usually do: no warmup, single measure... Indeed, as soon as we do more than OSR, the effect disappear.

Otherwise, it's nice to see that the allocation is not there anymore in OSR. That could be an IR framework test, but alas, IR framework doesn't support OSR so easily. The test is thus running a subprocess and parsing the output quite basically. This should be ported to an IR test once the IR framework supports OSR.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8361352](https://bugs.openjdk.org/browse/JDK-8361352): [lworld] Weird interaction between OSR and value class instances (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1531/head:pull/1531` \
`$ git checkout pull/1531`

Update a local copy of the PR: \
`$ git checkout pull/1531` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1531`

View PR using the GUI difftool: \
`$ git pr show -t 1531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1531.diff">https://git.openjdk.org/valhalla/pull/1531.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1531#issuecomment-3214533928)
</details>
