### PR TITLE
Fix issues in javac combo tests

### DIFF
--- a/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
+++ b/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8234899
  * @summary Verify behavior w.r.t. preview feature API errors and warnings
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      java.base/jdk.internal

--- a/test/langtools/tools/javac/DefiniteAssignment/T8204610.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/T8204610.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8204610
  * @summary Compiler confused by parenthesized "this" in final fields assignments
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/cast/intersection/IntersectionTypeCastTest.java
+++ b/test/langtools/tools/javac/cast/intersection/IntersectionTypeCastTest.java
@@ -26,7 +26,6 @@
  * @bug 8002099 8006694 8129962
  * @summary Add support for intersection types in cast expression
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/defaultMethods/static/hiding/InterfaceMethodHidingTest.java
+++ b/test/langtools/tools/javac/defaultMethods/static/hiding/InterfaceMethodHidingTest.java
@@ -26,7 +26,6 @@
  * @bug 8005166 8129962
  * @summary Add support for static interface methods
  *          Smoke test for static interface method hiding
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/defaultMethods/super/TestDefaultSuperCall.java
+++ b/test/langtools/tools/javac/defaultMethods/super/TestDefaultSuperCall.java
@@ -26,7 +26,6 @@
  * @bug 7192246 8006694 8129962
  * @summary Automatic test for checking correctness of default super/this resolution
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/failover/CheckAttributedTree.java
+++ b/test/langtools/tools/javac/failover/CheckAttributedTree.java
@@ -26,7 +26,6 @@
  * @bug 6970584 8006694 8062373 8129962
  * @summary assorted position errors in compiler syntax trees
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library ../lib
  * @modules java.desktop
  *          jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/generics/diamond/7046778/DiamondAndInnerClassTest.java
+++ b/test/langtools/tools/javac/generics/diamond/7046778/DiamondAndInnerClassTest.java
@@ -26,7 +26,6 @@
  * @bug 7046778 8006694 8129962
  * @summary Project Coin: problem with diamond and member inner classes
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/generics/inference/8176534/TestUncheckedCalls.java
+++ b/test/langtools/tools/javac/generics/inference/8176534/TestUncheckedCalls.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
  * @test
  * @bug 8176534
  * @summary Missing check against target-type during applicability inference
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/generics/rawOverride/7062745/GenericOverrideTest.java
+++ b/test/langtools/tools/javac/generics/rawOverride/7062745/GenericOverrideTest.java
@@ -27,7 +27,6 @@
  * @summary  Regression: difference in overload resolution when two methods
  *  are maximally specific
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/FunctionalInterfaceConversionTest.java
+++ b/test/langtools/tools/javac/lambda/FunctionalInterfaceConversionTest.java
@@ -27,7 +27,6 @@
  * @summary Add lambda tests
  *  perform several automated checks in lambda conversion, esp. around accessibility
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/LambdaParserTest.java
+++ b/test/langtools/tools/javac/lambda/LambdaParserTest.java
@@ -27,7 +27,6 @@
  * @summary Add lambda tests
  *  Add parser support for lambda expressions
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/MethodReferenceParserTest.java
+++ b/test/langtools/tools/javac/lambda/MethodReferenceParserTest.java
@@ -27,7 +27,6 @@
  * @summary Add lambda tests
  *  Add parser support for method references
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/T8235564.java
+++ b/test/langtools/tools/javac/lambda/T8235564.java
@@ -26,7 +26,6 @@
  * @bug 8235564
  * @summary Verify that passing member references to a method not accepting
  *          functional interface does not crash the compiler.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/TestLambdaToMethodStats.java
+++ b/test/langtools/tools/javac/lambda/TestLambdaToMethodStats.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8013576 8129962
  * @summary Add stat support to LambdaToMethod
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/mostSpecific/StructuralMostSpecificTest.java
+++ b/test/langtools/tools/javac/lambda/mostSpecific/StructuralMostSpecificTest.java
@@ -27,7 +27,6 @@
  * @summary Add lambda tests
  *  Automatic test for checking correctness of structural most specific test routine
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/typeInference/combo/TypeInferenceComboTest.java
+++ b/test/langtools/tools/javac/lambda/typeInference/combo/TypeInferenceComboTest.java
@@ -28,7 +28,6 @@
  *  perform automated checks in type inference in lambda expressions
  *  in different contexts
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/multicatch/7030606/DisjunctiveTypeWellFormednessTest.java
+++ b/test/langtools/tools/javac/multicatch/7030606/DisjunctiveTypeWellFormednessTest.java
@@ -26,7 +26,6 @@
  * @bug 7030606 8006694 8129962
  * @summary Project-coin: multi-catch types should be pairwise disjoint
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/patterns/BindingsInitializer.java
+++ b/test/langtools/tools/javac/patterns/BindingsInitializer.java
@@ -26,7 +26,6 @@
  * @bug 8278834
  * @summary Verify pattern matching nested inside initializers of classes nested in methods
  *          works correctly.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/BreakAndLoops.java
+++ b/test/langtools/tools/javac/patterns/BreakAndLoops.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8234922
  * @summary Verify proper scope of binding related to loops and breaks.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/CaseStructureTest.java
+++ b/test/langtools/tools/javac/patterns/CaseStructureTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8269146 8290709
  * @summary Check compilation outcomes for various combinations of case label element.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/ConditionalTest.java
+++ b/test/langtools/tools/javac/patterns/ConditionalTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8236670
  * @summary Verify proper scope of binding related to loops and breaks.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/LocalVariableReuse.java
+++ b/test/langtools/tools/javac/patterns/LocalVariableReuse.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8260593
  * @summary Verify that a temporary storage variable is or is not used as needed when pattern matching.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/PrimitiveInstanceOfComboTest.java
+++ b/test/langtools/tools/javac/patterns/PrimitiveInstanceOfComboTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8304487
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/ScopeResizeTest.java
+++ b/test/langtools/tools/javac/patterns/ScopeResizeTest.java
@@ -26,7 +26,6 @@
  * @bug 8292756
  * @summary Verify the Scope can be safely and correctly resized to accommodate pattern binding variables
  *          when the Scope for a guard is constructed.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/records/LocalStaticDeclarations.java
+++ b/test/langtools/tools/javac/records/LocalStaticDeclarations.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8242293 8246774
  * @summary allow for local interfaces and enums plus nested records, interfaces and enums
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/recovery/ClassBlockExits.java
+++ b/test/langtools/tools/javac/recovery/ClassBlockExits.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8243047
  * @summary javac should not crash while processing exits in class initializers in Flow
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/resolve/BitWiseOperators.java
+++ b/test/langtools/tools/javac/resolve/BitWiseOperators.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8082311 8129962
  * @summary Verify that bitwise operators don't allow to mix numeric and boolean operands.
- * @enablePreview
  * @library ../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/switchexpr/SwitchExpressionNoValue.java
+++ b/test/langtools/tools/javac/switchexpr/SwitchExpressionNoValue.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8276836
  * @summary Check that switch expression with no value does not crash the compiler.
- * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      java.base/jdk.internal

--- a/test/langtools/tools/javac/varargs/warning/Warn4.java
+++ b/test/langtools/tools/javac/varargs/warning/Warn4.java
@@ -26,7 +26,6 @@
  * @bug     6945418 6993978 8006694 7196160 8129962
  * @summary Project Coin: Simplified Varargs Method Invocation
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/varargs/warning/Warn5.java
+++ b/test/langtools/tools/javac/varargs/warning/Warn5.java
@@ -26,7 +26,6 @@
  * @bug     6993978 7097436 8006694 7196160
  * @summary Project Coin: Annotation to reduce varargs warnings
  *  temporarily workaround combo tests are causing time out in several platforms
- * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file


### PR DESCRIPTION
A [change](https://bugs.openjdk.org/browse/JDK-8334294) made last year added `@enablePreview` to some tests using the combinatorial javac testing framework.
I believe the issue was that back then we had no way to load different version of a class (e.g. `Optional`) based on whether we were running on preview vs. non-preview so. Since the framework uses `Optional` it was treated as having an hard dependency on a preview feature, and compilation failed.
To fix this, we added `@enablePreview` in the tests that depend on that framework -- this meant the framework was now compiled with `--enable-preview` which solved the issue.

But this workaround is no longer needed today. And, worse, as we keep getting new tests from mainline, such tests will fail if they depend on the combinatorial framework, as they will depend on a "preview" classfile. So this means that to keep test working we will have to add `@enablePreview` to an increasing number of tests. This doesn't scale and since we no longer need it, it seems better to just just drop the `@enablePreview` directives that were added, effectively reverting the code to what is there in mainline/master.
