### PR TITLE
8366200: Modify jimage package flags to support preview mode

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageHeader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,23 @@ import java.nio.IntBuffer;
 import java.util.Objects;
 
 /**
+ * Defines the header and version information for jimage files.
+ *
+ * <p>Version number changes must be synced in a single change across all code
+ * which reads/writes jimage files, and code which tries to open a jimage file
+ * with an unexpected version should fail.
+ *
+ * <p>Known jimage file code which needs updating on version change:
+ * <ul>
+ *     <li>src/java.base/share/native/libjimage/imageFile.hpp
+ * </ul>
+ *
+ * <p>Version history:
+ * <ul>
+ *     <li>{@code 1.0}: Original version.
+ *     <li>{@code 1.1}: Change package entry flags to support preview mode.
+ * </ul>
+ *
  * @implNote This class needs to maintain JDK 8 source compatibility.
  *
  * It is used internally in the JDK to implement jimage/jrtfs access,
@@ -39,7 +56,7 @@ import java.util.Objects;
 public final class ImageHeader {
     public static final int MAGIC = 0xCAFEDADA;
     public static final int MAJOR_VERSION = 1;
-    public static final int MINOR_VERSION = 0;
+    public static final int MINOR_VERSION = 1;
     private static final int HEADER_SLOTS = 7;
 
     private final int magic;

--- a/src/java.base/share/native/libjimage/imageFile.hpp
+++ b/src/java.base/share/native/libjimage/imageFile.hpp
@@ -433,7 +433,7 @@ public:
         // Image file major version number.
         MAJOR_VERSION = 1,
         // Image file minor version number.
-        MINOR_VERSION = 0
+        MINOR_VERSION = 1
     };
 
     // Locate an image if file already open.

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -42,14 +41,11 @@ import java.util.stream.Stream;
 
 /**
  * A class to build a sorted tree of Resource paths as a tree of ImageLocation.
- *
  */
 // XXX Public only due to the JImageTask / JImageTask code duplication
 public final class ImageResourcesTree {
-    //
-
     public static boolean isTreeInfoResource(String path) {
-        return path.startsWith("/packages") || path.startsWith("/modules");
+        return path.startsWith("/packages/") || path.startsWith("/modules/");
     }
 
     /**
@@ -198,8 +194,7 @@ public final class ImageResourcesTree {
 
             @Override
             public String toString() {
-                return String.format(Locale.ROOT,
-                        "%s [has_normal_content=%s, has_preview_content=%s, is_preview_only=%s]",
+                return String.format("%s [has_normal_content=%s, has_preview_content=%s, is_preview_only=%s]",
                         name(),
                         (flags() & PKG_FLAG_HAS_NORMAL_CONTENT) != 0,
                         (flags() & PKG_FLAG_HAS_PREVIEW_CONTENT) != 0,

--- a/test/jdk/tools/jlink/whitebox/ImageResourcesTreeTestDriver.java
+++ b/test/jdk/tools/jlink/whitebox/ImageResourcesTreeTestDriver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Whitebox tests for ImageResourcesTree.
+ * @modules jdk.jlink/jdk.tools.jlink.internal
+ * @build jdk.jlink/jdk.tools.jlink.internal.ImageResourcesTreeTest
+ * @run junit/othervm jdk.jlink/jdk.tools.jlink.internal.ImageResourcesTreeTest
+ */
+public class ImageResourcesTreeTestDriver {}

--- a/test/jdk/tools/jlink/whitebox/TEST.properties
+++ b/test/jdk/tools/jlink/whitebox/TEST.properties
@@ -1,0 +1,3 @@
+modules = \
+    jdk.jlink/jdk.tools.jlink.internal
+bootclasspath.dirs=.

--- a/test/jdk/tools/jlink/whitebox/jdk.jlink/jdk/tools/jlink/internal/ImageResourcesTreeTest.java
+++ b/test/jdk/tools/jlink/whitebox/jdk.jlink/jdk/tools/jlink/internal/ImageResourcesTreeTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.tools.jlink.internal;
+
+import jdk.tools.jlink.internal.ImageResourcesTree.Node;
+import jdk.tools.jlink.internal.ImageResourcesTree.PackageNode;
+import jdk.tools.jlink.internal.ImageResourcesTree.PackageNode.PackageReference;
+import jdk.tools.jlink.internal.ImageResourcesTree.Tree;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *
+ */
+public class ImageResourcesTreeTest {
+
+    public static void main(String[] args) {
+        throw new RuntimeException("Well at least it got here...");
+    }
+
+    private static final String PACKAGE_PREFIX = "/packages/";
+
+    // Copied from ImageResourcesTree.
+    private static final int PKG_FLAG_HAS_NORMAL_CONTENT = 0x1;
+    private static final int PKG_FLAG_HAS_PREVIEW_CONTENT = 0x2;
+    private static final int PKG_FLAG_IS_PREVIEW_ONLY = 0x4;
+
+    @Test
+    public void expectedPackages() {
+        // Paths are only to resources. Packages are inferred.
+        List<String> paths = List.of(
+                "/java.base/java/util/SomeClass.class",
+                "/java.logging/java/util/logging/SomeClass.class");
+
+        Tree tree = new Tree(paths);
+        Map<String, Node> nodes = tree.getMap();
+        Node packages = nodes.get("/packages");
+        List<String> pkgNames = nodes.keySet().stream()
+                .filter(p -> p.startsWith(PACKAGE_PREFIX))
+                .map(p -> p.substring(PACKAGE_PREFIX.length()))
+                .sorted()
+                .toList();
+
+        assertEquals(List.of("java", "java.util", "java.util.logging"), pkgNames);
+        for (String pkgName : pkgNames) {
+            PackageNode pkgNode = assertInstanceOf(PackageNode.class, packages.getChildren(pkgName));
+            assertSame(nodes.get(PACKAGE_PREFIX + pkgNode.getName()), pkgNode);
+        }
+    }
+
+    @Test
+    public void expectedPackageEntries() {
+        List<String> paths = List.of(
+                "/java.base/java/util/SomeClass.class",
+                "/java.logging/java/util/logging/SomeClass.class");
+
+        Tree tree = new Tree(paths);
+        Map<String, Node> nodes = tree.getMap();
+        PackageNode pkgUtil = getPackageNode(nodes, "java.util");
+        assertEquals(2, pkgUtil.moduleCount());
+        List<PackageReference> modRefs = pkgUtil.modules().toList();
+
+        List<String> modNames = modRefs.stream().map(PackageReference::name).toList();
+        assertEquals(List.of("java.base", "java.logging"), modNames);
+
+        PackageReference baseRef = modRefs.get(0);
+        assertNonEmptyRef(baseRef, "java.base");
+        assertEquals(PKG_FLAG_HAS_NORMAL_CONTENT, baseRef.flags());
+
+        PackageReference loggingRef = modRefs.get(1);
+        assertEmptyRef(loggingRef, "java.logging");
+        assertEquals(0, loggingRef.flags());
+    }
+
+    @Test
+    public void expectedPackageEntries_withPreviewResources() {
+        List<String> paths = List.of(
+                "/java.base/java/util/SomeClass.class",
+                "/java.base/java/util/OtherClass.class",
+                "/java.base/META-INF/preview/java/util/OtherClass.class",
+                "/java.logging/java/util/logging/SomeClass.class");
+
+        Tree tree = new Tree(paths);
+        Map<String, Node> nodes = tree.getMap();
+        PackageNode pkgUtil = getPackageNode(nodes, "java.util");
+        List<PackageReference> modRefs = pkgUtil.modules().toList();
+
+        PackageReference baseRef = modRefs.get(0);
+        assertNonEmptyRef(baseRef, "java.base");
+        assertEquals(PKG_FLAG_HAS_NORMAL_CONTENT | PKG_FLAG_HAS_PREVIEW_CONTENT, baseRef.flags());
+    }
+
+    @Test
+    public void expectedPackageEntries_withPreviewOnlyPackages() {
+        List<String> paths = List.of(
+                "/java.base/java/util/SomeClass.class",
+                "/java.base/META-INF/preview/java/util/preview/only/PreviewClass.class");
+
+        Tree tree = new Tree(paths);
+        Map<String, Node> nodes = tree.getMap();
+
+        // Preview only package (with content).
+        PackageNode nonEmptyPkg = getPackageNode(nodes, "java.util.preview.only");
+        PackageReference nonEmptyRef = nonEmptyPkg.modules().findFirst().orElseThrow();
+        assertNonEmptyPreviewOnlyRef(nonEmptyRef, "java.base");
+        assertEquals(PKG_FLAG_IS_PREVIEW_ONLY | PKG_FLAG_HAS_PREVIEW_CONTENT, nonEmptyRef.flags());
+
+        // Preview only packages can be empty.
+        PackageNode emptyPkg = getPackageNode(nodes, "java.util.preview");
+        PackageReference emptyRef = emptyPkg.modules().findFirst().orElseThrow();
+        assertEmptyPreviewOnlyRef(emptyRef, "java.base");
+        assertEquals(PKG_FLAG_IS_PREVIEW_ONLY, emptyRef.flags());
+    }
+
+    @Test
+    public void expectedPackageEntries_sharedPackage() {
+        // Many modules define the same package, all but one are empty.
+        // Order shuffled to show reordering in entry list.
+        // Expect: content -> empty{1..6} -> preview{1..2}
+        List<String> paths = List.of(
+                "/java.empty1/java/shared/one/SomeClass.class",
+                "/java.preview1/META-INF/preview/java/shared/foo/SomeClass.class",
+                "/java.empty3/java/shared/three/SomeClass.class",
+                "/java.empty6/java/shared/six/SomeClass.class",
+                "/java.preview2/META-INF/preview/java/shared/bar/SomeClass.class",
+                "/java.empty5/java/shared/five/SomeClass.class",
+                "/java.content/java/shared/MainPackageClass.class",
+                "/java.empty2/java/shared/two/SomeClass.class",
+                "/java.empty4/java/shared/four/SomeClass.class");
+
+        Tree tree = new Tree(paths);
+        Map<String, Node> nodes = tree.getMap();
+
+        // Preview only package (with content).
+        PackageNode sharedPkg = getPackageNode(nodes, "java.shared");
+        assertEquals(9, sharedPkg.moduleCount());
+
+        List<PackageReference> refs = sharedPkg.modules().toList();
+        assertNonEmptyRef(refs.getFirst(), "java.content");
+        assertEquals(PKG_FLAG_HAS_NORMAL_CONTENT, refs.getFirst().flags());
+
+        // Empty non-preview refs after non-empty ref.
+        int idx = 1;
+        for (PackageReference emptyRef : refs.subList(1, 7)) {
+            assertEmptyRef(emptyRef, "java.empty" + idx++);
+            assertEquals(0, emptyRef.flags());
+        }
+
+        // Empty preview-only refs last.
+        idx = 1;
+        for (PackageReference emptyRef : refs.subList(7, 9)) {
+            assertEmptyPreviewOnlyRef(emptyRef, "java.preview" + idx++);
+            assertEquals(PKG_FLAG_IS_PREVIEW_ONLY, emptyRef.flags());
+        }
+    }
+
+    static PackageNode getPackageNode(Map<String, Node> nodes, String pkgName) {
+        return assertInstanceOf(PackageNode.class, nodes.get(PACKAGE_PREFIX + pkgName));
+    }
+
+    static void assertNonEmptyRef(PackageReference ref, String modName) {
+        assertEquals(modName, ref.name(), "Unexpected module name: " + ref);
+        assertFalse(ref.isEmpty(), "Expected non-empty reference: " + ref);
+        assertFalse(ref.isPreviewOnly(), "Expected not preview-only: " + ref);
+    }
+
+    static void assertEmptyRef(PackageReference ref, String modName) {
+        assertEquals(modName, ref.name(), "Unexpected module name: " + ref);
+        assertTrue(ref.isEmpty(), "Expected empty reference: " + ref);
+        assertFalse(ref.isPreviewOnly(), "Expected not preview-only: " + ref);
+    }
+
+    static void assertNonEmptyPreviewOnlyRef(PackageReference ref, String modName) {
+        assertEquals(modName, ref.name(), "Unexpected module name: " + ref);
+        assertFalse(ref.isEmpty(), "Expected empty reference: " + ref);
+        assertTrue(ref.isPreviewOnly(), "Expected preview-only: " + ref);
+    }
+
+    static void assertEmptyPreviewOnlyRef(PackageReference ref, String modName) {
+        assertEquals(modName, ref.name(), "Unexpected module name: " + ref);
+        assertTrue(ref.isEmpty(), "Expected empty reference: " + ref);
+        assertTrue(ref.isPreviewOnly(), "Expected preview-only: " + ref);
+    }
+}

--- a/test/jdk/tools/jlink/whitebox/jdk.jlink/jdk/tools/jlink/internal/ImageResourcesTreeTest.java
+++ b/test/jdk/tools/jlink/whitebox/jdk.jlink/jdk/tools/jlink/internal/ImageResourcesTreeTest.java
@@ -38,14 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- *
- */
 public class ImageResourcesTreeTest {
-
-    public static void main(String[] args) {
-        throw new RuntimeException("Well at least it got here...");
-    }
 
     private static final String PACKAGE_PREFIX = "/packages/";
 


### PR DESCRIPTION
Reuses the previously unused package flags in the /packages/xxx entries of jimage files to support preview mode.

With these flags it becomes simple to determine things like:
1. Which modules are children of /packages/xxx
  - This can differ between preview and non-preview mode.

2. Which modules/packages have any preview content
  - Useful in preview mode for faster rejection testing to avoid double-lookup on all resources.

If there are no preview resources built into the jimage file, then the difference between output is that the "isEmpty" flag (old version) has become a "hasContent" flag (but since these flags are not read by anyone right now, this should not be an issue).

Note that bumping the minor version number was done to ensure that, during testing, no undiscovered code is reading the new file with old logic (this would work since there's no structural change, but the semantics are different).

This does mean that on systems where a 'jimage' binary is installed for the JDK (e.g. /usr/bin/jimage), that tool will stop working on files generate by this code, but the version of that binary in the built JDK will work. The alternative is to just not bump the version number (if nobody is reading the flags now, it shouldn't matter what's in them).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366200](https://bugs.openjdk.org/browse/JDK-8366200): Modify jimage package flags to support preview mode (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1537/head:pull/1537` \
`$ git checkout pull/1537`

Update a local copy of the PR: \
`$ git checkout pull/1537` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1537`

View PR using the GUI difftool: \
`$ git pr show -t 1537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1537.diff">https://git.openjdk.org/valhalla/pull/1537.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1537#issuecomment-3237042760)
</details>
