### PR TITLE
8365978: [lworld] C2: assert(vk->maybe_flat_in_array()) when using compareAndSetFlatValue with -XX:-UseArrayFlattening

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2825,11 +2825,7 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
       }
       ptr = basic_plus_adr(base, ConvL2X(offset));
     } else {
-      if (!UseArrayFlattening) {
-        uncommon_trap(Deoptimization::Reason_intrinsic,
-                      Deoptimization::Action_none);
-        return true;
-      } else {
+      if (UseArrayFlattening) {
         // Flat array must have an exact type
         bool is_null_free = layout != LayoutKind::NULLABLE_ATOMIC_FLAT;
         bool is_atomic = layout != LayoutKind::NON_ATOMIC_FLAT;
@@ -2841,6 +2837,10 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
         if (ptr_type->field_offset().get() != 0) {
           ptr = _gvn.transform(new CastPPNode(control(), ptr, ptr_type->with_field_offset(0), ConstraintCastNode::StrongDependency));
         }
+      } else {
+        uncommon_trap(Deoptimization::Reason_intrinsic,
+                      Deoptimization::Action_none);
+        return true;
       }
     }
   } else {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2825,16 +2825,22 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
       }
       ptr = basic_plus_adr(base, ConvL2X(offset));
     } else {
-      // Flat array must have an exact type
-      bool is_null_free = layout != LayoutKind::NULLABLE_ATOMIC_FLAT;
-      bool is_atomic = layout != LayoutKind::NON_ATOMIC_FLAT;
-      Node* new_base = cast_to_flat_array(base, value_klass, is_null_free, !is_null_free, is_atomic);
-      replace_in_map(base, new_base);
-      base = new_base;
-      ptr = basic_plus_adr(base, ConvL2X(offset));
-      const TypeAryPtr* ptr_type = _gvn.type(ptr)->is_aryptr();
-      if (ptr_type->field_offset().get() != 0) {
-        ptr = _gvn.transform(new CastPPNode(control(), ptr, ptr_type->with_field_offset(0), ConstraintCastNode::StrongDependency));
+      if (!UseArrayFlattening) {
+        uncommon_trap(Deoptimization::Reason_intrinsic,
+                      Deoptimization::Action_none);
+        return true;
+      } else {
+        // Flat array must have an exact type
+        bool is_null_free = layout != LayoutKind::NULLABLE_ATOMIC_FLAT;
+        bool is_atomic = layout != LayoutKind::NON_ATOMIC_FLAT;
+        Node* new_base = cast_to_flat_array(base, value_klass, is_null_free, !is_null_free, is_atomic);
+        replace_in_map(base, new_base);
+        base = new_base;
+        ptr = basic_plus_adr(base, ConvL2X(offset));
+        const TypeAryPtr* ptr_type = _gvn.type(ptr)->is_aryptr();
+        if (ptr_type->field_offset().get() != 0) {
+          ptr = _gvn.transform(new CastPPNode(control(), ptr, ptr_type->with_field_offset(0), ConstraintCastNode::StrongDependency));
+        }
       }
     }
   } else {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
@@ -26,8 +26,9 @@
  * @bug 8365978
  * @summary Unsafe::compareAndSetFlatValue crashes with -XX:-UseArrayFlattening
  * @enablePreview
+ * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening::test
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening::test
  *                   -XX:-TieredCompilation -Xcomp
  *                   -XX:-UseArrayFlattening
  *                   compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
@@ -36,8 +37,9 @@
 
 package compiler.valhalla.inlinetypes;
 
-import jdk.internal.misc.Unsafe;
 import java.lang.reflect.Field;
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.Asserts;
 
 public class PutFlatValueWithoutUseArrayFlattening {
     static public value class SmallValue {
@@ -59,6 +61,7 @@ public class PutFlatValueWithoutUseArrayFlattening {
             Field f = PutFlatValueWithoutUseArrayFlattening.class.getDeclaredField("f");
             OFFSET = U.objectFieldOffset(f);
             IS_FLATTENED = U.isFlatField(f);
+            Asserts.assertTrue(IS_FLATTENED, "Field f should be flat, the test makes no sense otherwise. And why isn't it?!");
             LAYOUT = U.fieldLayout(f);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -66,7 +69,6 @@ public class PutFlatValueWithoutUseArrayFlattening {
     }
 
     public void test(boolean flag) {
-        assert IS_FLATTENED;
         var newVal = new SmallValue(1, 1);
         var oldVal = new SmallValue(0, 0);
         f = oldVal;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8365978
+ * @summary Unsafe::compareAndSetFlatValue crashes with -XX:-UseArrayFlattening
+ * @enablePreview
+ * @modules java.base/jdk.internal.misc
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening::test
+ *                   -XX:-TieredCompilation -Xcomp
+ *                   -XX:-UseArrayFlattening
+ *                   compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
+ * @run main compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.reflect.Field;
+
+public class PutFlatValueWithoutUseArrayFlattening {
+    static public value class SmallValue {
+        byte a;
+        byte b;
+        SmallValue(int a, int b) {
+            this.a = (byte)a;
+            this.b = (byte)b;
+        }
+    }
+
+    SmallValue f;
+    private static final long OFFSET;
+    private static final boolean IS_FLATTENED;
+    private static final int LAYOUT;
+    static private final Unsafe U = Unsafe.getUnsafe();
+    static {
+        try {
+            Field f = PutFlatValueWithoutUseArrayFlattening.class.getDeclaredField("f");
+            OFFSET = U.objectFieldOffset(f);
+            IS_FLATTENED = U.isFlatField(f);
+            LAYOUT = U.fieldLayout(f);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void test(boolean flag) {
+        assert IS_FLATTENED;
+        var newVal = new SmallValue(1, 1);
+        var oldVal = new SmallValue(0, 0);
+        f = oldVal;
+        if (flag) {
+            U.compareAndSetFlatValue(this, OFFSET, LAYOUT, SmallValue.class, oldVal, newVal);
+        }
+    }
+
+    static public void main(String args[]) {
+        new SmallValue(0, 0);
+        new PutFlatValueWithoutUseArrayFlattening().test(false);
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
@@ -30,9 +30,10 @@
  * @modules java.base/jdk.internal.misc
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening::test
  *                   -XX:-TieredCompilation -Xcomp
- *                   -XX:-UseArrayFlattening
+ *                   -XX:-UseArrayFlattening -XX:+UseFieldFlattening
  *                   compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
- * @run main compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
+ * @run main/othervm -XX:+UseFieldFlattening
+ *                   compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
  */
 
 package compiler.valhalla.inlinetypes;


### PR DESCRIPTION
`Unsafe::compareAndSetFlatValue` calls `Unsafe::compareAndSetFlatValueAsBytes` which then calls `Unsafe::putFlatValue` on a flat array created by `Unsafe::newSpecialArray`.

https://github.com/openjdk/valhalla/blob/858be30119bd5bc37a69d16042523f53bea71a36/src/java.base/share/classes/jdk/internal/misc/Unsafe.java#L2870-L2875

`putFlatValue` can be intrinsified in

https://github.com/openjdk/valhalla/blob/858be30119bd5bc37a69d16042523f53bea71a36/src/hotspot/share/opto/library_call.cpp#L2727

that calls `cast_to_flat_array`

https://github.com/openjdk/valhalla/blob/858be30119bd5bc37a69d16042523f53bea71a36/src/hotspot/share/opto/library_call.cpp#L2831

which fails the assert

https://github.com/openjdk/valhalla/blob/858be30119bd5bc37a69d16042523f53bea71a36/src/hotspot/share/opto/graphKit.cpp#L1875-L1876

because of

https://github.com/openjdk/valhalla/blob/858be30119bd5bc37a69d16042523f53bea71a36/src/hotspot/share/oops/inlineKlass.cpp#L287-L290

Of course, if array flattening is disabled, one can't have flat arrays. And indeed, `Unsafe::newSpecialArray` will raise if called. So at runtime, the call to `Unsafe::compareAndSetFlatValue` should simply raise. But when compiled the assert is hit, crashing the VM, because it cannot tell that the code is dead, but can check that if it's not the array is not flat. That doesn't seem reasonable to me. I propose to insert a trap instead. Even in the case where this code wouldn't be dead (like if `Unsafe::newSpecialArray` is just undefined behavior instead of throwing), crashing the compiler doesn't seem like a good option.

The situation is actually more surprising than it seems: using `Unsafe::compareAndSetFlatValue` on a flat field with `-XX:-UseArrayFlattening` sounds reasonable, but doesn't actually work since the implementation will (attempt to) create flat arrays under the hood. It is not clear to me whether it's actually desirable, as `Unsafe::compareAndSetFlatValue` introduce some coupling of field and array flattening, but on the other hand, it's an unsafe API, so it's not that crazy to require more constrains to use.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8365978](https://bugs.openjdk.org/browse/JDK-8365978): [lworld] C2: assert(vk-&gt;maybe_flat_in_array()) when using compareAndSetFlatValue with -XX:-UseArrayFlattening (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1549/head:pull/1549` \
`$ git checkout pull/1549`

Update a local copy of the PR: \
`$ git checkout pull/1549` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1549`

View PR using the GUI difftool: \
`$ git pr show -t 1549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1549.diff">https://git.openjdk.org/valhalla/pull/1549.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1549#issuecomment-3258078724)
</details>
