### PR TITLE
8310649: [lworld] PrimitiveClassConstantTest fails with ClassFormatError

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -790,12 +790,6 @@ jdk/jfr/jvm/TestWaste.java                                      8282427 generic-
 
 # jdk_internal
 
-jdk/classfile/SwapTest.java                                     8308778 generic-all
-jdk/classfile/LowAdaptTest.java                                 8308778 generic-all
-jdk/classfile/BuilderBlockTest.java                             8308778 generic-all
-jdk/classfile/BuilderTryCatchTest.java                          8308778 generic-all
-jdk/classfile/PrimitiveClassConstantTest.java                   8310649 generic-all
-
 ############################################################################
 
 # jdk_jpackage


### PR DESCRIPTION
Trivially remove a few outdated classfile problemlist entries. These tests all pass now, except  `PrimitiveClassConstantTest` has since been removed and its successor has already been passing in tier1 part3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310649](https://bugs.openjdk.org/browse/JDK-8310649): [lworld] PrimitiveClassConstantTest fails with ClassFormatError (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1539/head:pull/1539` \
`$ git checkout pull/1539`

Update a local copy of the PR: \
`$ git checkout pull/1539` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1539`

View PR using the GUI difftool: \
`$ git pr show -t 1539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1539.diff">https://git.openjdk.org/valhalla/pull/1539.diff</a>

</details>
