### PR TITLE
8366841 objects equals no acmp

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -26,6 +26,7 @@
 package java.util;
 
 import jdk.internal.javac.PreviewFeature;
+import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -60,7 +61,12 @@ public final class Objects {
      * @see Object#equals(Object)
      */
     public static boolean equals(Object a, Object b) {
-        return (a == b) || (a != null && a.equals(b));
+        if (PreviewFeatures.isEnabled()) {
+            // With --enable-preview avoid acmp
+            return (a == null) ? b == null : a.equals(b);
+        } else {
+            return (a == b) || (a != null && a.equals(b));
+        }
     }
 
    /**

--- a/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
+++ b/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,7 +237,7 @@ public class SimpleValueGraphs implements Serializable {
 
         public boolean equals(Object obj) {
             if (obj instanceof SimpleValue simpleValue) {
-                return (i == simpleValue.i && Objects.equals(obj, simpleValue));
+                return (i == simpleValue.i && Objects.equals(this.obj, simpleValue.obj));
             }
             return false;
         }


### PR DESCRIPTION
Modify java.util.Objects.equals to avoid acmp (==) when --enable-preview.

There is a simple bug fix in the SimpleValueGraphs test.