### PR TITLE
8366239: Remove 'package_to_module' function from imageFile.cpp

### DIFF
--- a/src/java.base/share/native/libjimage/imageFile.hpp
+++ b/src/java.base/share/native/libjimage/imageFile.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -302,20 +302,6 @@ public:
     }
 };
 
-//
-// Manage the image module meta data.
-class ImageModuleData {
-    const ImageFileReader* _image_file; // Source image file
-    Endian* _endian;                    // Endian handler
-
-public:
-    ImageModuleData(const ImageFileReader* image_file);
-    ~ImageModuleData();
-
-    // Return the module in which a package resides.    Returns NULL if not found.
-    const char* package_to_module(const char* package_name);
-};
-
 // Image file header, starting at offset 0.
 class ImageHeader {
 private:
@@ -428,7 +414,6 @@ private:
     u4* _offsets_table;  // Location offset table
     u1* _location_bytes; // Location attributes
     u1* _string_bytes;   // String table
-    ImageModuleData *_module_data;       // The ImageModuleData for this image
 
     ImageFileReader(const char* name, bool big_endian);
     ~ImageFileReader();
@@ -577,9 +562,5 @@ public:
 
     // Return the resource for the supplied path.
     void get_resource(ImageLocation& location, u1* uncompressed_data) const;
-
-    // Return the ImageModuleData for this image
-    ImageModuleData * get_image_module_data();
-
 };
 #endif // LIBJIMAGE_IMAGEFILE_HPP

--- a/src/java.base/share/native/libjimage/jimage.cpp
+++ b/src/java.base/share/native/libjimage/jimage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,23 +84,6 @@ JIMAGE_Open(const char *name, jint* error) {
 extern "C" JNIEXPORT void
 JIMAGE_Close(JImageFile* image) {
     ImageFileReader::close((ImageFileReader*) image);
-}
-
-/*
- * JImagePackageToModule - Given an open image file (see JImageOpen) and the name
- * of a package, return the name of module where the package resides. If the
- * package does not exist in the image file, the function returns NULL.
- * The resulting string does/should not have to be released. All strings are
- * utf-8, zero byte terminated.
- *
- * Ex.
- *  const char* package = (*JImagePackageToModule)(image, "java/lang");
- *  tty->print_cr(package);
- *  -> java.base
- */
-extern "C" JNIEXPORT const char*
-JIMAGE_PackageToModule(JImageFile* image, const char* package_name) {
-    return ((ImageFileReader*) image)->get_image_module_data()->package_to_module(package_name);
 }
 
 /*

--- a/src/java.base/share/native/libjimage/jimage.hpp
+++ b/src/java.base/share/native/libjimage/jimage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,25 +91,6 @@ extern "C" JNIEXPORT void
 JIMAGE_Close(JImageFile* jimage);
 
 typedef void (*JImageClose_t)(JImageFile* jimage);
-
-
-/*
- * JImagePackageToModule - Given an open image file (see JImageOpen) and the name
- * of a package, return the name of module where the package resides. If the
- * package does not exist in the image file, the function returns NULL.
- * The resulting string does/should not have to be released. All strings are
- * utf-8, zero byte terminated.
- *
- * Ex.
- *  const char* package = (*JImagePackageToModule)(image, "java/lang");
- *  tty->print_cr(package);
- *  -> java.base
- */
-
-extern "C" JNIEXPORT const char *
-JIMAGE_PackageToModule(JImageFile* jimage, const char* package_name);
-
-typedef const char* (*JImagePackageToModule_t)(JImageFile* jimage, const char* package_name);
 
 
 /*


### PR DESCRIPTION
Removing the 'package_to_module' function from imageFile.cpp and the associated JNI export.
This code isn't used or referenced from anywhere, and removing it makes adapting the package flags for use with preview mode simpler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366239](https://bugs.openjdk.org/browse/JDK-8366239): Remove 'package_to_module' function from imageFile.cpp (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1535/head:pull/1535` \
`$ git checkout pull/1535`

Update a local copy of the PR: \
`$ git checkout pull/1535` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1535`

View PR using the GUI difftool: \
`$ git pr show -t 1535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1535.diff">https://git.openjdk.org/valhalla/pull/1535.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1535#issuecomment-3228082142)
</details>
