### PR TITLE
[lworld] Problem listing 8367405

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -231,6 +231,8 @@ serviceability/sa/TestPrintMdo.java 8190936 generic-all
 serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java 8190936 generic-all
 serviceability/sa/ClhsdbDumpclass.java 8190936 generic-all
 
+compiler/stringopts/TestStackedConcatsAppendUncommonTrap.java 8367405 generic-all
+
 # Array Changes TODO
 serviceability/sa/CDSJMapClstats.java 8365722 generic-all
 serviceability/sa/ClhsdbClasses.java 8365722 generic-all


### PR DESCRIPTION
Problem listing test until [JDK-8367405](https://bugs.openjdk.org/browse/JDK-8367405) is fixed (which is probably a mainline issue but only triggered in Valhalla).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1571/head:pull/1571` \
`$ git checkout pull/1571`

Update a local copy of the PR: \
`$ git checkout pull/1571` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1571`

View PR using the GUI difftool: \
`$ git pr show -t 1571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1571.diff">https://git.openjdk.org/valhalla/pull/1571.diff</a>

</details>
