### PR TITLE
8367564: Fields access in interpreter needs cleanup and refactoring

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -156,7 +156,11 @@ class InterpreterMacroAssembler: public MacroAssembler {
   //   - assumes holder_klass and valueKlass field klass have both been resolved
   void read_flat_field(Register entry,
                        Register field_index, Register field_offset,
-                       Register temp, Register obj = r0);
+                       Register temp, Register obj);
+
+  void write_flat_field(Register entry, Register field_offset,
+                        Register tmp1, Register tmp2,
+                        Register obj);
 
   // Allocate value buffer in "obj" and read in flat element at the given index
   // NOTES:

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2775,51 +2775,23 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   } else { // Valhalla
     if (is_static) {
       __ load_heap_oop(r0, field, rscratch1, rscratch2);
-      Label is_null_free_inline_type, uninitialized;
-      // Issue below if the static field has not been initialized yet
-      __ test_field_is_null_free_inline_type(flags, noreg /*temp*/, is_null_free_inline_type);
-        // field is not a null free inline type
-        __ push(atos);
-        __ b(Done);
-      // field is a null free inline type, must not return null even if uninitialized
-      __ bind(is_null_free_inline_type);
-        __ cbz(r0, uninitialized);
-          __ push(atos);
-          __ b(Done);
-        __ bind(uninitialized);
-          __ b(ExternalAddress(Interpreter::_throw_NPE_UninitializedField_entry));
+      __ push(atos);
+      __ b(Done);
     } else {
-      Label is_flat, nonnull, is_inline_type, has_null_marker, rewrite_inline;
-      __ test_field_is_null_free_inline_type(flags, noreg /*temp*/, is_inline_type);
-      __ test_field_has_null_marker(flags, noreg /*temp*/, has_null_marker);
-        // Non-inline field case
-        __ load_heap_oop(r0, field, rscratch1, rscratch2);
+      Label is_flat, rewrite_inline;
+      __ test_field_is_flat(flags, noreg /*temp*/, is_flat);
+      __ load_heap_oop(r0, field, rscratch1, rscratch2);
+      __ push(atos);
+      if (rc == may_rewrite) {
+        patch_bytecode(Bytecodes::_fast_agetfield, bc, r1);
+      }
+      __ b(Done);
+      __ bind(is_flat);
+        // field is flat (null-free or nullable with a null-marker)
+        __ mov(r0, obj);
+        __ read_flat_field(cache, field_index, off, inline_klass /* temp */, r0);
+        __ verify_oop(r0);
         __ push(atos);
-        if (rc == may_rewrite) {
-          patch_bytecode(Bytecodes::_fast_agetfield, bc, r1);
-        }
-        __ b(Done);
-      __ bind(is_inline_type);
-        __ test_field_is_flat(flags, noreg /* temp */, is_flat);
-         // field is not flat
-          __ load_heap_oop(r0, field, rscratch1, rscratch2);
-          __ cbnz(r0, nonnull);
-            __ b(ExternalAddress(Interpreter::_throw_NPE_UninitializedField_entry));
-          __ bind(nonnull);
-          __ verify_oop(r0);
-          __ push(atos);
-          __ b(rewrite_inline);
-        __ bind(is_flat);
-        // field is flat
-          __ mov(r0, obj);
-          __ read_flat_field(cache, field_index, off, inline_klass /* temp */, r0);
-          __ verify_oop(r0);
-          __ push(atos);
-          __ b(rewrite_inline);
-        __ bind(has_null_marker);
-          call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_nullable_flat_field), obj, cache);
-          __ verify_oop(r0);
-          __ push(atos);
       __ bind(rewrite_inline);
       if (rc == may_rewrite) {
         patch_bytecode(Bytecodes::_fast_vgetfield, bc, r1);
@@ -3060,52 +3032,35 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
      } else { // Valhalla
       __ pop(atos);
       if (is_static) {
-        Label is_inline_type;
-         __ test_field_is_not_null_free_inline_type(flags, noreg /* temp */, is_inline_type);
-         __ null_check(r0);
-         __ bind(is_inline_type);
+        Label is_nullable;
+         __ test_field_is_not_null_free_inline_type(flags, noreg /* temp */, is_nullable);
+         __ null_check(r0);  // FIXME JDK-8341120
+         __ bind(is_nullable);
          do_oop_store(_masm, field, r0, IN_HEAP);
          __ b(Done);
       } else {
-        Label is_inline_type, is_flat, has_null_marker, rewrite_not_inline, rewrite_inline;
-        __ test_field_is_null_free_inline_type(flags, noreg /*temp*/, is_inline_type);
-        __ test_field_has_null_marker(flags, noreg /*temp*/, has_null_marker);
-        // Not an inline type
+        Label null_free_reference, is_flat, rewrite_inline;
+        __ test_field_is_flat(flags, noreg /*temp*/, is_flat);
+        __ test_field_is_null_free_inline_type(flags, noreg /*temp*/, null_free_reference);
         pop_and_check_object(obj);
         // Store into the field
         // Clobbers: r10, r11, r3
         do_oop_store(_masm, field, r0, IN_HEAP);
-        __ bind(rewrite_not_inline);
         if (rc == may_rewrite) {
           patch_bytecode(Bytecodes::_fast_aputfield, bc, r19, true, byte_no);
         }
         __ b(Done);
         // Implementation of the inline type semantic
-        __ bind(is_inline_type);
-        __ null_check(r0);
-        __ test_field_is_flat(flags, noreg /*temp*/, is_flat);
-        // field is not flat
+        __ bind(null_free_reference);
+        __ null_check(r0);  // FIXME JDK-8341120
         pop_and_check_object(obj);
         // Store into the field
         // Clobbers: r10, r11, r3
         do_oop_store(_masm, field, r0, IN_HEAP);
         __ b(rewrite_inline);
         __ bind(is_flat);
-        __ load_field_entry(cache, index); // reload field entry (cache) because it was erased by tos_state
-        __ load_unsigned_short(index, Address(cache, in_bytes(ResolvedFieldEntry::field_index_offset())));
-        __ ldr(r2, Address(cache, in_bytes(ResolvedFieldEntry::field_holder_offset())));
-        __ inline_layout_info(r2, index, r6);
-        pop_and_check_object(obj);
-        __ load_klass(inline_klass, r0);
-        __ payload_address(r0, r0, inline_klass);
-        __ add(obj, obj, off);
-        // because we use InlineLayoutInfo, we need special value access code specialized for fields (arrays will need a different API)
-        __ flat_field_copy(IN_HEAP, r0, obj, r6);
-        __ b(rewrite_inline);
-        __ bind(has_null_marker);
-        assert_different_registers(r0, cache, r19);
-        pop_and_check_object(r19);
-        __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::write_nullable_flat_field), r19, r0, cache);
+        pop_and_check_object(r7);
+        __ write_flat_field(cache, off, r3, r6, r7);
         __ bind(rewrite_inline);
         if (rc == may_rewrite) {
           patch_bytecode(Bytecodes::_fast_vputfield, bc, r19, true, byte_no);
@@ -3326,29 +3281,18 @@ void TemplateTable::fast_storefield(TosState state)
   // access field
   switch (bytecode()) {
   case Bytecodes::_fast_vputfield:
-   {
+    {
       Label is_flat, has_null_marker, done;
-      __ test_field_has_null_marker(r5, noreg /* temp */, has_null_marker);
-      __ null_check(r0);
       __ test_field_is_flat(r5, noreg /* temp */, is_flat);
-      // field is not flat
+      __ null_check(r0);
       do_oop_store(_masm, field, r0, IN_HEAP);
       __ b(done);
       __ bind(is_flat);
-      // field is flat
       __ load_field_entry(r4, r5);
-      __ load_unsigned_short(r5, Address(r4, in_bytes(ResolvedFieldEntry::field_index_offset())));
-      __ ldr(r4, Address(r4, in_bytes(ResolvedFieldEntry::field_holder_offset())));
-      __ inline_layout_info(r4, r5, r6);
-      __ load_klass(r4, r0);
-      __ payload_address(r0, r0, r4);
-      __ lea(rscratch1, field);
-      __ flat_field_copy(IN_HEAP, r0, rscratch1, r6);
-      __ b(done);
-      __ bind(has_null_marker);
-      __ load_field_entry(r4, r1);
-      __ mov(r1, r2);
-      __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::write_nullable_flat_field), r1, r0, r4);
+      // Re-shuffle registers because of VM calls calling convention
+      __ mov(r19, r1);
+      __ mov(r7, r2);
+      __ write_flat_field(r4, r19, r6, r8, r7);
       __ bind(done);
     }
     break;
@@ -3447,27 +3391,11 @@ void TemplateTable::fast_accessfield(TosState state)
   switch (bytecode()) {
   case Bytecodes::_fast_vgetfield:
     {
-      Register index = r4, klass = r5, inline_klass = r6, tmp = r7;
-      Label is_flat, has_null_marker, nonnull, Done;
-      __ test_field_has_null_marker(r3, noreg /*temp*/, has_null_marker);
-      __ test_field_is_flat(r3, noreg /* temp */, is_flat);
-        // field is not flat
-        __ load_heap_oop(r0, field, rscratch1, rscratch2);
-        __ cbnz(r0, nonnull);
-          __ b(ExternalAddress(Interpreter::_throw_NPE_UninitializedField_entry));
-        __ bind(nonnull);
-        __ verify_oop(r0);
-        __ b(Done);
-      __ bind(is_flat);
+      Register index = r4, tmp = r7;
       // field is flat
-        __ load_unsigned_short(index, Address(r2, in_bytes(ResolvedFieldEntry::field_index_offset())));
-        __ read_flat_field(r2, index, r1, tmp /* temp */, r0);
-        __ verify_oop(r0);
-        __ b(Done);
-      __ bind(has_null_marker);
-        call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_nullable_flat_field), r0, r2);
-        __ verify_oop(r0);
-      __ bind(Done);
+      __ load_unsigned_short(index, Address(r2, in_bytes(ResolvedFieldEntry::field_index_offset())));
+      __ read_flat_field(r2, index, r1, tmp /* temp */, r0);
+      __ verify_oop(r0);
     }
     break;
   case Bytecodes::_fast_agetfield:

--- a/src/hotspot/cpu/x86/interp_masm_x86.hpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.hpp
@@ -215,6 +215,9 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void read_flat_field(Register entry,
                        Register tmp1, Register tmp2,
                        Register obj = rax);
+  void write_flat_field(Register entry,
+                        Register tmp1, Register tmp2,
+                        Register obj, Register off, Register value);
 
   // Object locking
   void lock_object  (Register lock_reg);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -251,29 +251,7 @@ JRT_ENTRY(void, InterpreterRuntime::read_flat_field(JavaThread* current, oopDesc
   current->set_vm_result_oop(res);
 JRT_END
 
-JRT_ENTRY(void, InterpreterRuntime::read_nullable_flat_field(JavaThread* current, oopDesc* obj, ResolvedFieldEntry* entry))
-  assert(oopDesc::is_oop(obj), "Sanity check");
-  assert(entry->has_null_marker(), "Otherwise should not get there");
-  Handle obj_h(THREAD, obj);
-
-  InstanceKlass* holder = entry->field_holder();
-  int field_index = entry->field_index();
-  InlineLayoutInfo* li= holder->inline_layout_info_adr(field_index);
-
-#ifdef ASSERT
-  fieldDescriptor fd;
-  bool found = holder->find_field_from_offset(entry->field_offset(), false, &fd);
-  assert(found, "Field not found");
-  assert(fd.is_flat(), "Field must be flat");
-#endif // ASSERT
-
-  InlineKlass* field_vklass = InlineKlass::cast(li->klass());
-  oop res = field_vklass->read_payload_from_addr(obj_h(), entry->field_offset(), li->kind(), CHECK);
-  current->set_vm_result_oop(res);
-
-JRT_END
-
-JRT_ENTRY(void, InterpreterRuntime::write_nullable_flat_field(JavaThread* current, oopDesc* obj, oopDesc* value, ResolvedFieldEntry* entry))
+JRT_ENTRY(void, InterpreterRuntime::write_flat_field(JavaThread* current, oopDesc* obj, oopDesc* value, ResolvedFieldEntry* entry))
   assert(oopDesc::is_oop(obj), "Sanity check");
   Handle obj_h(THREAD, obj);
   assert(value == nullptr || oopDesc::is_oop(value), "Sanity check");

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -63,8 +63,7 @@ class InterpreterRuntime: AllStatic {
   static void    register_finalizer(JavaThread* current, oopDesc* obj);
   static void    write_heap_copy (JavaThread* current, oopDesc* value, int offset, oopDesc* rcv);
   static void    read_flat_field(JavaThread* current, oopDesc* object, ResolvedFieldEntry* entry);
-  static void    read_nullable_flat_field(JavaThread* current, oopDesc* object, ResolvedFieldEntry* entry);
-  static void    write_nullable_flat_field(JavaThread* current, oopDesc* object, oopDesc* value, ResolvedFieldEntry* entry);
+  static void    write_flat_field(JavaThread* current, oopDesc* object, oopDesc* value, ResolvedFieldEntry* entry);
 
   static void flat_array_load(JavaThread* current, arrayOopDesc* array, int index);
   static void flat_array_store(JavaThread* current, oopDesc* val, arrayOopDesc* array, int index);
@@ -91,7 +90,6 @@ class InterpreterRuntime: AllStatic {
   static void    throw_ArrayIndexOutOfBoundsException(JavaThread* current, arrayOopDesc* a, jint index);
   static void    throw_ClassCastException(JavaThread* current, oopDesc* obj);
   static void    throw_NullPointerException(JavaThread* current);
-  static void    throw_NPE_UninitializedField_entry(JavaThread* current);
 
   static void    create_exception(JavaThread* current, char* name, char* message);
   static void    create_klass_exception(JavaThread* current, char* name, oopDesc* obj);

--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -209,7 +209,6 @@ address    TemplateInterpreter::_throw_ArrayStoreException_entry            = nu
 address    TemplateInterpreter::_throw_ArithmeticException_entry            = nullptr;
 address    TemplateInterpreter::_throw_ClassCastException_entry             = nullptr;
 address    TemplateInterpreter::_throw_NullPointerException_entry           = nullptr;
-address    TemplateInterpreter::_throw_NPE_UninitializedField_entry         = nullptr;
 address    TemplateInterpreter::_throw_StackOverflowError_entry             = nullptr;
 address    TemplateInterpreter::_throw_exception_entry                      = nullptr;
 address    TemplateInterpreter::_cont_resume_interpreter_adapter            = nullptr;

--- a/src/hotspot/share/interpreter/templateInterpreter.hpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.hpp
@@ -106,7 +106,6 @@ class TemplateInterpreter: public AbstractInterpreter {
   static address    _throw_ArithmeticException_entry;
   static address    _throw_ClassCastException_entry;
   static address    _throw_NullPointerException_entry;
-  static address    _throw_NPE_UninitializedField_entry;
   static address    _throw_exception_entry;
 
   static address    _throw_StackOverflowError_entry;
@@ -154,7 +153,6 @@ class TemplateInterpreter: public AbstractInterpreter {
   static address    throw_exception_entry()                     { return _throw_exception_entry; }
   static address    throw_ArithmeticException_entry()           { return _throw_ArithmeticException_entry; }
   static address    throw_NullPointerException_entry()          { return _throw_NullPointerException_entry; }
-  static address    throw_NPE_UninitializedField_entry()        { return _throw_NPE_UninitializedField_entry; }
   static address    throw_StackOverflowError_entry()            { return _throw_StackOverflowError_entry; }
 
   static address    cont_resume_interpreter_adapter()           { return _cont_resume_interpreter_adapter; }

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -171,7 +171,6 @@ void TemplateInterpreterGenerator::generate_all() {
     Interpreter::_throw_ArithmeticException_entry            = generate_exception_handler("java/lang/ArithmeticException", "/ by zero");
     Interpreter::_throw_ClassCastException_entry             = generate_ClassCastException_handler();
     Interpreter::_throw_NullPointerException_entry           = generate_exception_handler("java/lang/NullPointerException", nullptr);
-    Interpreter::_throw_NPE_UninitializedField_entry         = generate_exception_handler("java/lang/NullPointerException", "Uninitialized null-restricted field");
     Interpreter::_throw_StackOverflowError_entry             = generate_StackOverflowError_handler();
   }
 


### PR DESCRIPTION
Remove dead code from [get|put][field|static] in the interpreter.
Interpreter code refactoring to remove code duplication and reduce number of tests at runtime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367564](https://bugs.openjdk.org/browse/JDK-8367564): Fields access in interpreter needs cleanup and refactoring (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1583/head:pull/1583` \
`$ git checkout pull/1583`

Update a local copy of the PR: \
`$ git checkout pull/1583` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1583`

View PR using the GUI difftool: \
`$ git pr show -t 1583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1583.diff">https://git.openjdk.org/valhalla/pull/1583.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1583#issuecomment-3286327186)
</details>
