### PR TITLE
8366440: [lworld] Two tests broken with JDK-8364483

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6218,7 +6218,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
                                           "(cause: field type in LoadableDescriptors attribute) but loaded class is not a value class",
                                           name->as_C_string(), _class_name->as_C_string());
             }
-            } else {
+          } else {
             log_warning(class, preload)("Preloading of class %s during loading of class %s "
                                         "(cause: field type in LoadableDescriptors attribute) failed : %s",
                                         name->as_C_string(), _class_name->as_C_string(),
@@ -6229,11 +6229,16 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
             CLEAR_PENDING_EXCEPTION;
           }
         } else {
-          // Just poking the system dictionary to see if the class has already be loaded
+          // Just poking the system dictionary to see if the class has already be loaded. Looking for migrated classes
+          // used when --enable-preview when jdk isn't compiled with --enable-preview so doesn't include LoadableDescriptors.
+          // This is temporary.
           oop loader = loader_data()->class_loader();
           InstanceKlass* klass = SystemDictionary::find_instance_klass(THREAD, name, Handle(THREAD, loader));
           if (klass != nullptr && klass->is_inline_klass()) {
             _inline_layout_info_array->adr_at(fieldinfo.index())->set_klass(InlineKlass::cast(klass));
+            log_info(class, preload)("Preloading of class %s during loading of class %s "
+                                     "(cause: field type not in LoadableDescriptors attribute) succeeded",
+                                     name->as_C_string(), _class_name->as_C_string());
           }
         }
       }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
@@ -61,6 +61,9 @@ public class ValuePreloadTest {
         checkFor(pb, "[warning][class,preload] Preloading of class PreloadValue1 during linking of class ValuePreloadClient1 (cause: LoadableDescriptors attribute) failed");
 
         pb = exec("-Xlog:class+preload", "PreloadShared");
-        checkFor(pb, "[info][class,preload] Preloading of class java/time/LocalDate during loading of shared class java/time/LocalDateTime (cause: field type in LoadableDescriptors attribute) succeeded");
+        // Class java/time/LocalDate is already preloaded, so the LoadableDescriptor attribute does not trigger it
+        // to be loaded from the shared archive.
+        // checkFor(pb, "[info][class,preload] Preloading of class java/time/LocalDate during loading of shared class java/time/LocalDateTime (cause: field type in LoadableDescriptors attribute) succeeded");
+        checkFor(pb, "[info][class,preload] Preloading of class java/time/LocalDateTime during linking of class PreloadShared (cause: LoadableDescriptors attribute) succeeded");
     }
 }

--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
@@ -39,7 +39,6 @@
  */
 
 import java.lang.invoke.MethodHandles;
-import java.time.Duration;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassTransform;
 import java.lang.classfile.MethodTransform;
@@ -61,7 +60,7 @@ import java.io.FileNotFoundException;
 
 public class TestVerify {
 
-    private static final String CLASS_TO_BREAK = "java.time.Duration";
+    private static final String CLASS_TO_BREAK = "java.util.Date";
     private static final String INTERNAL_CLASS_TO_BREAK = CLASS_TO_BREAK.replace('.', '/');
     private static final boolean DEBUG = false;
 
@@ -91,7 +90,7 @@ public class TestVerify {
                     }
                     builder.with(element);
                 });
-                var classTransform = ClassTransform.transformingMethods(mm -> mm.methodName().stringValue().equals("getSeconds"), methodTransform);
+                var classTransform = ClassTransform.transformingMethods(mm -> mm.methodName().stringValue().equals("parse"), methodTransform);
 
                 byte[] bytes;
                 try {
@@ -164,7 +163,8 @@ public class TestVerify {
             } else {
                 // Load the class instrumented with CFLH for the VerifyError.
                 inst.addTransformer(new BadTransformer());
-                System.out.println("1 hour is " + Duration.ofHours(1).getSeconds() + " seconds");
+                Class<?> cls = Class.forName(CLASS_TO_BREAK);
+                System.out.println("class loaded" + cls);
             }
             throw new RuntimeException("Failed: Did not throw VerifyError");
         } catch (VerifyError e) {


### PR DESCRIPTION
I added some logging and fixed the tests so that one doesn't rely on a migrated class in java.base to throw a VerifyError (will make a parallel fix to this test in mainline).  The other, I changed the logging message that it is looking for. More tests in this area will be added.
Tested locally.