### PR TITLE
[lworld] One more workaround for JDK-8366668

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3494,7 +3494,8 @@ public class TestLWorld {
         MyValueEmpty[] arr1 = new MyValueEmpty[] { new MyValueEmpty() };
         MyValueEmpty res = test117(arr1, arr1);
         Asserts.assertEquals(res, new MyValueEmpty());
-        Asserts.assertEquals(arr1[0], new MyValueEmpty());
+        // TODO 8366668 Re-enable
+        // Asserts.assertEquals(arr1[0], new MyValueEmpty());
     }
 
     // Test acmp with empty inline types


### PR DESCRIPTION
Disabling one more test, similar to `test119`, that will be fixed by [JDK-8366668](https://bugs.openjdk.org/browse/JDK-8366668).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1564/head:pull/1564` \
`$ git checkout pull/1564`

Update a local copy of the PR: \
`$ git checkout pull/1564` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1564`

View PR using the GUI difftool: \
`$ git pr show -t 1564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1564.diff">https://git.openjdk.org/valhalla/pull/1564.diff</a>

</details>
