### PR TITLE
8367156: [lworld] MacroAssembler::remove_frame hits "Field too big for insn"

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6133,7 +6133,8 @@ void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair
 
     int sp_inc_offset = initial_framesize - 3 * wordSize;  // Immediately below saved LR and FP
 
-    ldp(rscratch1, rfp, Address(sp, sp_inc_offset));
+    ldr(rscratch1, Address(sp, sp_inc_offset));
+    ldr(rfp, Address(sp, sp_inc_offset + wordSize));
     add(sp, sp, rscratch1);
     ldr(lr, Address(sp, wordSize));
     add(sp, sp, 2 * wordSize);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/RepairStackWithBigFrame.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/RepairStackWithBigFrame.java
@@ -40,7 +40,7 @@ import static compiler.valhalla.inlinetypes.InlineTypes.*;
  *      -Xcomp
  *      -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.RepairStackWithBigFrame::test
  *      compiler.valhalla.inlinetypes.RepairStackWithBigFrame
- * @run main/othervm compiler.valhalla.inlinetypes.RepairStackWithBigFrame
+ * @run main compiler.valhalla.inlinetypes.RepairStackWithBigFrame
  */
 
 public class RepairStackWithBigFrame {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/RepairStackWithBigFrame.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/RepairStackWithBigFrame.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import static compiler.valhalla.inlinetypes.InlineTypes.*;
+
+/*
+ * @test
+ * @bug 8367156
+ * @summary On Aarch64, when the frame is very big and we need to repair it after
+ *          scalarization of the arguments, we cannot use ldp to get the stack
+ *          increment and rfp at the same time, since it only has a 7 bit offset.
+ *          We use two ldr with 9-bit offsets instead.
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run main/othervm
+ *      -Xcomp
+ *      -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.RepairStackWithBigFrame::test
+ *      compiler.valhalla.inlinetypes.RepairStackWithBigFrame
+ * @run main/othervm compiler.valhalla.inlinetypes.RepairStackWithBigFrame
+ */
+
+public class RepairStackWithBigFrame {
+    static final MyValue1 testValue1 = MyValue1.createWithFieldsInline(rI, rL);
+
+    public static void main(String[] args) {
+        new RepairStackWithBigFrame().test(testValue1);
+    }
+
+    long test(MyValue1 arg) {
+        MyAbstract vt1 = MyValue1.createWithFieldsInline(rI, rL);
+        MyAbstract vt2 = MyValue1.createWithFieldsDontInline(rI, rL);
+        MyAbstract vt3 = MyValue1.createWithFieldsInline(rI, rL);
+        MyAbstract vt4 = arg;
+        return ((MyValue1)vt1).hash() + ((MyValue1)vt2).hash() +
+               ((MyValue1)vt3).hash() + ((MyValue1)vt4).hash();
+    }
+}


### PR DESCRIPTION
As suspected, it's just a too big offset. We used to have a
https://github.com/openjdk/valhalla/blob/c8d4a247861052aa6ed43125bcbe49995326938f/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L6133

I changed it into
https://github.com/openjdk/valhalla/blob/880ae47831ed7262a0d3b30b92c3645bc67e5df2/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L6136

But [`ldp`](https://developer.arm.com/documentation/ddi0602/2025-06/Base-Instructions/LDP--Load-pair-of-registers-) has only a 7-bit offset. It's big, but not big enough. In some cases I've looked at, the offset can be as big as `536` which fits on 9 bits. [`ldr`](https://developer.arm.com/documentation/ddi0602/2025-06/Base-Instructions/LDR--immediate---Load-register--immediate--) supports a 9-bit offset. Let's change the `ldp` into

```aarch64
ldr(rscratch1, Address(sp, sp_inc_offset))
ldr(rfp, Address(sp, sp_inc_offset + wordSize))
```
which will be merged into one `ldp` if the offset fits.

But what if the offset is bigger than what fits on 9 bits? Well, us used to have the `ldr(rscratch1, Address(sp, sp_inc_offset))` so either we have a big problem (too big frames?) or `sp_inc_offset` was just bordeline and `sp_inc_offset + wordSize` is too big. But we still have `sp_inc_offset + wordSize == initial_framesize - 2 * wordSize` which would mean that `initial_framesize` doesn't fit on 9 bits either. Once again, that sounds like a bigger (and unlikely) problem.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367156](https://bugs.openjdk.org/browse/JDK-8367156): [lworld] MacroAssembler::remove_frame hits "Field too big for insn" (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [098bc1a0](https://git.openjdk.org/valhalla/pull/1575/files/098bc1a06fb30330cde523a96cff70ec20e443c5)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1575/head:pull/1575` \
`$ git checkout pull/1575`

Update a local copy of the PR: \
`$ git checkout pull/1575` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1575`

View PR using the GUI difftool: \
`$ git pr show -t 1575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1575.diff">https://git.openjdk.org/valhalla/pull/1575.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1575#issuecomment-3281130515)
</details>
