### PR TITLE
8341846: [lworld] compiler/valhalla/inlinetypes/TestStressReturnBuffering.java fails to boot with genzgc

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStressReturnBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStressReturnBuffering.java
@@ -27,7 +27,7 @@
  * @summary Verify that TLAB allocated buffer initialization when returning a value object works properly with oops.
  * @library /test/lib
  * @enablePreview
- * @run main/othervm -XX:CompileCommand=exclude,compiler.valhalla.inlinetypes.TestStressReturnBuffering::caller -Xmx4m
+ * @run main/othervm -XX:CompileCommand=exclude,compiler.valhalla.inlinetypes.TestStressReturnBuffering::caller -Xmx6m
  *                   compiler.valhalla.inlinetypes.TestStressReturnBuffering
  */
 


### PR DESCRIPTION
Hi all,

The test `compiler/valhalla/inlinetypes/TestStressReturnBuffering.java` was intermittently failing on all platforms if run enough. This patch increases the memory by 50%, leaving nonetheless a very small heap.

I've run it with the new flag on Linux x64, macOS x64, and Windows x64, 5x 100 iterations on each platform. While with the old heap size this would consistently fail, the new heap size sees no failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341846](https://bugs.openjdk.org/browse/JDK-8341846): [lworld] compiler/valhalla/inlinetypes/TestStressReturnBuffering.java fails to boot with genzgc (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1574/head:pull/1574` \
`$ git checkout pull/1574`

Update a local copy of the PR: \
`$ git checkout pull/1574` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1574`

View PR using the GUI difftool: \
`$ git pr show -t 1574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1574.diff">https://git.openjdk.org/valhalla/pull/1574.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1574#issuecomment-3280851800)
</details>
