### PR TITLE
8366973: [lworld] Deopt/recompilation cycle due to call to method with unloaded return type

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3707,7 +3707,7 @@ encode %{
       // Check that stack depth is unchanged: find majik cookie on stack
       __ call_Unimplemented();
     }
-    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
+    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic() && _method->return_type()->is_loaded()) {
       // The last return value is not set by the callee but used to pass the null marker to compiled code.
       // Search for the corresponding projection, get the register and emit code that initialized it.
       uint con = (tf()->range_cc()->cnt() - 1);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2718,7 +2718,7 @@ encode %{
       __ int3();
       __ bind(L);
     }
-    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
+    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic() && _method->return_type()->is_loaded()) {
       // The last return value is not set by the callee but used to pass the null marker to compiled code.
       // Search for the corresponding projection, get the register and emit code that initialized it.
       uint con = (tf()->range_cc()->cnt() - 1);

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -762,17 +762,7 @@ void ciTypeFlow::StateVector::do_invoke(ciBytecodeStream* str,
         // ever sees a non-null value, loading has occurred.
         //
         // See do_getstatic() for similar explanation, as well as bug 4684993.
-        if (InlineTypeReturnedAsFields) {
-          // Return might be in scalarized form but we can't handle it because we
-          // don't know the type. This can happen due to a missing preload attribute.
-          // TODO 8284443 Use PhaseMacroExpand::expand_mh_intrinsic_return for this
-          trap(str, nullptr,
-               Deoptimization::make_trap_request
-               (Deoptimization::Reason_uninitialized,
-                Deoptimization::Action_reinterpret));
-        } else {
-          do_null_assert(return_type->as_klass());
-        }
+        do_null_assert(return_type->as_klass());
       } else {
         push_translate(return_type);
       }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6214,7 +6214,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
                                        name->as_C_string(), _class_name->as_C_string());
             } else {
               // Non value class are allowed by the current spec, but it could be an indication of an issue so let's log a warning
-              log_warning(class, preload)("Preloading class %s during loading of class %s "
+              log_warning(class, preload)("Preloading of class %s during loading of class %s "
                                           "(cause: field type in LoadableDescriptors attribute) but loaded class is not a value class",
                                           name->as_C_string(), _class_name->as_C_string());
             }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6173,7 +6173,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           THROW_MSG(vmSymbols::java_lang_ClassCircularityError(),
                     err_msg("Class %s cannot have a null-free non-static field of its own type", _class_name->as_C_string()));
         }
-        log_info(class, preload)("Preloading class %s during loading of class %s. "
+        log_info(class, preload)("Preloading of class %s during loading of class %s. "
                                   "Cause: a null-free non-static field is declared with this type",
                                   s->as_C_string(), _class_name->as_C_string());
         InstanceKlass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, s,
@@ -6194,12 +6194,12 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
         log_info(class, preload)("Preloading of class %s during loading of class %s "
                                  "(cause: null-free non-static field) succeeded",
                                  s->as_C_string(), _class_name->as_C_string());
-      } else if (Signature::has_envelope(sig)) {
+      } else if (Signature::has_envelope(sig) && PreloadClasses) {
         // Preloading classes for nullable fields that are listed in the LoadableDescriptors attribute
         // Those classes would be required later for the flattening of nullable inline type fields
         TempNewSymbol name = Signature::strip_envelope(sig);
         if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) {
-          log_info(class, preload)("Preloading class %s during loading of class %s. "
+          log_info(class, preload)("Preloading of class %s during loading of class %s. "
                                    "Cause: field type in LoadableDescriptors attribute",
                                    name->as_C_string(), _class_name->as_C_string());
           oop loader = loader_data()->class_loader();

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1101,7 +1101,7 @@ bool SystemDictionary::check_shared_class_super_types(InstanceKlass* ik, Handle 
 // Some pre-loading does not fail fatally
 bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
-  log_info(class, preload)("Preloading class %s during loading of shared class %s. "
+  log_info(class, preload)("Preloading of class %s during loading of shared class %s. "
                            "Cause: a null-free non-static field is declared with this type",
                            name->as_C_string(), ik->name()->as_C_string());
   InstanceKlass* real_k = SystemDictionary::resolve_with_circularity_detection_or_fail(ik->name(), name,
@@ -1139,7 +1139,7 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
 void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, Handle class_loader, Symbol* sig, int field_index, TRAPS) {
   TempNewSymbol name = Signature::strip_envelope(sig);
   if (name != ik->name() && ik->is_class_in_loadable_descriptors_attribute(sig)) {
-    log_info(class, preload)("Preloading class %s during loading of shared class %s. "
+    log_info(class, preload)("Preloading of class %s during loading of shared class %s. "
                              "Cause: field type in LoadableDescriptors attribute",
                              name->as_C_string(), ik->name()->as_C_string());
     InstanceKlass* real_k = SystemDictionary::resolve_with_circularity_detection_or_fail(ik->name(), name,

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -296,7 +296,7 @@ class InlineKlass: public InstanceKlass {
   void save_oop_fields(const RegisterMap& map, GrowableArray<Handle>& handles) const;
   void restore_oop_results(RegisterMap& map, GrowableArray<Handle>& handles) const;
   oop realloc_result(const RegisterMap& reg_map, const GrowableArray<Handle>& handles, TRAPS);
-  static InlineKlass* returned_inline_klass(const RegisterMap& reg_map, bool* return_oop = nullptr);
+  static InlineKlass* returned_inline_klass(const RegisterMap& reg_map, bool* return_oop = nullptr, Method* method = nullptr);
 
   address pack_handler() const {
     return *(address*)adr_pack_handler();

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1127,7 +1127,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
           log_info(class, preload)("Preloading of class %s during linking of class %s (cause: LoadableDescriptors attribute) succeeded", class_name->as_C_string(), name()->as_C_string());
           if (!klass->is_inline_klass()) {
             // Non value class are allowed by the current spec, but it could be an indication of an issue so let's log a warning
-              log_warning(class, preload)("Preloading class %s during linking of class %s (cause: LoadableDescriptors attribute) but loaded class is not a value class", class_name->as_C_string(), name()->as_C_string());
+            log_warning(class, preload)("Preloading of class %s during linking of class %s (cause: LoadableDescriptors attribute) but loaded class is not a value class", class_name->as_C_string(), name()->as_C_string());
           }
         } else {
           log_warning(class, preload)("Preloading of class %s during linking of class %s (cause: LoadableDescriptors attribute) failed", class_name->as_C_string(), name()->as_C_string());

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1066,7 +1066,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
         Symbol* sig = fs.signature();
         TempNewSymbol s = Signature::strip_envelope(sig);
         if (s != name()) {
-          log_info(class, preload)("Preloading class %s during linking of class %s. Cause: a null-free static field is declared with this type", s->as_C_string(), name()->as_C_string());
+          log_info(class, preload)("Preloading of class %s during linking of class %s. Cause: a null-free static field is declared with this type", s->as_C_string(), name()->as_C_string());
           Klass* klass = SystemDictionary::resolve_or_fail(s,
                                                           Handle(THREAD, class_loader()), true,
                                                           CHECK_false);
@@ -1109,14 +1109,14 @@ bool InstanceKlass::link_class_impl(TRAPS) {
     }
 
     // Aggressively preloading all classes from the LoadableDescriptors attribute
-    if (loadable_descriptors() != nullptr) {
+    if (loadable_descriptors() != nullptr && PreloadClasses) {
       HandleMark hm(THREAD);
       for (int i = 0; i < loadable_descriptors()->length(); i++) {
         Symbol* sig = constants()->symbol_at(loadable_descriptors()->at(i));
         if (!Signature::has_envelope(sig)) continue;
         TempNewSymbol class_name = Signature::strip_envelope(sig);
         if (class_name == name()) continue;
-        log_info(class, preload)("Preloading class %s during linking of class %s because of the class is listed in the LoadableDescriptors attribute", sig->as_C_string(), name()->as_C_string());
+        log_info(class, preload)("Preloading of class %s during linking of class %s because of the class is listed in the LoadableDescriptors attribute", sig->as_C_string(), name()->as_C_string());
         oop loader = class_loader();
         Klass* klass = SystemDictionary::resolve_or_null(class_name,
                                                          Handle(THREAD, loader), THREAD);

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -737,16 +737,14 @@ int Method::extra_stack_words() {
 // InlineKlass the method is declared to return. This must not
 // safepoint as it is called with references live on the stack at
 // locations the GC is unaware of.
-InlineKlass* Method::returns_inline_type(Thread* thread) const {
+InlineKlass* Method::returns_inline_type() const {
   assert(InlineTypeReturnedAsFields, "Inline types should never be returned as fields");
   if (is_native()) {
     return nullptr;
   }
   NoSafepointVerifier nsv;
   SignatureStream ss(signature());
-  while (!ss.at_return_type()) {
-    ss.next();
-  }
+  ss.skip_to_return_type();
   return ss.as_inline_klass(method_holder());
 }
 
@@ -1313,7 +1311,7 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
       SharedRuntime::native_method_throw_unsatisfied_link_error_entry(),
       !native_bind_event_is_interesting);
   }
-  if (InlineTypeReturnedAsFields && returns_inline_type(THREAD) && !has_scalarized_return()) {
+  if (InlineTypeReturnedAsFields && returns_inline_type() && !has_scalarized_return()) {
     set_has_scalarized_return();
   }
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -516,7 +516,7 @@ public:
   Symbol* klass_name() const;                    // returns the name of the method holder
   BasicType result_type() const                  { return constMethod()->result_type(); }
   bool is_returning_oop() const                  { BasicType r = result_type(); return is_reference_type(r); }
-  InlineKlass* returns_inline_type(Thread* thread) const;
+  InlineKlass* returns_inline_type() const;
 
   // Checked exceptions thrown by this method (resolved to mirrors)
   objArrayHandle resolved_checked_exceptions(TRAPS) { return resolved_checked_exceptions_impl(this, THREAD); }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -834,7 +834,7 @@ void CallGenerator::do_late_inline_helper() {
       }
       DEBUG_ONLY(buffer_oop = nullptr);
     } else {
-      assert(result->is_top() || !call->tf()->returns_inline_type_as_fields(), "Unexpected return value");
+      assert(result->is_top() || !call->tf()->returns_inline_type_as_fields() || !call->as_CallJava()->method()->return_type()->is_loaded(), "Unexpected return value");
     }
     assert(buffer_oop == nullptr, "unused buffer allocation");
 

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -2095,7 +2095,8 @@ void ConnectionGraph::add_call_node(CallNode* call) {
     if (meth == nullptr) {
       const char* name = call->as_CallStaticJava()->_name;
       assert(strncmp(name, "C2 Runtime multianewarray", 25) == 0 ||
-             strncmp(name, "C2 Runtime load_unknown_inline", 30) == 0, "TODO: add failed case check");
+             strncmp(name, "C2 Runtime load_unknown_inline", 30) == 0 ||
+             strncmp(name, "store_inline_type_fields_to_buf", 31) == 0, "TODO: add failed case check");
       // Returns a newly allocated non-escaped object.
       add_java_object(call, PointsToNode::NoEscape);
       set_not_scalar_replaceable(ptnode_adr(call_idx) NOT_PRODUCT(COMMA "is result of multinewarray"));
@@ -2275,6 +2276,7 @@ void ConnectionGraph::process_call_arguments(CallNode *call) {
                   strcmp(call->as_CallLeaf()->_name, "vectorizedMismatch") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "load_unknown_inline") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "store_unknown_inline") == 0 ||
+                  strcmp(call->as_CallLeaf()->_name, "store_inline_type_fields_to_buf") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "bigIntegerRightShiftWorker") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "bigIntegerLeftShiftWorker") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "vectorizedMismatch") == 0 ||
@@ -2814,7 +2816,8 @@ int ConnectionGraph::find_init_values_phantom(JavaObjectNode* pta) {
   if (alloc->is_CallStaticJava() && alloc->as_CallStaticJava()->method() == nullptr) {
     const char* name = alloc->as_CallStaticJava()->_name;
     assert(strncmp(name, "C2 Runtime multianewarray", 25) == 0 ||
-           strncmp(name, "C2 Runtime load_unknown_inline", 30) == 0, "sanity");
+           strncmp(name, "C2 Runtime load_unknown_inline", 30) == 0 ||
+           strncmp(name, "store_inline_type_fields_to_buf", 31) == 0, "sanity");
   }
 #endif
   // Non-escaped allocation returned from Java or runtime call have unknown values in fields.

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -2385,7 +2385,7 @@ const TypeFunc *OptoRuntime::store_inline_type_fields_Type() {
 
   // create result type (range)
   fields = TypeTuple::fields(1);
-  fields[TypeFunc::Parms+0] = TypeInstPtr::NOTNULL;
+  fields[TypeFunc::Parms+0] = TypeInstPtr::BOTTOM;
 
   const TypeTuple *range = TypeTuple::make(TypeFunc::Parms+1,fields);
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1984,6 +1984,9 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, StressCallingConvention, false,                             \
           "Stress the scalarized calling convention.")                      \
                                                                             \
+  develop(bool, PreloadClasses, true,                                       \
+          "Preloading all classes from the LoadableDescriptors attribute")  \
+                                                                            \
   product(ccstrlist, ForceNonTearable, "", DIAGNOSTIC,                      \
           "List of inline classes which are forced to be atomic "           \
           "(whitespace and commas separate names, "                         \

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -382,7 +382,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
   if (InlineTypeReturnedAsFields && (result->get_type() == T_OBJECT)) {
     // Pre allocate a buffered inline type in case the result is returned
     // flattened by compiled code
-    InlineKlass* vk = method->returns_inline_type(thread);
+    InlineKlass* vk = method->returns_inline_type();
     if (vk != nullptr && vk->can_be_returned_as_fields()) {
       oop instance = vk->allocate_instance(CHECK);
       value_buffer = JNIHandles::make_local(thread, instance);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -790,15 +790,13 @@ void ThreadSafepointState::handle_polling_page_exception() {
     HandleMark hm(self);
     GrowableArray<Handle> return_values;
     InlineKlass* vk = nullptr;
-    if (method->has_scalarized_return()) {
+    if (InlineTypeReturnedAsFields && return_oop) {
       // Check if an inline type is returned as fields
-      assert(return_oop, "must be");
-      vk = InlineKlass::returned_inline_klass(map, &return_oop);
+      vk = InlineKlass::returned_inline_klass(map, &return_oop, method);
       if (vk != nullptr) {
         // We're at a safepoint at the return of a method that returns
         // multiple values. We must make sure we preserve the oop values
         // across the safepoint.
-        assert(vk == method->returns_inline_type(thread()), "bad inline klass");
         vk->save_oop_fields(map, return_values);
       }
     }

--- a/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
+++ b/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
@@ -187,7 +187,6 @@ public class TestInlineUnloaded {
             "-cp", "launcher.jar",
             "-XX:+IgnoreUnrecognizedVMOptions", "-showversion",
             "-XX:-TieredCompilation", "-Xbatch",
-            "-XX:-InlineTypeReturnedAsFields", // TODO Remove this once 8284443 fixed handling of unloaded return types
             "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
             "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*TestNull::run",
             Launcher.class.getName(), testCaseName);

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -45,8 +45,7 @@ public class TestInliningProtectionDomain extends InliningBase {
     public static void main(String[] args) {
         new TestInliningProtectionDomain(ProtectionDomainTestCompiledBefore.class, true);
         new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPublic.class, false);
-        // TODO Re-enable this once 8284443 fixed handling of unloaded return types
-        // new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPrivate.class, false);
+        new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPrivate.class, false);
         new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPrivateString.class, false);
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java
@@ -30,9 +30,9 @@
  * @modules java.base/jdk.internal.misc
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening::test
  *                   -XX:-TieredCompilation -Xcomp
- *                   -XX:-UseArrayFlattening -XX:+UseFieldFlattening
+ *                   -XX:-UseArrayFlattening -XX:+UseFieldFlattening -XX:+IgnoreUnrecognizedVMOptions -XX:+PreloadClasses
  *                   compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
- * @run main/othervm -XX:+UseFieldFlattening
+ * @run main/othervm -XX:+UseFieldFlattening -XX:+IgnoreUnrecognizedVMOptions -XX:+PreloadClasses
  *                   compiler.valhalla.inlinetypes.PutFlatValueWithoutUseArrayFlattening
  */
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
@@ -53,7 +53,7 @@ import static compiler.lib.ir_framework.IRNode.STATIC_CALL;
  * @enablePreview
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
- * @run main/othervm/timeout=300 compiler.valhalla.inlinetypes.TestMethodHandles
+ * @run main/othervm/timeout=450 compiler.valhalla.inlinetypes.TestMethodHandles
  */
 
 @ForceCompileClassInitializer

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java
@@ -58,6 +58,21 @@
  *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention::callee
  *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention*::verify
  *                   TestOopsInReturnConvention C2
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:-TieredCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:-PreloadClasses
+ *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention::callee
+ *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention*::verify
+ *                   TestOopsInReturnConvention Interpreted
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-PreloadClasses
+ *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention::callee
+ *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention*::verify
+ *                   TestOopsInReturnConvention C1
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:-TieredCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:-PreloadClasses
+ *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention::callee
+ *                   -XX:CompileCommand=dontinline,TestOopsInReturnConvention*::verify
+ *                   TestOopsInReturnConvention C2
  **/
 
 import java.lang.reflect.Method;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestTearing.java
@@ -61,7 +61,7 @@ import jdk.internal.vm.annotation.Strict;
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
  *                   compiler.valhalla.inlinetypes.TestTearing
  *
- * @run main/othervm -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening -XX:+UseArrayFlattening
+ * @run main/othervm/timeout=450 -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening -XX:+UseArrayFlattening
  *                   -Xcomp -XX:-TieredCompilation
  *                   compiler.valhalla.inlinetypes.TestTearing
  * @run main/othervm -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening -XX:+UseArrayFlattening

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedReturnTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedReturnTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,18 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -Xbatch -XX:CompileCommand=dontinline,*::test*
  *                   TestUnloadedReturnTypes
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-PreloadClasses
+ *                   -Xbatch -XX:CompileCommand=dontinline,*::test*
+ *                   TestUnloadedReturnTypes
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-PreloadClasses -XX:+AlwaysIncrementalInline
+ *                   TestUnloadedReturnTypes
  */
 
 import java.lang.reflect.Method;
 
+import jdk.test.lib.Asserts;
 import jdk.test.whitebox.WhiteBox;
 
 value class MyValue1 {
@@ -45,10 +53,97 @@ value class MyValue1 {
     }
 }
 
-class MyClass {
-
-    static MyValue1 test(boolean b) {
+class MyHolder1 {
+    static MyValue1 test1(boolean b) {
         return b ? new MyValue1(42) : null;
+    }
+}
+
+// Uses all registers available for scalarized return on x64
+value class MyValue2 {
+    int i1 = 42;
+    int i2 = 43;
+    int i3 = 44;
+    int i4 = 45;
+    int i5 = 46;
+    double d1 = 47;
+    double d2 = 48;
+    double d3 = 49;
+    double d4 = 50;
+    double d5 = 51;
+    double d6 = 52;
+    double d7 = 53;
+    double d8 = 54;
+}
+
+class MyHolder2Super {
+    public MyValue2 test2Virtual(boolean loadIt) {
+        if (loadIt) {
+            return new MyValue2();
+        }
+        return null;
+    }
+}
+
+class MyHolder2 extends MyHolder2Super {
+    public MyValue2 test2(boolean loadIt) {
+        if (loadIt) {
+            return new MyValue2();
+        }
+        return null;
+    }
+
+    @Override
+    public MyValue2 test2Virtual(boolean loadIt) {
+        if (loadIt) {
+            return new MyValue2();
+        }
+        return null;
+    }
+}
+
+// Uses all registers available for scalarized return on AArch64
+value class MyValue3 {
+    int i1 = 42;
+    int i2 = 43;
+    int i3 = 44;
+    int i4 = 45;
+    int i5 = 46;
+    int i6 = 47;
+    int i7 = 48;
+    double d1 = 49;
+    double d2 = 50;
+    double d3 = 51;
+    double d4 = 52;
+    double d5 = 53;
+    double d6 = 54;
+    double d7 = 55;
+    double d8 = 56;
+}
+
+class MyHolder3Super {
+    public MyValue3 test3Virtual(boolean loadIt) {
+        if (loadIt) {
+            return new MyValue3();
+        }
+        return null;
+    }
+}
+
+class MyHolder3 extends MyHolder3Super {
+    public MyValue3 test3(boolean loadIt) {
+        if (loadIt) {
+            return new MyValue3();
+        }
+        return null;
+    }
+
+    @Override
+    public MyValue3 test3Virtual(boolean loadIt) {
+        if (loadIt) {
+            return new MyValue3();
+        }
+        return null;
     }
 }
 
@@ -57,28 +152,64 @@ public class TestUnloadedReturnTypes {
 
     static Object res = null;
 
-    public static void test(boolean b) {
-        res = MyClass.test(b);
+    public static void test1(boolean b) {
+        res = MyHolder1.test1(b);
+    }
+
+    public static Object test2(MyHolder2 h, boolean loadIt) {
+        return h.test2(loadIt);
+    }
+
+    public static Object test2Virtual(MyHolder2Super h, boolean loadIt) {
+        return h.test2Virtual(loadIt);
+    }
+
+    public static Object test3(MyHolder3 h, boolean loadIt) {
+        return h.test3(loadIt);
+    }
+
+    public static Object test3Virtual(MyHolder3Super h, boolean loadIt) {
+        return h.test3Virtual(loadIt);
     }
 
     public static void main(String[] args) throws Exception {
         // C1 compile caller method
-        Method m = TestUnloadedReturnTypes.class.getMethod("test", boolean.class);
+        Method m = TestUnloadedReturnTypes.class.getMethod("test1", boolean.class);
         WHITE_BOX.enqueueMethodForCompilation(m, 3);
 
-        // Make sure the callee method is C2 compiled
+        MyHolder2 h2 = new MyHolder2();
+        MyHolder2Super h2Super = new MyHolder2Super();
+        MyHolder3 h3 = new MyHolder3();
+        MyHolder3Super h3Super = new MyHolder3Super();
+
+        // Warmup
         for (int i = 0; i < 100_000; ++i) {
-            MyClass.test((i % 2) == 0);
+            MyHolder1.test1((i % 2) == 0);
+            Asserts.assertEquals(test2(h2, false), null);
+            Asserts.assertEquals(test2Virtual(h2, false), null);
+            Asserts.assertEquals(test2Virtual(h2Super, false), null);
+            Asserts.assertEquals(test3(h3, false), null);
+            Asserts.assertEquals(test3Virtual(h3, false), null);
+            Asserts.assertEquals(test3Virtual(h3Super, false), null);
         }
 
-        test(true);
-        if (((MyValue1)res).x != 42) {
-            throw new RuntimeException("Test failed");
-        }
+        test1(true);
+        Asserts.assertEquals(((MyValue1)res).x, 42);
+        test1(false);
+        Asserts.assertEquals(res, null);
 
-        test(false);
-        if (res != null) {
-            throw new RuntimeException("Test failed");
+        // Deopt and re-compile callee at C2 so it returns scalarized, then deopt again
+        for (int i = 0; i < 100_000; ++i) {
+            Asserts.assertEquals(h2.test2(true), new MyValue2());
+            Asserts.assertEquals(h2Super.test2Virtual(true), new MyValue2());
+            Asserts.assertEquals(h3.test3(true), new MyValue3());
+            Asserts.assertEquals(h3Super.test3Virtual(true), new MyValue3());
         }
+        Asserts.assertEquals(test2(h2, true), new MyValue2());
+        Asserts.assertEquals(test2Virtual(h2, true), new MyValue2());
+        Asserts.assertEquals(test2Virtual(h2Super, true), new MyValue2());
+        Asserts.assertEquals(test3(h3, true), new MyValue3());
+        Asserts.assertEquals(test3Virtual(h3, true), new MyValue3());
+        Asserts.assertEquals(test3Virtual(h3Super, true), new MyValue3());
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedInlineClass.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedInlineClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
  * @test
  * @bug 8187679
  * @summary The VM should exit gracefully when unable to preload an inline type argument
- * @library /test/lib
  * @enablePreview
+ * @requires vm.flagless
+ * @library /test/lib
  * @compile SimpleInlineType.java TestUnresolvedInlineClass.java
  * @run main/othervm TestUnresolvedInlineClass
  */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
@@ -72,8 +72,8 @@ public class PreloadCircularityTest {
     void test_0() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class0a");
         out.shouldHaveExitValue(0);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class0b during loading of class PreloadCircularityTest$Class0a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class0c during loading of class PreloadCircularityTest$Class0b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class0b during loading of class PreloadCircularityTest$Class0a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class0c during loading of class PreloadCircularityTest$Class0b. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class0c during loading of class PreloadCircularityTest$Class0b (cause: null-free non-static field) succeeded");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class0b during loading of class PreloadCircularityTest$Class0a (cause: null-free non-static field) succeeded");
         out.shouldNotContain("(cause: null-free non-static field) failed");
@@ -96,8 +96,8 @@ public class PreloadCircularityTest {
     void test_1() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class1a");
         out.shouldHaveExitValue(0);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class1b during loading of class PreloadCircularityTest$Class1a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class1c during loading of class PreloadCircularityTest$Class1b. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class1b during loading of class PreloadCircularityTest$Class1a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class1c during loading of class PreloadCircularityTest$Class1b. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class1c during loading of class PreloadCircularityTest$Class1b (cause: field type in LoadableDescriptors attribute) succeeded");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class1b during loading of class PreloadCircularityTest$Class1a (cause: null-free non-static field) succeeded");
     }
@@ -123,9 +123,9 @@ public class PreloadCircularityTest {
     void test_2() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class2a");
         out.shouldHaveExitValue(1);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class2b during loading of class PreloadCircularityTest$Class2a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class2c during loading of class PreloadCircularityTest$Class2b. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class2b during loading of class PreloadCircularityTest$Class2c. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class2b during loading of class PreloadCircularityTest$Class2a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class2c during loading of class PreloadCircularityTest$Class2b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class2b during loading of class PreloadCircularityTest$Class2c. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class2b during loading of class PreloadCircularityTest$Class2c (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class2c during loading of class PreloadCircularityTest$Class2b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class2b during loading of class PreloadCircularityTest$Class2a (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
@@ -150,9 +150,9 @@ public class PreloadCircularityTest {
     void test_3() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class3a");
         out.shouldHaveExitValue(0);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class3c during loading of class PreloadCircularityTest$Class3b. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3c. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class3c during loading of class PreloadCircularityTest$Class3b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3c. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3c (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
         out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class3c during loading of class PreloadCircularityTest$Class3b (cause: null-free non-static field) succeeded");
         out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3a (cause: null-free non-static field) succeeded");
@@ -173,8 +173,8 @@ public class PreloadCircularityTest {
     void test_4() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class4a");
         out.shouldHaveExitValue(1);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class4b during loading of class PreloadCircularityTest$Class4a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class4a during loading of class PreloadCircularityTest$Class4b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class4b during loading of class PreloadCircularityTest$Class4a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class4a during loading of class PreloadCircularityTest$Class4b. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class4a during loading of class PreloadCircularityTest$Class4b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class4b during loading of class PreloadCircularityTest$Class4a (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
     }
@@ -206,16 +206,16 @@ public class PreloadCircularityTest {
     void test_5() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class5a");
         out.shouldHaveExitValue(0);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5a. Cause: field type in LoadableDescriptors attribute");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5a. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5a (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
-        out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5c during loading of class PreloadCircularityTest$Class5a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5c. Cause: field type in LoadableDescriptors attribute");
-        out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class5c during loading of class PreloadCircularityTest$Class5a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5c. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5c (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
@@ -249,11 +249,11 @@ public class PreloadCircularityTest {
     void test_6() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class6a");
         out.shouldHaveExitValue(1);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6c during loading of class PreloadCircularityTest$Class6b. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class6c during loading of class PreloadCircularityTest$Class6b. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class6c during loading of class PreloadCircularityTest$Class6b (cause: field type in LoadableDescriptors attribute) succeeded");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6d during loading of class PreloadCircularityTest$Class6b. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6d. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class6d during loading of class PreloadCircularityTest$Class6b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6d. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6d (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class6d during loading of class PreloadCircularityTest$Class6b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6a (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
@@ -268,7 +268,7 @@ public class PreloadCircularityTest {
     void test_7() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class7a");
         out.shouldHaveExitValue(1);
-        out.shouldNotContain("[info][class,preload] Preloading class PreloadCircularityTest$Class7a during loading of class PreloadCircularityTest$Class7a. Cause: a null-free non-static field is declared with this type");
+        out.shouldNotContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class7a during loading of class PreloadCircularityTest$Class7a. Cause: a null-free non-static field is declared with this type");
     }
 
     static value class Class8a {
@@ -278,7 +278,7 @@ public class PreloadCircularityTest {
     void test_8() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class8a");
         out.shouldHaveExitValue(0);
-        out.shouldNotContain("[info][class,preload] Preloading class PreloadCircularityTest$Class8a during loading of class PreloadCircularityTest$Class8a. Cause: a null-free non-static field is declared with this type");
+        out.shouldNotContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class8a during loading of class PreloadCircularityTest$Class8a. Cause: a null-free non-static field is declared with this type");
     }
 
     static value class Class9a {
@@ -292,7 +292,7 @@ public class PreloadCircularityTest {
     void test_9() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class9a");
         out.shouldHaveExitValue(1);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class9b during loading of class PreloadCircularityTest$Class9a. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class9b during loading of class PreloadCircularityTest$Class9a. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("java.lang.IncompatibleClassChangeError: Class PreloadCircularityTest$Class9a expects class PreloadCircularityTest$Class9b to be a value class, but it is an identity class");
     }
 
@@ -307,7 +307,7 @@ public class PreloadCircularityTest {
     // void test_10() throws Exception {
     //     OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class10a");
     //     out.shouldHaveExitValue(1);
-    //     out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class10b during loading of class PreloadCircularityTest$Class10a. Cause: a null-free non-static field is declared with this type");
+    //     out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class10b during loading of class PreloadCircularityTest$Class10a. Cause: a null-free non-static field is declared with this type");
     //     out.shouldContain("java.lang.IncompatibleClassChangeError: class PreloadCircularityTest$Class10b is not implicitly constructible and it is used in a null restricted non-static field (not supported)");
     // }
 
@@ -350,13 +350,13 @@ public class PreloadCircularityTest {
     void test_51() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class51a");
         out.shouldHaveExitValue(0);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class51b during linking of class PreloadCircularityTest$Class51a. Cause: a null-free static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51b during linking of class PreloadCircularityTest$Class51a. Cause: a null-free static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51b during linking of class PreloadCircularityTest$Class51a (cause: null-free static field) succeeded");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class51c during linking of class PreloadCircularityTest$Class51a. Cause: a null-free static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class51a during loading of class PreloadCircularityTest$Class51c. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51c during linking of class PreloadCircularityTest$Class51a. Cause: a null-free static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51a during loading of class PreloadCircularityTest$Class51c. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51a during loading of class PreloadCircularityTest$Class51c (cause: null-free non-static field) succeeded");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51c during linking of class PreloadCircularityTest$Class51a (cause: null-free static field) succeeded");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class51a during linking of class PreloadCircularityTest$Class51b. Cause: a null-free static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51a during linking of class PreloadCircularityTest$Class51b. Cause: a null-free static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class51a during linking of class PreloadCircularityTest$Class51b (cause: null-free static field) succeeded");
     }
 
@@ -381,9 +381,9 @@ public class PreloadCircularityTest {
     void test_52() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class52a");
         out.shouldHaveExitValue(1);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class52b during linking of class PreloadCircularityTest$Class52a. Cause: a null-free static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class52c during loading of class PreloadCircularityTest$Class52b. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class52b during loading of class PreloadCircularityTest$Class52c. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class52b during linking of class PreloadCircularityTest$Class52a. Cause: a null-free static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class52c during loading of class PreloadCircularityTest$Class52b. Cause: a null-free non-static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class52b during loading of class PreloadCircularityTest$Class52c. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class52b during loading of class PreloadCircularityTest$Class52c (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class52c during loading of class PreloadCircularityTest$Class52b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
     }
@@ -407,12 +407,12 @@ public class PreloadCircularityTest {
     // void test_53() throws Exception {
     //     OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class53a");
     //     out.shouldHaveExitValue(0);
-    //     out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class53b during loading of class PreloadCircularityTest$Class53a. Cause: field type in LoadableDescriptors attribute");
-    //     out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b. Cause: a null-free non-static field is declared with this type");
+    //     out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class53b during loading of class PreloadCircularityTest$Class53a. Cause: field type in LoadableDescriptors attribute");
+    //     out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b. Cause: a null-free non-static field is declared with this type");
     //     out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
     //     out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class53b during loading of class PreloadCircularityTest$Class53a (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
-    //     out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class53b during linking of class PreloadCircularityTest$Class53a. Cause: a null-free static field is declared with this type");
-    //     out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b. Cause: a null-free non-static field is declared with this type");
+    //     out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class53b during linking of class PreloadCircularityTest$Class53a. Cause: a null-free static field is declared with this type");
+    //     out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b. Cause: a null-free non-static field is declared with this type");
     //     out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b (cause: null-free non-static field) succeeded");
     //     out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class53b during linking of class PreloadCircularityTest$Class53a (cause: null-free static field) succeeded");
     // }
@@ -428,7 +428,7 @@ public class PreloadCircularityTest {
     void test_54() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class54a");
         out.shouldHaveExitValue(1);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class54b during linking of class PreloadCircularityTest$Class54a. Cause: a null-free static field is declared with this type");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class54b during linking of class PreloadCircularityTest$Class54a. Cause: a null-free static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class54b during linking of class PreloadCircularityTest$Class54a (cause: null-free static field) succeeded");
         out.shouldContain("java.lang.IncompatibleClassChangeError: class PreloadCircularityTest$Class54a expects class PreloadCircularityTest$Class54b to be a value class but it is an identity class");
     }
@@ -444,7 +444,7 @@ public class PreloadCircularityTest {
     // void test_55() throws Exception {
     //     OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class55a");
     //     out.shouldHaveExitValue(1);
-    //     out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class55b during linking of class PreloadCircularityTest$Class55a. Cause: a null-free static field is declared with this type");
+    //     out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class55b during linking of class PreloadCircularityTest$Class55a. Cause: a null-free static field is declared with this type");
     //     out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class55b during linking of class PreloadCircularityTest$Class55a (cause: null-free static field) succeeded");
     //     out.shouldContain("java.lang.IncompatibleClassChangeError: class PreloadCircularityTest$Class55b is not implicitly constructible and it is used in a null restricted static field (not supported)");
     // }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
@@ -55,7 +55,7 @@ public class ValuePreloadTest {
 
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = exec("-Xlog:class+preload","ValuePreloadClient0");
-        checkFor(pb, "[info][class,preload] Preloading class PreloadValue0 during loading of class ValuePreloadClient0. Cause: field type in LoadableDescriptors attribute");
+        checkFor(pb, "[info][class,preload] Preloading of class PreloadValue0 during loading of class ValuePreloadClient0. Cause: field type in LoadableDescriptors attribute");
 
         pb = exec("-Xlog:class+preload","ValuePreloadClient1");
         checkFor(pb, "[warning][class,preload] Preloading of class PreloadValue1 during linking of class ValuePreloadClient1 (cause: LoadableDescriptors attribute) failed");


### PR DESCRIPTION
In some benchmarks we hit an endless deopt/recompilation cycle because of this bailout in C2 when we compile a method with an unloaded return type:
https://github.com/openjdk/valhalla/blob/858be30119bd5bc37a69d16042523f53bea71a36/src/hotspot/share/ci/ciTypeFlow.cpp#L766-L772

It's a regression / limitation from [JDK-8301007](https://bugs.openjdk.org/browse/JDK-8301007) that I had planned to fix later with [JDK-8284443](https://bugs.openjdk.org/browse/JDK-8284443) because I thought it wouldn't have an impact on performance. Turns out it does, so I'll fix it with this issue similar to what we do in `PhaseMacroExpand::expand_mh_intrinsic_return`.

For testing, I added a new `PreloadClasses` debug flag that's enabled by default. Disabling it will disable preloading of all classes from the LoadableDescriptors attributes. Running testing with this caught some more issues that I fixed in this PR as well. I'll add it to our (internal) stress testing job separately.

I also fixed some inconsistency in the preload logging and adjusted the corresponding tests.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366973](https://bugs.openjdk.org/browse/JDK-8366973): [lworld] Deopt/recompilation cycle due to call to method with unloaded return type (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1554/head:pull/1554` \
`$ git checkout pull/1554`

Update a local copy of the PR: \
`$ git checkout pull/1554` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1554`

View PR using the GUI difftool: \
`$ git pr show -t 1554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1554.diff">https://git.openjdk.org/valhalla/pull/1554.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1554#issuecomment-3270302510)
</details>
