### PR TITLE
8366214: [lworld] Use Objects.equals in HashMap and ConcurrentHashmap

### DIFF
--- a/src/java.base/share/classes/java/util/HashMap.java
+++ b/src/java.base/share/classes/java/util/HashMap.java
@@ -576,14 +576,14 @@ public class HashMap<K,V> extends AbstractMap<K,V>
         if ((tab = table) != null && (n = tab.length) > 0 &&
             (first = tab[(n - 1) & (hash = hash(key))]) != null) {
             if (first.hash == hash && // always check first node
-                ((k = first.key) == key || (key != null && key.equals(k))))
+                    Objects.equals(key, first.key))
                 return first;
             if ((e = first.next) != null) {
                 if (first instanceof TreeNode)
                     return ((TreeNode<K,V>)first).getTreeNode(hash, key);
                 do {
                     if (e.hash == hash &&
-                        ((k = e.key) == key || (key != null && key.equals(k))))
+                            Objects.equals(key, e.key))
                         return e;
                 } while ((e = e.next) != null);
             }
@@ -639,7 +639,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
         else {
             Node<K,V> e; K k;
             if (p.hash == hash &&
-                ((k = p.key) == key || (key != null && key.equals(k))))
+                    Objects.equals(key, p.key))
                 e = p;
             else if (p instanceof TreeNode)
                 e = ((TreeNode<K,V>)p).putTreeVal(this, tab, hash, key, value);
@@ -652,7 +652,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
                         break;
                     }
                     if (e.hash == hash &&
-                        ((k = e.key) == key || (key != null && key.equals(k))))
+                            Objects.equals(key, e.key))
                         break;
                     p = e;
                 }
@@ -824,7 +824,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
             (p = tab[index = (n - 1) & hash]) != null) {
             Node<K,V> node = null, e; K k; V v;
             if (p.hash == hash &&
-                ((k = p.key) == key || (key != null && key.equals(k))))
+                    Objects.equals(key, p.key))
                 node = p;
             else if ((e = p.next) != null) {
                 if (p instanceof TreeNode)
@@ -832,8 +832,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
                 else {
                     do {
                         if (e.hash == hash &&
-                            ((k = e.key) == key ||
-                             (key != null && key.equals(k)))) {
+                                Objects.equals(key, e.key)) {
                             node = e;
                             break;
                         }
@@ -1212,7 +1211,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
                 Node<K,V> e = first; K k;
                 do {
                     if (e.hash == hash &&
-                        ((k = e.key) == key || (key != null && key.equals(k)))) {
+                            Objects.equals(key, e.key)) {
                         old = e;
                         break;
                     }
@@ -1312,7 +1311,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
                 Node<K,V> e = first; K k;
                 do {
                     if (e.hash == hash &&
-                        ((k = e.key) == key || (key != null && key.equals(k)))) {
+                            Objects.equals(key, e.key)) {
                         old = e;
                         break;
                     }
@@ -1377,7 +1376,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
                 Node<K,V> e = first; K k;
                 do {
                     if (e.hash == hash &&
-                        ((k = e.key) == key || (key != null && key.equals(k)))) {
+                            Objects.equals(key, e.key)) {
                         old = e;
                         break;
                     }
@@ -2024,7 +2023,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
                     p = pl;
                 else if (ph < h)
                     p = pr;
-                else if ((pk = p.key) == k || (k != null && k.equals(pk)))
+                else if (Objects.equals(k, (pk = p.key)))
                     return p;
                 else if (pl == null)
                     p = pr;
@@ -2142,7 +2141,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
                     dir = -1;
                 else if (ph < h)
                     dir = 1;
-                else if ((pk = p.key) == k || (k != null && k.equals(pk)))
+                else if (Objects.equals(k, (pk = p.key)))
                     return p;
                 else if ((kc == null &&
                           (kc = comparableClassFor(k)) == null) ||

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -48,6 +48,7 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicReference;
@@ -665,8 +666,8 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
             return ((o instanceof Map.Entry) &&
                     (k = (e = (Map.Entry<?,?>)o).getKey()) != null &&
                     (v = e.getValue()) != null &&
-                    (k == key || k.equals(key)) &&
-                    (v == (u = val) || v.equals(u)));
+                    (Objects.equals(k, key)) &&
+                    v.equals(val));
         }
 
         /**
@@ -678,7 +679,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                 do {
                     K ek;
                     if (e.hash == h &&
-                        ((ek = e.key) == k || (ek != null && k.equals(ek))))
+                        (ek = e.key) != null && Objects.equals(k, ek))
                         return e;
                 } while ((e = e.next) != null);
             }
@@ -949,14 +950,14 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
         if ((tab = table) != null && (n = tab.length) > 0 &&
             (e = tabAt(tab, (n - 1) & h)) != null) {
             if ((eh = e.hash) == h) {
-                if ((ek = e.key) == key || (ek != null && key.equals(ek)))
+                if ((ek = e.key) != null && Objects.equals(key, ek))
                     return e.val;
             }
             else if (eh < 0)
                 return (p = e.find(h, key)) != null ? p.val : null;
             while ((e = e.next) != null) {
                 if (e.hash == h &&
-                    ((ek = e.key) == key || (ek != null && key.equals(ek))))
+                    ((ek = e.key) != null && Objects.equals(key, ek)))
                     return e.val;
             }
         }
@@ -994,7 +995,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
             Traverser<K,V> it = new Traverser<K,V>(t, t.length, 0, t.length);
             for (Node<K,V> p; (p = it.advance()) != null; ) {
                 V v;
-                if ((v = p.val) == value || (v != null && value.equals(v)))
+                if ((v = p.val) != null && Objects.equals(value, v))
                     return true;
             }
         }
@@ -1035,7 +1036,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                 tab = helpTransfer(tab, f);
             else if (onlyIfAbsent // check first node without acquiring lock
                      && fh == hash
-                     && ((fk = f.key) == key || (fk != null && key.equals(fk)))
+                     && (fk = f.key) != null && Objects.equals(key, fk)
                      && (fv = f.val) != null)
                 return fv;
             else {
@@ -1047,8 +1048,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                             for (Node<K,V> e = f;; ++binCount) {
                                 K ek;
                                 if (e.hash == hash &&
-                                    ((ek = e.key) == key ||
-                                     (ek != null && key.equals(ek)))) {
+                                    (ek = e.key) != null && Objects.equals(key, ek)) {
                                     oldVal = e.val;
                                     if (!onlyIfAbsent)
                                         e.val = value;
@@ -1140,11 +1140,10 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                             for (Node<K,V> e = f, pred = null;;) {
                                 K ek;
                                 if (e.hash == hash &&
-                                    ((ek = e.key) == key ||
-                                     (ek != null && key.equals(ek)))) {
+                                    ((ek = e.key) != null && Objects.equals(key, ek))) {
                                     V ev = e.val;
-                                    if (cv == null || cv == ev ||
-                                        (ev != null && cv.equals(ev))) {
+                                    if (cv == null ||
+                                        (ev != null && Objects.equals(cv, ev))) {
                                         oldVal = ev;
                                         if (value != null)
                                             e.val = value;
@@ -1167,8 +1166,8 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                             if ((r = t.root) != null &&
                                 (p = r.findTreeNode(hash, key, null)) != null) {
                                 V pv = p.val;
-                                if (cv == null || cv == pv ||
-                                    (pv != null && cv.equals(pv))) {
+                                if (cv == null ||
+                                    (pv != null && Objects.equals(cv, pv))) {
                                     oldVal = pv;
                                     if (value != null)
                                         p.val = value;
@@ -1372,7 +1371,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
             for (Node<K,V> p; (p = it.advance()) != null; ) {
                 V val = p.val;
                 Object v = m.get(p.key);
-                if (v == null || (v != val && !v.equals(val)))
+                if (!Objects.equals(val, v))
                     return false;
             }
             for (Map.Entry<?,?> e : m.entrySet()) {
@@ -1380,7 +1379,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                 if ((mk = e.getKey()) == null ||
                     (mv = e.getValue()) == null ||
                     (v = get(mk)) == null ||
-                    (mv != v && !mv.equals(v)))
+                    !Objects.equals(mv, v))
                     return false;
             }
         }
@@ -1504,8 +1503,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                         Node<K,V> q; K qk;
                         for (q = first; q != null; q = q.next) {
                             if (q.hash == h &&
-                                ((qk = q.key) == k ||
-                                 (qk != null && k.equals(qk)))) {
+                                ((qk = q.key) != null && Objects.equals(k, qk))) {
                                 insertAtFront = false;
                                 break;
                             }
@@ -1734,7 +1732,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
             else if ((fh = f.hash) == MOVED)
                 tab = helpTransfer(tab, f);
             else if (fh == h    // check first node without acquiring lock
-                     && ((fk = f.key) == key || (fk != null && key.equals(fk)))
+                     && ((fk = f.key) != null && Objects.equals(key, fk))
                      && (fv = f.val) != null)
                 return fv;
             else {
@@ -1839,8 +1837,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                             for (Node<K,V> e = f, pred = null;; ++binCount) {
                                 K ek;
                                 if (e.hash == h &&
-                                    ((ek = e.key) == key ||
-                                     (ek != null && key.equals(ek)))) {
+                                    ((ek = e.key) != null && Objects.equals(key, ek))) {
                                     val = remappingFunction.apply(key, e.val);
                                     if (val != null)
                                         e.val = val;
@@ -1951,8 +1948,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                             for (Node<K,V> e = f, pred = null;; ++binCount) {
                                 K ek;
                                 if (e.hash == h &&
-                                    ((ek = e.key) == key ||
-                                     (ek != null && key.equals(ek)))) {
+                                    ((ek = e.key) != null && Objects.equals(key, ek))) {
                                     val = remappingFunction.apply(key, e.val);
                                     if (val != null)
                                         e.val = val;
@@ -2067,8 +2063,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                             for (Node<K,V> e = f, pred = null;; ++binCount) {
                                 K ek;
                                 if (e.hash == h &&
-                                    ((ek = e.key) == key ||
-                                     (ek != null && key.equals(ek)))) {
+                                    ((ek = e.key) != null && Objects.equals(key, ek))) {
                                     val = remappingFunction.apply(e.val, value);
                                     if (val != null)
                                         e.val = val;
@@ -2261,7 +2256,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                 for (;;) {
                     int eh; K ek;
                     if ((eh = e.hash) == h &&
-                        ((ek = e.key) == k || (ek != null && k.equals(ek))))
+                        ((ek = e.key) != null && Objects.equals(k, ek)))
                         return e;
                     if (eh < 0) {
                         if (e instanceof ForwardingNode) {
@@ -2756,7 +2751,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                         p = pl;
                     else if (ph < h)
                         p = pr;
-                    else if ((pk = p.key) == k || (pk != null && k.equals(pk)))
+                    else if ((pk = p.key) != null && Objects.equals(k, pk))
                         return p;
                     else if (pl == null)
                         p = pr;
@@ -2907,7 +2902,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                     int s; K ek;
                     if (((s = lockState) & (WAITER|WRITER)) != 0) {
                         if (e.hash == h &&
-                            ((ek = e.key) == k || (ek != null && k.equals(ek))))
+                            ((ek = e.key) != null && Objects.equals(k, ek)))
                             return e;
                         e = e.next;
                     }
@@ -2947,7 +2942,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
                     dir = -1;
                 else if (ph < h)
                     dir = 1;
-                else if ((pk = p.key) == k || (pk != null && k.equals(pk)))
+                else if ((pk = p.key) != null && Objects.equals(k, pk))
                     return p;
                 else if ((kc == null &&
                           (kc = comparableClassFor(k)) == null) ||
@@ -3546,8 +3541,8 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
             return ((o instanceof Map.Entry) &&
                     (k = (e = (Map.Entry<?,?>)o).getKey()) != null &&
                     (v = e.getValue()) != null &&
-                    (k == key || k.equals(key)) &&
-                    (v == val || v.equals(val)));
+                    Objects.equals(k, key) &&
+                    Objects.equals(v, val));
         }
 
         /**


### PR DESCRIPTION
As observed in [JDK-8366043](https://bugs.openjdk.org/browse/JDK-8366043) [lworld] (LIFE = Legacy Idiom For Equality) causes performance regressions.
Updating HashMap and ConcurrentHashMap to use `java.util.Objects.equals` will make it easier to measure performance of options that remove or modify the use of `==`

Replace constructs like:
```
-                        ((k = e.key) == key || (key != null && key.equals(k))))
with:
+                        Objects.equals(key, k))
```

The changes in ConcurrentHashMap are a bit different due to the use of null as a sentinel.

The order of arguments to the .equals methods must remain the same to ensure compatibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366214](https://bugs.openjdk.org/browse/JDK-8366214): [lworld] Use Objects.equals in HashMap and ConcurrentHashmap (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1536/head:pull/1536` \
`$ git checkout pull/1536`

Update a local copy of the PR: \
`$ git checkout pull/1536` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1536`

View PR using the GUI difftool: \
`$ git pr show -t 1536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1536.diff">https://git.openjdk.org/valhalla/pull/1536.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1536#issuecomment-3229537179)
</details>
