### PR TITLE
8366802: [lworld] jdk/javadoc/doccheck/checks/jdkCheckLinks.java fails since jdk-26+26

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/Attributes.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attributes.java
@@ -28,6 +28,7 @@ import java.lang.classfile.AttributeMapper.AttributeStability;
 import java.lang.classfile.attribute.*;
 
 import jdk.internal.classfile.impl.AbstractAttributeMapper.*;
+import jdk.internal.javac.PreviewFeature;
 
 /**
  * Attribute mappers for predefined (JVMS {@jvms 4.7}) and JDK-specific
@@ -250,8 +251,9 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code LoadableDescriptors} attribute}
-     * @since 23
+     * @since Valhalla
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     public static AttributeMapper<LoadableDescriptorsAttribute> loadableDescriptors() {
         return LoadableDescriptorsMapper.INSTANCE;
     }


### PR DESCRIPTION
The missing link points to the preview note on `Attributes::loadableDescriptors`. Simply marking this API as preview fixes it.

Also I fixed the since version from 23 to Valhalla.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366802](https://bugs.openjdk.org/browse/JDK-8366802): [lworld] jdk/javadoc/doccheck/checks/jdkCheckLinks.java fails since jdk-26+26 (**Bug** - P4)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1542/head:pull/1542` \
`$ git checkout pull/1542`

Update a local copy of the PR: \
`$ git checkout pull/1542` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1542`

View PR using the GUI difftool: \
`$ git pr show -t 1542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1542.diff">https://git.openjdk.org/valhalla/pull/1542.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1542#issuecomment-3249460292)
</details>
