### PR TITLE
8353303: Configuring with --disable-cds causes cdsConfig.hpp compilation errors

### DIFF
--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -306,6 +306,7 @@ void ObjArrayKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   }
 }
 
+#if INCLUDE_CDS
 void ObjArrayKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, TRAPS) {
   ArrayKlass::restore_unshareable_info(loader_data, protection_domain, CHECK);
   if (_next_refined_array_klass != nullptr) {
@@ -328,6 +329,7 @@ void ObjArrayKlass::remove_java_mirror() {
     _next_refined_array_klass->remove_java_mirror();
   }
 }
+#endif // INCLUDE_CDS
 
 u2 ObjArrayKlass::compute_modifier_flags() const {
   // The modifier for an objectArray is the same as its element

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -101,9 +101,12 @@ class ObjArrayKlass : public ArrayKlass {
   oop protection_domain() const { return bottom_klass()->protection_domain(); }
 
   virtual void metaspace_pointers_do(MetaspaceClosure* iter);
+
+#if INCLUDE_CDS
   virtual void remove_unshareable_info();
   virtual void remove_java_mirror();
   void restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, TRAPS);
+#endif
 
  public:
   static ObjArrayKlass* cast(Klass* k) {


### PR DESCRIPTION
Configuring with --disable-cds results in compilation errors due to CDS code not being encapsulated correctly. Verified with tier 1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8353303](https://bugs.openjdk.org/browse/JDK-8353303): Configuring with --disable-cds causes cdsConfig.hpp compilation errors (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1591/head:pull/1591` \
`$ git checkout pull/1591`

Update a local copy of the PR: \
`$ git checkout pull/1591` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1591`

View PR using the GUI difftool: \
`$ git pr show -t 1591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1591.diff">https://git.openjdk.org/valhalla/pull/1591.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1591#issuecomment-3300026389)
</details>
