### PR TITLE
[lworld] Problem listing tests failing due to JDK-8366806

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -308,6 +308,25 @@ serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java 8365722 generic-all
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8365722 generic-all
 serviceability/HeapDump/DuplicateArrayClassesTest.java 8365722 generic-all
 
+vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ClassObjectReference/toString/tostring001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/equals/equals001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature002/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/isFinal/isfinal001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/isStatic/isstatic001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/isStatic/isstatic002/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/name/name001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/nestedTypes/nestedtypes002/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/VirtualMachineManager/connectedVirtualMachines/convm003/TestDescription.java 8366806 generic-all
+
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -308,6 +308,8 @@ serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java 8365722 generic-all
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8365722 generic-all
 serviceability/HeapDump/DuplicateArrayClassesTest.java 8365722 generic-all
 
+resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java 8366806 generic-all
+serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java 8366806 generic-all
 vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001/TestDescription.java 8366806 generic-all
 vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001/TestDescription.java 8366806 generic-all
 vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001/TestDescription.java 8366806 generic-all
@@ -325,8 +327,10 @@ vmTestbase/nsk/jdi/ReferenceType/isStatic/isstatic002/TestDescription.java 83668
 vmTestbase/nsk/jdi/ReferenceType/name/name001/TestDescription.java 8366806 generic-all
 vmTestbase/nsk/jdi/ReferenceType/nestedTypes/nestedtypes002/TestDescription.java 8366806 generic-all
 vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/VirtualMachineManager/connectedVirtualMachines/convm001/TestDescription.java 8366806 generic-all
+vmTestbase/nsk/jdi/VirtualMachineManager/connectedVirtualMachines/convm002/TestDescription.java 8366806 generic-all
 vmTestbase/nsk/jdi/VirtualMachineManager/connectedVirtualMachines/convm003/TestDescription.java 8366806 generic-all
-
+vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/TestDescription.java 8366806 generic-all
 
 #############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -858,5 +858,11 @@ tools/sincechecker/modules/java.base/JavaBaseCheckSince.java 8358627 generic-all
 
 # valhalla
 jdk/classfile/AccessFlagsTest.java 8366270 generic-all
+
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
+
 jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java 8366820 generic-all
+
+com/sun/jdi/valhalla/FieldWatchpointsTest.java 8366806 generic-all
+com/sun/jdi/valhalla/ValueArrayReferenceTest.java 8366806 generic-all
+com/sun/jdi/valhalla/ValueClassTypeTest.java 8366806 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -866,3 +866,7 @@ jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java 8366820 generic-all
 com/sun/jdi/valhalla/FieldWatchpointsTest.java 8366806 generic-all
 com/sun/jdi/valhalla/ValueArrayReferenceTest.java 8366806 generic-all
 com/sun/jdi/valhalla/ValueClassTypeTest.java 8366806 generic-all
+sun/tools/jhsdb/BasicLauncherTest.java 8366806 generic-all
+sun/tools/jhsdb/HeapDumpTest.java 8366806 generic-all
+sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8366806 generic-all
+sun/tools/jhsdb/JShellHeapDumpTest.java 8366806 generic-all


### PR DESCRIPTION
Problem listing tests affected by [JDK-8366806](https://bugs.openjdk.org/browse/JDK-8366806) to get our CI clean.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1563/head:pull/1563` \
`$ git checkout pull/1563`

Update a local copy of the PR: \
`$ git checkout pull/1563` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1563`

View PR using the GUI difftool: \
`$ git pr show -t 1563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1563.diff">https://git.openjdk.org/valhalla/pull/1563.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1563#issuecomment-3274091980)
</details>
