### PR TITLE
8270527: [lworld] markWord::print_on() needs to reflect the additional Valhalla mark word bits

### DIFF
--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -84,7 +84,7 @@ void markWord::print_on(outputStream* st, bool print_monitor_info) const {
     }
   } else if (is_locked()) {  // last bits != 01 => 00
     // thin locked
-    // Valhalla: inline types/arrays can't be locked/inflating
+    // Valhalla: inline types can not possess an object monitor
     st->print(" locked(" INTPTR_FORMAT ")", value());
   } else {
     st->print(" mark(");

--- a/test/hotspot/gtest/oops/test_markWord.cpp
+++ b/test/hotspot/gtest/oops/test_markWord.cpp
@@ -40,13 +40,15 @@
 // The test doesn't work for PRODUCT because it needs WizardMode
 #ifndef PRODUCT
 
-static void assert_test_pattern(Handle object, const char* pattern) {
+template<typename Printable>
+static void assert_test_pattern(Printable object, const char* pattern) {
   stringStream st;
   object->print_on(&st);
   ASSERT_THAT(st.base(), testing::HasSubstr(pattern));
 }
 
-static void assert_mark_word_print_pattern(Handle object, const char* pattern) {
+template<typename Printable>
+static void assert_mark_word_print_pattern(Printable object, const char* pattern) {
   if (LockingMode == LM_MONITOR) {
     // With heavy monitors, we do not use the mark word. Printing the oop only shows "monitor" regardless of the
     // locking state.
@@ -171,6 +173,7 @@ TEST_VM(markWord, inline_type_prototype) {
   markWord mark = markWord::inline_type_prototype();
   assert_unlocked_state(mark);
   EXPECT_FALSE(mark.is_neutral());
+  assert_test_pattern(&mark, " inline_type");
 
   assert_inline_type(mark);
   EXPECT_FALSE(mark.is_larval_state());
@@ -182,6 +185,8 @@ TEST_VM(markWord, inline_type_prototype) {
   markWord larval = mark.enter_larval_state();
   EXPECT_TRUE(larval.is_larval_state());
   assert_inline_type(larval);
+  assert_test_pattern(&larval, " inline_type=larval");
+
   mark = larval.exit_larval_state();
   EXPECT_FALSE(mark.is_larval_state());
   assert_inline_type(mark);
@@ -214,6 +219,8 @@ TEST_VM(markWord, null_free_flat_array_prototype) {
   assert_copy_set_hash(mark);
   assert_flat_array_type(mark);
   EXPECT_TRUE(mark.is_null_free_array());
+
+  assert_test_pattern(&mark, " flat_null_free_array");
 }
 
 TEST_VM(markWord, nullable_flat_array_prototype) {
@@ -231,6 +238,8 @@ TEST_VM(markWord, nullable_flat_array_prototype) {
   assert_copy_set_hash(mark);
   assert_flat_array_type(mark);
   EXPECT_FALSE(mark.is_null_free_array());
+
+  assert_test_pattern(&mark, " flat_array");
 }
 
 static void assert_null_free_array_type(markWord mark) {
@@ -253,6 +262,8 @@ TEST_VM(markWord, null_free_array_prototype) {
 
   assert_copy_set_hash(mark);
   assert_null_free_array_type(mark);
+
+  assert_test_pattern(&mark, " null_free_array");
 }
 #endif // _LP64
 


### PR DESCRIPTION
Hi all,

This adds debug information to the `markWord::print_on` method for the Valhalla bits. The existing unit tests have been augmented.

Testing: tier 1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8270527](https://bugs.openjdk.org/browse/JDK-8270527): [lworld] markWord::print_on() needs to reflect the additional Valhalla mark word bits (**Enhancement** - P4)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer) ⚠️ Review applies to [325355f1](https://git.openjdk.org/valhalla/pull/1588/files/325355f11b397163cb2bb3440184b23e9a9cd1fd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1588/head:pull/1588` \
`$ git checkout pull/1588`

Update a local copy of the PR: \
`$ git checkout pull/1588` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1588`

View PR using the GUI difftool: \
`$ git pr show -t 1588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1588.diff">https://git.openjdk.org/valhalla/pull/1588.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1588#issuecomment-3291812062)
</details>
