### PR TITLE
8367698: [lworld] New lint category for code that would not be allowed in the prologue

### DIFF
--- a/make/modules/java.base/Java.gmk
+++ b/make/modules/java.base/Java.gmk
@@ -29,7 +29,7 @@
 # new warning is added to javac, it can be temporarily added to the
 # disabled warnings list.
 #
-# DISABLED_WARNINGS_java +=
+DISABLED_WARNINGS_java += initialization
 
 DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:java.*,javax.*'

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -279,6 +279,12 @@ public class Lint {
         INCUBATING("incubating", false),
 
         /**
+         * Warn about code in identity classes that wouldn't be allowed in early
+         * construction due to a this dependency.
+         */
+        INITIALIZATION("initialization"),
+
+        /**
           * Warn about compiler possible lossy conversions.
           */
         LOSSY_CONVERSIONS("lossy-conversions"),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1189,6 +1189,7 @@ public class Attr extends JCTree.Visitor {
                 // Add an implicit super() call unless an explicit call to
                 // super(...) or this(...) is given
                 // or we are compiling class java.lang.Object.
+                boolean addedSuperInIdentityClass = false;
                 if (isConstructor && owner.type != syms.objectType) {
                     if (!TreeInfo.hasAnyConstructorCall(tree)) {
                         JCStatement supCall = make.at(tree.body.pos).Exec(make.Apply(List.nil(),
@@ -1197,6 +1198,7 @@ public class Attr extends JCTree.Visitor {
                             tree.body.stats = tree.body.stats.append(supCall);
                         } else {
                             tree.body.stats = tree.body.stats.prepend(supCall);
+                            addedSuperInIdentityClass = true;
                         }
                     } else if ((env.enclClass.sym.flags() & ENUM) != 0 &&
                             (tree.mods.flags & GENERATEDCONSTR) == 0 &&
@@ -1246,11 +1248,13 @@ public class Attr extends JCTree.Visitor {
                         if (stat instanceof JCExpressionStatement expStmt &&
                                 expStmt.expr instanceof JCMethodInvocation mi &&
                                 TreeInfo.isConstructorCall(mi)) {
-                            break;
+                            if (!addedSuperInIdentityClass || !allowValueClasses) {
+                                break;
+                            }
                         }
                     }
                     if (!prologueCode.isEmpty()) {
-                        CtorPrologueVisitor ctorPrologueVisitor = new CtorPrologueVisitor(localEnv);
+                        CtorPrologueVisitor ctorPrologueVisitor = new CtorPrologueVisitor(localEnv, addedSuperInIdentityClass && allowValueClasses);
                         ctorPrologueVisitor.scan(prologueCode.toList());
                     }
                 }
@@ -1267,9 +1271,12 @@ public class Attr extends JCTree.Visitor {
 
     class CtorPrologueVisitor extends TreeScanner {
         Env<AttrContext> localEnv;
-        CtorPrologueVisitor(Env<AttrContext> localEnv) {
+        boolean warningsOnly;
+
+        CtorPrologueVisitor(Env<AttrContext> localEnv, boolean warningsOnly) {
             this.localEnv = localEnv;
             currentClassSym = localEnv.enclClass.sym;
+            this.warningsOnly = warningsOnly;
         }
 
         boolean insideLambdaOrClassDef = false;
@@ -1302,8 +1309,21 @@ public class Attr extends JCTree.Visitor {
         }
 
         private void reportPrologueError(JCTree tree, Symbol sym) {
+            reportPrologueError(tree, sym, false);
+        }
+
+        private void reportPrologueError(JCTree tree, Symbol sym, boolean hasInit) {
             preview.checkSourceLevel(tree, Feature.FLEXIBLE_CONSTRUCTORS);
-            log.error(tree, Errors.CantRefBeforeCtorCalled(sym));
+            if (!warningsOnly) {
+                if (hasInit) {
+                    log.error(tree, Errors.CantAssignInitializedBeforeCtorCalled(sym));
+                } else {
+                    log.error(tree, Errors.CantRefBeforeCtorCalled(sym));
+                }
+            } else if (allowValueClasses) {
+                // issue lint warning
+                localEnv.info.lint.logIfEnabled(tree, LintWarnings.WouldNotBeAllowedInPrologue(sym));
+            }
         }
 
         @Override
@@ -1399,12 +1419,12 @@ public class Attr extends JCTree.Visitor {
                 if (isEarlyReference(localEnv, tree, sym)) {
                     // Field may not be inherited from a superclass
                     if (sym.owner != localEnv.enclClass.sym) {
-                        log.error(tree, Errors.CantRefBeforeCtorCalled(sym));
+                        reportPrologueError(tree, sym);
                         return;
                     }
                     // Field may not have an initializer
                     if ((sym.flags() & HASINIT) != 0) {
-                        log.error(tree, Errors.CantAssignInitializedBeforeCtorCalled(sym));
+                        reportPrologueError(tree, sym, true);
                         return;
                     }
                 }
@@ -1578,9 +1598,9 @@ public class Attr extends JCTree.Visitor {
                             //fixup local variable type
                             v.type = chk.checkLocalVarType(tree, tree.init.type, tree.name);
                         }
-                        if (v.owner.kind == TYP && !v.isStatic() && v.isStrict()) {
+                        if (allowValueClasses && v.owner.kind == TYP && !v.isStatic()) {
                             // strict field initializers are inlined in constructor's prologues
-                            CtorPrologueVisitor ctorPrologueVisitor = new CtorPrologueVisitor(initEnv);
+                            CtorPrologueVisitor ctorPrologueVisitor = new CtorPrologueVisitor(initEnv, !v.isStrict());
                             ctorPrologueVisitor.scan(tree.init);
                         }
                     } finally {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4296,6 +4296,11 @@ compiler.warn.attempt.to.synchronize.on.instance.of.value.based.class=\
 compiler.warn.attempt.to.use.value.based.where.identity.expected=\
     use of a value-based class with an operation that expects reliable identity
 
+# 0: symbol or name
+# lint: initialization
+compiler.warn.would.not.be.allowed.in.prologue=\
+    reference to {0} would not be allowed in the prologue phase
+
 # 0: type
 compiler.err.enclosing.class.type.non.denotable=\
     enclosing class type: {0}\n\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -219,6 +219,10 @@ javac.opt.Xlint.desc.finally=\
 javac.opt.Xlint.desc.incubating=\
     Warn about use of incubating modules.
 
+javac.opt.Xlint.desc.initialization=\
+    Warn about code in identity classes that wouldn''t be allowed in early\n\
+\                         construction due to a this dependency.
+
 javac.opt.Xlint.desc.lossy-conversions=\
     Warn about possible lossy conversions in compound assignment.
 

--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -166,6 +166,8 @@ import javax.tools.StandardLocation;
  * <tr><th scope="row">{@code finally}              <td>{@code finally} clauses that do not terminate normally
  * <tr><th scope="row">{@code identity}             <td>use of a value-based class where an identity class is expected
  * <tr><th scope="row">{@code incubating}           <td>use of incubating modules
+ * <tr><th scope="row">{@code initialization}       <td>code in identity classes that wouldn't be allowed in early
+ *                                                      construction due to a this dependency.
  * <tr><th scope="row">{@code lossy-conversions}    <td>possible lossy conversions in compound assignment
  * <tr><th scope="row">{@code missing-explicit-ctor} <td>missing explicit constructors in public and protected classes
  *                                                      in exported packages

--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -601,6 +601,9 @@ file system locations may be directories, JAR files or JMOD files.
 
     -   `incubating`: Warns about the use of incubating modules.
 
+    -   `initialization`: Warns about code in identity classes that wouldn't be
+        allowed in early construction due to a `this` dependency.
+
     -   `lossy-conversions`: Warns about possible lossy conversions
         in compound assignment.
 

--- a/test/langtools/tools/javac/SuperInit/InitializationWarningTest.java
+++ b/test/langtools/tools/javac/SuperInit/InitializationWarningTest.java
@@ -1,0 +1,29 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8367698
+ * @summary New lint category `initialization` for code that would not be allowed in the prologue
+ * @compile/fail/ref=InitializationWarningTest.out -XDrawDiagnostics -Xlint:initialization -Werror InitializationWarningTest.java
+ * @enablePreview
+ */
+
+class InitializationWarningTest implements Iterable<Object> {
+    InitializationWarningTest self = this;
+    Object o = null;
+
+    InitializationWarningTest(Object oo, InitializationWarningTest other) {
+        this.o = oo;                                  // warning, field has initializer
+        m();                                          // warning, instance method
+        InitializationWarningTest.this.m();           // warning, instance method
+        InitializationWarningTest.super.hashCode();   // warning
+        other.m();                                    // good
+        sm();                                         // good too
+        System.identityHashCode(this);                // warning
+        Iterable.super.spliterator();                 // warning
+        new Inner();
+    }
+
+    class Inner {}
+
+    void m() {}
+    static void sm() {}
+}

--- a/test/langtools/tools/javac/SuperInit/InitializationWarningTest.out
+++ b/test/langtools/tools/javac/SuperInit/InitializationWarningTest.out
@@ -1,0 +1,11 @@
+InitializationWarningTest.java:9:1: compiler.err.does.not.override.abstract: InitializationWarningTest, iterator(), java.lang.Iterable
+InitializationWarningTest.java:10:38: compiler.warn.would.not.be.allowed.in.prologue: this
+InitializationWarningTest.java:14:13: compiler.warn.would.not.be.allowed.in.prologue: o
+InitializationWarningTest.java:15:9: compiler.warn.would.not.be.allowed.in.prologue: m()
+InitializationWarningTest.java:16:39: compiler.warn.would.not.be.allowed.in.prologue: m()
+InitializationWarningTest.java:17:40: compiler.warn.would.not.be.allowed.in.prologue: hashCode()
+InitializationWarningTest.java:20:33: compiler.warn.would.not.be.allowed.in.prologue: this
+InitializationWarningTest.java:21:23: compiler.warn.would.not.be.allowed.in.prologue: spliterator()
+InitializationWarningTest.java:22:9: compiler.warn.would.not.be.allowed.in.prologue: InitializationWarningTest
+1 error
+8 warnings

--- a/test/langtools/tools/javac/diags/examples/InitializationWarning.java
+++ b/test/langtools/tools/javac/diags/examples/InitializationWarning.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.would.not.be.allowed.in.prologue
+// options: -Xlint:initialization --enable-preview -source ${jdk.version}
+
+public class InitializationWarning {
+    Object o = null;
+
+    InitializationWarning(Object oo) {
+        this.o = oo;
+    }
+}


### PR DESCRIPTION
This PR introduces a new Xlint category: `initialization`. When enabled it will indicate if some code in an identity class couldn't be placed in the prologue phase. This applies to field initializers and constructors with no explicit `super` invocation. So for example for code like:

```
class Test {
    int i = 0;

    Test() {
        this.i = 1;
    }
}
```

a warning will be issued as if there were a super invocation at the end of the constructor, the compiler would issue an error.