### PR TITLE
8366794: [lworld] "assert(!is_null(v)) failed: narrow klass value can never be zero" with -Xint and COH

### DIFF
--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -169,9 +169,13 @@ jint FlatArrayKlass::array_layout_helper(InlineKlass* vk, LayoutKind lk) {
 }
 
 size_t FlatArrayKlass::oop_size(oop obj) const {
-  assert(obj->klass()->is_flatArray_klass(),"must be an flat array");
+  // In this assert, we cannot safely access the Klass* with compact headers,
+  // because size_given_klass() calls oop_size() on objects that might be
+  // concurrently forwarded, which would overwrite the Klass*.
+  // Also, why we need to pass this layout_helper() to flatArrayOop::object_size.
+  assert(UseCompactObjectHeaders || obj->is_flatArray(),"must be an flat array");
   flatArrayOop array = flatArrayOop(obj);
-  return array->object_size();
+  return array->object_size(layout_helper());
 }
 
 // For now return the maximum number of array elements that will not exceed:

--- a/src/hotspot/share/oops/flatArrayOop.hpp
+++ b/src/hotspot/share/oops/flatArrayOop.hpp
@@ -59,7 +59,7 @@ class flatArrayOopDesc : public objArrayOopDesc {
     return align_object_size((intptr_t)size_in_words);
   }
 
-  int object_size() const;
+  int object_size(int lh) const;
 
 };
 

--- a/src/hotspot/share/oops/flatArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/flatArrayOop.inline.hpp
@@ -42,8 +42,8 @@ inline void* flatArrayOopDesc::value_at_addr(int index, jint lh) const {
   return (void*) addr;
 }
 
-inline int flatArrayOopDesc::object_size() const {
-  return object_size(klass()->layout_helper(), length());
+inline int flatArrayOopDesc::object_size(int lh) const {
+  return object_size(lh, length());
 }
 
 inline oop flatArrayOopDesc::obj_at(int index) const {

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -149,7 +149,7 @@ size_t ObjArrayKlass::oop_size(oop obj) const {
   // concurrently forwarded, which would overwrite the Klass*.
   assert(UseCompactObjectHeaders || obj->is_objArray(), "must be object array");
   // return objArrayOop(obj)->object_size();
-  return obj->is_flatArray() ? flatArrayOop(obj)->object_size() : refArrayOop(obj)->object_size();
+  return obj->is_flatArray() ? flatArrayOop(obj)->object_size(layout_helper()) : refArrayOop(obj)->object_size();
 }
 
 ArrayDescription ObjArrayKlass::array_layout_selection(Klass* element, ArrayProperties properties) {


### PR DESCRIPTION
The oop_size() function can't get the Klass from the oop with UseCompactObjectHeaders because there's some GC code that moves the klass out of the markWord somewhere.  Pass layout_helper() from the already fetched klass instead and disable the assert, like objArrayKlass::oop_size.
Testing with tier1-4 in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366794](https://bugs.openjdk.org/browse/JDK-8366794): [lworld] "assert(!is_null(v)) failed: narrow klass value can never be zero" with -Xint and COH (**Sub-task** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1557/head:pull/1557` \
`$ git checkout pull/1557`

Update a local copy of the PR: \
`$ git checkout pull/1557` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1557`

View PR using the GUI difftool: \
`$ git pr show -t 1557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1557.diff">https://git.openjdk.org/valhalla/pull/1557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1557#issuecomment-3271978751)
</details>
