### PR TITLE
8366701: [lworld] Method profiles for AOT cache introduced with JEP 515 miss Valhalla specific profiling

### DIFF
--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -1980,6 +1980,11 @@ public:
     _array.clean_weak_klass_links(always_clean);
   }
 
+  virtual void metaspace_pointers_do(MetaspaceClosure* it) {
+    ReceiverTypeData::metaspace_pointers_do(it);
+    _array.metaspace_pointers_do(it);
+  }
+
   static ByteSize array_store_data_size() {
     return cell_offset(static_cell_count());
   }
@@ -2053,6 +2058,11 @@ public:
     _element.clean_weak_klass_links(always_clean);
   }
 
+  virtual void metaspace_pointers_do(MetaspaceClosure* it) {
+    _array.metaspace_pointers_do(it);
+    _element.metaspace_pointers_do(it);
+  }
+
   static ByteSize array_load_data_size() {
     return cell_offset(static_cell_count());
   }
@@ -2124,6 +2134,11 @@ public:
   virtual void clean_weak_klass_links(bool always_clean) {
     _left.clean_weak_klass_links(always_clean);
     _right.clean_weak_klass_links(always_clean);
+  }
+
+  virtual void metaspace_pointers_do(MetaspaceClosure* it) {
+    _left.metaspace_pointers_do(it);
+    _right.metaspace_pointers_do(it);
   }
 
   static ByteSize acmp_data_size() {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -171,62 +171,6 @@ runtime/cds/TestDefaultArchiveLoading.java#coops_coh                            
 runtime/cds/TestDefaultArchiveLoading.java#nocoops_coh                          8348568 generic-all
 runtime/cds/appcds/TestZGCWithCDS.java                                          8348568 generic-all
 
-# Valhalla + AOT
-runtime/cds/appcds/aotCache/AOTCacheSupportForCustomLoaders.java                8366701 generic-all
-runtime/cds/appcds/aotCache/AOTLoggingTag.java                                  8366701 generic-all
-runtime/cds/appcds/aotCache/ClassPathLogging.java                               8366701 generic-all
-runtime/cds/appcds/aotCache/ExcludedClasses.java                                8366701 generic-all
-runtime/cds/appcds/aotCache/HelloAOTCache.java                                  8366701 generic-all
-runtime/cds/appcds/aotCache/JavaAgent.java                                      8366701 generic-all
-runtime/cds/appcds/aotCache/ManagementAgent.java                                8366701 generic-all
-runtime/cds/appcds/aotCache/PackageInfoClass.java                               8366701 generic-all
-runtime/cds/appcds/aotCache/SpecialCacheNames.java                              8366701 generic-all
-runtime/cds/appcds/aotCache/VerifierFailOver.java                               8366701 generic-all
-runtime/cds/appcds/aotClassLinking/AOTCacheWithZGC.java                         8366701 generic-all
-runtime/cds/appcds/aotClassLinking/AOTLoaderConstraintsTest.java                8366701 generic-all
-runtime/cds/appcds/aotClassLinking/AddExports.java                              8366701 generic-all
-runtime/cds/appcds/aotClassLinking/AddOpens.java                                8366701 generic-all
-runtime/cds/appcds/aotClassLinking/AddReads.java                                8366701 generic-all
-runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java#aot                      8366701 generic-all
-runtime/cds/appcds/aotClassLinking/FakeCodeLocation.java                        8366701 generic-all
-runtime/cds/appcds/aotClassLinking/GeneratedInternedString.java                 8366701 generic-all
-runtime/cds/appcds/aotClassLinking/MethodHandleTest.java                        8366701 generic-all
-runtime/cds/appcds/aotClassLinking/NonFinalStaticWithInitVal.java               8366701 generic-all
-runtime/cds/appcds/aotClassLinking/StringConcatStress.java#aot                  8366701 generic-all
-runtime/cds/appcds/aotClassLinking/TestSetupAOTTest.java                        8366701 generic-all
-runtime/cds/appcds/aotClassLinking/TrainingRun.java                             8366701 generic-all
-runtime/cds/appcds/aotClassLinking/WeakReferenceTest.java                       8366701 generic-all
-runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java                       8366701 generic-all
-runtime/cds/appcds/aotCode/AOTCodeFlags.java                                    8366701 generic-all
-runtime/cds/appcds/aotFlags/AOTFlags.java                                       8366701 generic-all
-runtime/cds/appcds/aotFlags/FileNameSubstitution.java                           8366701 generic-all
-runtime/cds/appcds/aotFlags/JDK_AOT_VM_OPTIONS.java                             8366701 generic-all
-runtime/cds/appcds/aotProfile/AOTProfileFlags.java                              8366701 generic-all
-runtime/cds/appcds/applications/JavacBench.java#aot                             8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesAsCollectorTest.java#aot          8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesCastFailureTest.java#aot          8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesGeneralTest.java#aot              8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesInvokersTest.java#aot             8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesPermuteArgumentsTest.java#aot     8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesSpreadArgumentsTest.java#aot      8366701 generic-all
-runtime/cds/appcds/aotClassLinking/StringConcatStress.java#aot                  8366701 generic-all
-runtime/cds/appcds/aotClassLinking/TestSetupAOTTest.java                        8366701 generic-all
-runtime/cds/appcds/aotClassLinking/TrainingRun.java                             8366701 generic-all
-runtime/cds/appcds/aotClassLinking/WeakReferenceTest.java                       8366701 generic-all
-runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java                       8366701 generic-all
-runtime/cds/appcds/aotCode/AOTCodeFlags.java                                    8366701 generic-all
-runtime/cds/appcds/aotFlags/AOTFlags.java                                       8366701 generic-all
-runtime/cds/appcds/aotFlags/FileNameSubstitution.java                           8366701 generic-all
-runtime/cds/appcds/aotFlags/JDK_AOT_VM_OPTIONS.java                             8366701 generic-all
-runtime/cds/appcds/aotProfile/AOTProfileFlags.java                              8366701 generic-all
-runtime/cds/appcds/applications/JavacBench.java#aot                             8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesAsCollectorTest.java#aot          8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesCastFailureTest.java#aot          8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesGeneralTest.java#aot              8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesInvokersTest.java#aot             8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesPermuteArgumentsTest.java#aot     8366701 generic-all
-runtime/cds/appcds/methodHandles/MethodHandlesSpreadArgumentsTest.java#aot      8366701 generic-all
-
 #############################################################################
 
 # :hotspot_serviceability


### PR DESCRIPTION
JEP 515 extended the AOT cache to also collect method profiles during training runs. In Valhalla, we have additional profiling for:
- Array store
- Array load
- Acmp

When JEP 515 was merged in, we did to account for these Valhalla specific profiling information and later crash when trying to create the AOT cache. The fix is straight forward to add the missing collection code for the Valhalla specific profiling.

I also unproblemlisted the affected tests.

Testing:
- tier1-4 + stress

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8366701](https://bugs.openjdk.org/browse/JDK-8366701): [lworld] Method profiles for AOT cache introduced with JEP 515 miss Valhalla specific profiling (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1568/head:pull/1568` \
`$ git checkout pull/1568`

Update a local copy of the PR: \
`$ git checkout pull/1568` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1568`

View PR using the GUI difftool: \
`$ git pr show -t 1568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1568.diff">https://git.openjdk.org/valhalla/pull/1568.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1568#issuecomment-3278682900)
</details>
