### PR TITLE
8366913: [lworld] Add ACC_STRICT_INIT to ClassFile

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -841,6 +841,9 @@ public sealed interface ClassFile
     /** The bit mask of {@link AccessFlag#STRICT} access and property modifier. */
     int ACC_STRICT = 0x0800;
 
+    /** The bit mask of {@link AccessFlag#STRICT_INIT} access and property modifier. */
+    int ACC_STRICT_INIT = 0x0800;
+
     /** The bit mask of {@link AccessFlag#MODULE} access and property modifier. */
     int ACC_MODULE = 0x8000;
 

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -26,7 +26,6 @@
 package java.lang.reflect;
 
 import jdk.internal.javac.PreviewFeature;
-import jdk.internal.misc.PreviewFeatures;
 
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
@@ -285,14 +284,14 @@ public enum AccessFlag {
                    Map.entry(RELEASE_1, Location.EMPTY_SET))),
 
     /**
-     * The access flag {@code ACC_STRICT_INIT}, with a mask
-     * value of {@code 0x0800}.
+     * The access flag {@code ACC_STRICT_INIT}, with a mask value of
+     * <code>{@value "0x%04x" java.lang.classfile.ClassFile#ACC_STRICT_INIT}</code>.
      *
      * @jvms 4.5 Fields
      * @since Valhalla
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
-    STRICT_INIT(Modifier.STRICT, false,
+    STRICT_INIT(ACC_STRICT_INIT, false,
                 Location.SET_FIELD,
                 List.of(Map.entry(latest(), Location.EMPTY_SET))),
 
@@ -480,7 +479,7 @@ public enum AccessFlag {
          */
         FIELD(ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED |
               ACC_STATIC | ACC_FINAL | ACC_VOLATILE |
-              ACC_TRANSIENT | ACC_SYNTHETIC | ACC_ENUM | ACC_STRICT,
+              ACC_TRANSIENT | ACC_SYNTHETIC | ACC_ENUM | ACC_STRICT_INIT,
               List.of(Map.entry(latest(), // no strict_init
                                 ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED |
                                 ACC_STATIC | ACC_FINAL | ACC_VOLATILE |

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -390,7 +390,7 @@ public final class Modifier {
     /**
      * The {@code int} value representing the {@code strictfp}
      * modifier.
-     * @see AccessFlag#STRICT and AccessFlag#STRICT_FIELD
+     * @see AccessFlag#STRICT
      */
     public static final int STRICT           = 0x00000800;
 
@@ -463,7 +463,7 @@ public final class Modifier {
     private static final int FIELD_MODIFIERS =
         Modifier.PUBLIC         | Modifier.PROTECTED    | Modifier.PRIVATE |
         Modifier.STATIC         | Modifier.FINAL        | Modifier.TRANSIENT |
-        Modifier.VOLATILE       | Modifier.STRICT;
+        Modifier.VOLATILE;
 
     /**
      * The Java source modifiers that can be applied to a method or constructor parameter.

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -38,8 +38,7 @@ import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.vm.annotation.ForceInline;
 
-import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static java.lang.classfile.ClassFile.ACC_STRICT;
+import static java.lang.classfile.ClassFile.*;
 import static java.lang.classfile.constantpool.PoolEntry.TAG_UTF8;
 import static jdk.internal.util.ModifiedUtf.putChar;
 import static jdk.internal.util.ModifiedUtf.utfLen;
@@ -93,7 +92,7 @@ public final class BufWriterImpl implements BufWriter {
         // UTF8 Entry can be used as equality objects
         var checks = new HashSet<>(Arrays.asList(getStrictInstanceFields()));
         for (var f : cm.fields()) {
-            if ((f.flags().flagsMask() & (ACC_STATIC | ACC_STRICT)) == ACC_STRICT) {
+            if ((f.flags().flagsMask() & (ACC_STATIC | ACC_STRICT_INIT)) == ACC_STRICT_INIT) {
                 if (!checks.remove(new WritableField.UnsetField(f.fieldName(), f.fieldType()))) {
                     return false; // Field mismatch!
                 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
@@ -50,8 +50,7 @@ import java.util.Objects;
 
 import jdk.internal.access.SharedSecrets;
 
-import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static java.lang.classfile.ClassFile.ACC_STRICT;
+import static java.lang.classfile.ClassFile.*;
 import static java.lang.classfile.attribute.StackMapFrameInfo.VerificationTypeInfo.*;
 import static java.util.Objects.requireNonNull;
 
@@ -124,7 +123,7 @@ public class StackMapDecoder {
             return List.of();
         var l = new ArrayList<NameAndTypeEntry>(clazz.fields().size());
         for (var field : clazz.fields()) {
-            if ((field.flags().flagsMask() & (ACC_STATIC | ACC_STRICT)) == ACC_STRICT) { // instance strict
+            if ((field.flags().flagsMask() & (ACC_STATIC | ACC_STRICT_INIT)) == ACC_STRICT_INIT) { // instance strict
                 l.add(TemporaryConstantPool.INSTANCE.nameAndTypeEntry(field.fieldName(), field.fieldType()));
             }
         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/WritableField.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/WritableField.java
@@ -28,8 +28,7 @@ import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.util.Arrays;
 
-import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static java.lang.classfile.ClassFile.ACC_STRICT;
+import static java.lang.classfile.ClassFile.*;
 
 /**
  * An interface to obtain field properties for direct class builders.
@@ -47,7 +46,7 @@ public sealed interface WritableField extends Util.Writable
         int size = 0;
         for (int i = 0; i < count; i++) {
             var field = array[i];
-            if ((field.fieldFlags() & (ACC_STATIC | ACC_STRICT)) == ACC_STRICT) {
+            if ((field.fieldFlags() & (ACC_STATIC | ACC_STRICT_INIT)) == ACC_STRICT_INIT) {
                 size++;
             }
         }
@@ -57,7 +56,7 @@ public sealed interface WritableField extends Util.Writable
         int j = 0;
         for (int i = 0; i < count; i++) {
             var field = array[i];
-            if ((field.fieldFlags() & (ACC_STATIC | ACC_STRICT)) == ACC_STRICT) {
+            if ((field.fieldFlags() & (ACC_STATIC | ACC_STRICT_INIT)) == ACC_STRICT_INIT) {
                 ret[j++] = new UnsetField(AbstractPoolEntry.maybeClone(cpb, field.fieldName()),
                         AbstractPoolEntry.maybeClone(cpb, field.fieldType()));
             }


### PR DESCRIPTION
@arraying discovered that java.lang.classfile.ClassFile is missing a constant for ACC_STRICT_INIT. This was due to previous iterations of strict fields proposal calling this flag simply ACC_STRICT like strictfp. The usages of ACC_STRICT and Modifier.STRICT has been reviewed, and ones that actually refer to STRICT_INIT (which is also not a source modifier) are migrated.