### PR TITLE
8367569: [lworld] ImageReaderBenchmark.java doesn't compile

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -92,6 +92,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/jdk.internal.classfile.impl=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.event=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.util=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.value=ALL-UNNAMED \


### PR DESCRIPTION
Build fix for missing --add-exports

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367569](https://bugs.openjdk.org/browse/JDK-8367569): [lworld] ImageReaderBenchmark.java doesn't compile (**Enhancement** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1584/head:pull/1584` \
`$ git checkout pull/1584`

Update a local copy of the PR: \
`$ git checkout pull/1584` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1584`

View PR using the GUI difftool: \
`$ git pr show -t 1584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1584.diff">https://git.openjdk.org/valhalla/pull/1584.diff</a>

</details>
