### PR TITLE
ProblemList MemoryAccessProviderTest.java and TestHotSpotResolvedJavaField.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,6 +79,9 @@ compiler/ciReplay/TestIncrementalInlining.java 8349191 generic-all
 
 compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
+compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/MemoryAccessProviderTest.java 8350208 generic-all
+compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestHotSpotResolvedJavaField.java 8350208 generic-all
+
 # Valhalla
 compiler/regalloc/TestVerifyRegisterAllocator.java 8365895 windows-x64
 compiler/startup/StartupOutput.java 8365895 windows-x64


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8350208: CTW: GraphKit::add_safepoint_edges asserts "not enough operands for reexecution"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1532/head:pull/1532` \
`$ git checkout pull/1532`

Update a local copy of the PR: \
`$ git checkout pull/1532` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1532`

View PR using the GUI difftool: \
`$ git pr show -t 1532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1532.diff">https://git.openjdk.org/valhalla/pull/1532.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1532#issuecomment-3214604856)
</details>
