### PR TITLE
8366267: [lworld] Injected ACC_IDENTITY escapes to instrumentation of older classes

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3264,6 +3264,10 @@ void InstanceKlass::set_minor_version(u2 minor_version) { _constants->set_minor_
 u2 InstanceKlass::major_version() const                 { return _constants->major_version(); }
 void InstanceKlass::set_major_version(u2 major_version) { _constants->set_major_version(major_version); }
 
+bool InstanceKlass::supports_inline_types() const {
+  return major_version() >= Verifier::VALUE_TYPES_MAJOR_VERSION && minor_version() == Verifier::JAVA_PREVIEW_MINOR_VERSION;
+}
+
 const InstanceKlass* InstanceKlass::get_klass_version(int version) const {
   for (const InstanceKlass* ik = this; ik != nullptr; ik = ik->previous_versions()) {
     if (ik->constants()->version() == version) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -754,6 +754,8 @@ public:
   u2 major_version() const;
   void set_major_version(u2 major_version);
 
+  bool supports_inline_types() const;
+
   // source debug extension
   const char* source_debug_extension() const { return _source_debug_extension; }
   void set_source_debug_extension(const char* array, int length);

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -572,7 +572,12 @@ void JvmtiClassFileReconstituter::write_inner_classes_attribute(int length) {
     write_u2(iter.inner_class_info_index());
     write_u2(iter.outer_class_info_index());
     write_u2(iter.inner_name_index());
-    write_u2(iter.inner_access_flags());
+    u2 flags = iter.inner_access_flags();
+    // ClassFileParser may add identity to inner class attributes, so remove it.
+    if (!ik()->supports_inline_types()) {
+      flags &= ~JVM_ACC_IDENTITY;;
+    }
+    write_u2(flags);
   }
 }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -850,4 +850,3 @@ java/awt/Modal/NativeDialogToFrontBackTest.java 7188049 windows-all,linux-all
 # valhalla
 jdk/classfile/AccessFlagsTest.java 8366270 generic-all
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
-java/lang/instrument/VerifyLocalVariableTableOnRetransformTest.java 8366267 generic-all


### PR DESCRIPTION
This is a simple fix to mask off the ACC_IDENTITY bit from the inner class attribute that was added in during classfile parsing for non-preview non-value classfiles.
Tested with tier1 and java/lang/instrument manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366267](https://bugs.openjdk.org/browse/JDK-8366267): [lworld] Injected ACC_IDENTITY escapes to instrumentation of older classes (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1547/head:pull/1547` \
`$ git checkout pull/1547`

Update a local copy of the PR: \
`$ git checkout pull/1547` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1547`

View PR using the GUI difftool: \
`$ git pr show -t 1547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1547.diff">https://git.openjdk.org/valhalla/pull/1547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1547#issuecomment-3254412503)
</details>
