### PR TITLE
LoadableDescriptorsAttrTest2 uses preview API Attributes.loadableDescriptors

### DIFF
--- a/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttrTest2.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttrTest2.java
@@ -26,6 +26,7 @@
  * @bug 8331461
  * @summary [lworld] javac is generating a class file with the LoadableDescriptors attribute but with minor version '0'
  * @library /tools/lib
+ * @enablePreview
  * @modules
  *      jdk.compiler/com.sun.tools.javac.code
  *      jdk.compiler/com.sun.tools.javac.util


### PR DESCRIPTION
Fixes new javac failures caused by #1542 when Attributes.loadableDescriptors is now preview. (It should probably be a reflective preview API; that will be addressed in #1439)