### PR TITLE
8367691: runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java crashes with segmentation fault

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @enablePreview
  * @compile BigClassTreeClassLoader.java
- * @run junit/othervm -XX:NonNMethodCodeHeapSize=256M -XX:ProfiledCodeHeapSize=512M -XX:NonProfiledCodeHeapSize=512M ConcurrentClassLoadingTest
+ * @run junit/othervm -XX:ReservedCodeCacheSize=2G ConcurrentClassLoadingTest
  */
 
 import java.util.Optional;


### PR DESCRIPTION
Hi all,

A very generous code cache should address the issue where we run out of memory.

Testing: stress testing this test with 50 iterations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367691](https://bugs.openjdk.org/browse/JDK-8367691): runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java crashes with segmentation fault (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1590/head:pull/1590` \
`$ git checkout pull/1590`

Update a local copy of the PR: \
`$ git checkout pull/1590` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1590`

View PR using the GUI difftool: \
`$ git pr show -t 1590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1590.diff">https://git.openjdk.org/valhalla/pull/1590.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1590#issuecomment-3297115634)
</details>
