### PR TITLE
8367263: [lworld] fix compiler/valhalla/inlinetypes/TestIntrinsics.java after current merges of JDK-8352737 and JDK-8366705

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -64,6 +64,7 @@ public class TestIntrinsics {
     private static final WhiteBox WHITEBOX = WhiteBox.getWhiteBox();
     private static final boolean UseArrayFlattening = WHITEBOX.getBooleanVMFlag("UseArrayFlattening");
     private static final boolean UseFieldFlattening = WHITEBOX.getBooleanVMFlag("UseFieldFlattening");
+    private static final boolean PreloadClasses = WHITEBOX.getBooleanVMFlag("PreloadClasses");
 
     public static void main(String[] args) {
 
@@ -1217,10 +1218,10 @@ public class TestIntrinsics {
     @Test
     public boolean test63(SmallValue oldVal, SmallValue newVal) {
         if (TEST63_VT_FLATTENED) {
-            Asserts.assertTrue(UseFieldFlattening);
+            Asserts.assertTrue(UseFieldFlattening && PreloadClasses);
             return U.compareAndSetFlatValue(this, TEST63_VT_OFFSET, TEST63_VT_LAYOUT, SmallValue.class, oldVal, newVal);
         } else {
-            Asserts.assertFalse(UseFieldFlattening);
+            Asserts.assertFalse(UseFieldFlattening && PreloadClasses);
             return U.compareAndSetReference(this, TEST63_VT_OFFSET, oldVal, newVal);
         }
     }
@@ -1303,10 +1304,10 @@ public class TestIntrinsics {
     @Test
     public boolean test65(Object o, Object oldVal, SmallValue newVal) {
         if (TEST63_VT_FLATTENED) {
-            Asserts.assertTrue(UseFieldFlattening);
+            Asserts.assertTrue(UseFieldFlattening && PreloadClasses);
             return U.compareAndSetFlatValue(o, TEST63_VT_OFFSET, TEST63_VT_LAYOUT, SmallValue.class, oldVal, newVal);
         } else {
-            Asserts.assertFalse(UseFieldFlattening);
+            Asserts.assertFalse(UseFieldFlattening && PreloadClasses);
             return U.compareAndSetReference(o, TEST63_VT_OFFSET, oldVal, newVal);
         }
     }
@@ -1331,10 +1332,10 @@ public class TestIntrinsics {
     @Test
     public boolean test66(Object oldVal, Object newVal) {
         if (TEST63_VT_FLATTENED) {
-            Asserts.assertTrue(UseFieldFlattening);
+            Asserts.assertTrue(UseFieldFlattening && PreloadClasses);
             return U.compareAndSetFlatValue(this, TEST63_VT_OFFSET, TEST63_VT_LAYOUT, SmallValue.class, oldVal, newVal);
         } else {
-            Asserts.assertFalse(UseFieldFlattening);
+            Asserts.assertFalse(UseFieldFlattening && PreloadClasses);
             return U.compareAndSetReference(this, TEST63_VT_OFFSET, oldVal, newVal);
         }
     }
@@ -1359,10 +1360,10 @@ public class TestIntrinsics {
     @Test
     public Object test67(SmallValue oldVal, SmallValue newVal) {
         if (TEST63_VT_FLATTENED) {
-            Asserts.assertTrue(UseFieldFlattening);
+            Asserts.assertTrue(UseFieldFlattening && PreloadClasses);
             return U.compareAndExchangeFlatValue(this, TEST63_VT_OFFSET, TEST63_VT_LAYOUT, SmallValue.class, oldVal, newVal);
         } else {
-            Asserts.assertFalse(UseFieldFlattening);
+            Asserts.assertFalse(UseFieldFlattening && PreloadClasses);
             return U.compareAndExchangeReference(this, TEST63_VT_OFFSET, oldVal, newVal);
         }
     }
@@ -1427,10 +1428,10 @@ public class TestIntrinsics {
     @Test
     public Object test69(Object o, Object oldVal, SmallValue newVal) {
         if (TEST63_VT_FLATTENED) {
-            Asserts.assertTrue(UseFieldFlattening);
+            Asserts.assertTrue(UseFieldFlattening && PreloadClasses);
             return U.compareAndExchangeFlatValue(o, TEST63_VT_OFFSET, TEST63_VT_LAYOUT, SmallValue.class, oldVal, newVal);
         } else {
-            Asserts.assertFalse(UseFieldFlattening);
+            Asserts.assertFalse(UseFieldFlattening && PreloadClasses);
             return U.compareAndExchangeReference(o, TEST63_VT_OFFSET, oldVal, newVal);
         }
     }
@@ -1456,10 +1457,10 @@ public class TestIntrinsics {
     @Test
     public Object test70(Object oldVal, Object newVal) {
         if (TEST63_VT_FLATTENED) {
-            Asserts.assertTrue(UseFieldFlattening);
+            Asserts.assertTrue(UseFieldFlattening && PreloadClasses);
             return U.compareAndExchangeFlatValue(this, TEST63_VT_OFFSET, TEST63_VT_LAYOUT, SmallValue.class, oldVal, newVal);
         } else {
-            Asserts.assertFalse(UseFieldFlattening);
+            Asserts.assertFalse(UseFieldFlattening && PreloadClasses);
             return U.compareAndExchangeReference(this, TEST63_VT_OFFSET, oldVal, newVal);
         }
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1256,11 +1256,11 @@ public class TestIntrinsics {
     static {
         try {
             TEST64_ARRAY = (SmallValue[])ValueClass.newNullRestrictedAtomicArray(SmallValue.class, 2, SmallValue.DEFAULT);
-            TEST64_BASE_OFFSET = U.arrayBaseOffset(TEST64_ARRAY.getClass());
-            TEST64_INDEX_SCALE = U.arrayIndexScale(TEST64_ARRAY.getClass());
+            TEST64_BASE_OFFSET = U.arrayBaseOffset(TEST64_ARRAY);
+            TEST64_INDEX_SCALE = U.arrayIndexScale(TEST64_ARRAY);
             TEST64_FLATTENED_ARRAY = ValueClass.isFlatArray(TEST64_ARRAY);
             TEST64_ATOMIC_ARRAY = ValueClass.isAtomicArray(TEST64_ARRAY);
-            TEST64_LAYOUT = U.arrayLayout(TEST64_ARRAY.getClass());
+            TEST64_LAYOUT = U.arrayLayout(TEST64_ARRAY);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
```
TEST64_LAYOUT = U.arrayLayout(TEST64_ARRAY.getClass());
```
is not correct anymore since [JDK-8366705](https://bugs.openjdk.org/browse/JDK-8366705) as the layout is no longer a class property, but an instance property (if I understood right)

Weirdly enough, code like
 ```
U.arrayBaseOffset(TEST64_ARRAY.getClass());
U.arrayIndexScale(TEST64_ARRAY.getClass());
```
got also their `.getClass()` removed in [JDK-8366705](https://bugs.openjdk.org/browse/JDK-8366705):
https://github.com/openjdk/valhalla/blob/0817750d434463a606523ac03b5461802f0328e1/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java#L650-L654
but there the compiler wasn't yelling at me. Is it overloaded and it works with instance or class, and the instance overload will just query the class. Not sure... I'm still removing it!

Thanks,
Marc