### PR TITLE
8367548: compiler/intrinsics/bmi tests fail with -XX:+AOTClassLinking

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
@@ -125,8 +125,7 @@ public class BMITestRunner {
         // Hide timestamps from warnings (e.g. due to potential AOT
         // saved/runtime state mismatch), to avoid false positives when
         // comparing output across runs.
-        vmOpts.add("-Xlog:all=warning:stdout:level,tags");
-        vmOpts.add("-Xlog:aot=off");
+        vmOpts.add("-Xlog:all=warning,aot=off:stdout:level,tags");
 
         //setup mode-specific options
         switch (testVMMode) {


### PR DESCRIPTION
The `compiler/intrinsics/bmi` tests started to fail with new AOT changes merged in. 

### AOT Warnings with Valhalla due to Adapter Hash Collision
From the log messages, I saw that we have the following warning message printed with UL:
```
'[0.020s][warning][aot,codecache,stubs] Saved blob's name 'IIIIIIIL' is different from the expected name 'LIIIIIII'
```
This warning can be traced back to a collision in caching adapters with AOT where two adapters have the same hash. As a result, we need to drop one of the adapters in the AOT cache which is unfortunate but not a problem in correctness. This hash collision seems to be specific to Valhalla because we have a lot more adapters compared to mainline. There is currently an open RFE in mainline ([JDK-8364929](https://bugs.openjdk.org/browse/JDK-8364929)) which tries to improve the situation to give each adapters a unique id.

###  Comparison of `Xint` and `Xcomp` Output Fails due to different Timestamps
The `compiler/intrinsics/bmi` tests call `BMITestRunner` which will run the same test with `-Xint` and `-Xcomp` and then compare the output:
https://github.com/openjdk/valhalla/blob/28b96c080081b8ebab2656d5dc0f904072d15e40/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java#L87-L100
We see the AOT warning actually in both runs. The comparison fails because we have a different timestamp in the log for `-Xint` and `-Xcomp`:
```
[0.020s][warning][aot,codecache,stubs] Saved blob's name 'IIIIIIIL' is different from the expected name 'LIIIIIII'
[0.013s][warning][aot,codecache,stubs] Saved blob's name 'IIIIIIIL' is different from the expected name 'LIIIIIII'
```
So, the fix would be to get rid of the timestamps. 

### Getting Rid of Timestamps already Implemented but Wrongly
However, we already have some special code that actually wants to remove timestamps and all AOT logs altogether (introduced with https://github.com/openjdk/valhalla/commit/3b32f6a8ec37338764d3e6713247ff96e49bf5b3 for some Graal specific failure) :
https://github.com/openjdk/valhalla/blob/28b96c080081b8ebab2656d5dc0f904072d15e40/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java#L125-L129
But this does not seem to work. I played around with `Xlog` and found that surprisingly this:
```
-Xlog:all=warning:stdout:level,tags -Xlog:aot=off
```
seems to be expanded to
```
-Xlog:all=warning:stdout:level,tags -Xlog:aot=off:stdout:<default decorators>
```
and the second `Xlog` overrides the decorators and reintroduces the timestamps again.

### Proposed Fix
The fix is to use one `Xlog` like this:
```
-Xlog:all=warning,aot=off:stdout:level,tags
```
I tested tier5 where the tests failed with `-XX:+AOTClassLinking` and this solved the issue.

### Only Apply to Valhalla and not Mainline
I'm not sure why the test was not failing in mainline anymore. Maybe it was too intermittent and thus not noticed again. We could also fix this bug in mainline but since it's only failing in Valhalla, I suggest to do a point fix here and not upstream it to mainline for now.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367548](https://bugs.openjdk.org/browse/JDK-8367548): compiler/intrinsics/bmi tests fail with -XX:+AOTClassLinking (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1582/head:pull/1582` \
`$ git checkout pull/1582`

Update a local copy of the PR: \
`$ git checkout pull/1582` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1582`

View PR using the GUI difftool: \
`$ git pr show -t 1582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1582.diff">https://git.openjdk.org/valhalla/pull/1582.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1582#issuecomment-3285839290)
</details>
