### PR TITLE
8367912: Add unit test for LoadableDescriptors attribute with invalid entries

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/LDTest.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/LDTest.jcod
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// This file contains a class file with an invalid entry in its
+// LoadableDescriptors attribute. The class file has been generated
+// from the source below with editing to the constant pool and
+// the LoadableDescriptors attribute.
+//
+//
+// import jdk.internal.vm.annotation.NullRestricted;
+// import jdk.internal.vm.annotation.Strict;
+//
+//
+// public class LDTest {
+//     static value class Point {
+//         short s0, s1;
+// 	       Point(short sa, short sb) {
+// 	           s0 = sa;
+// 	           s1 = sb;
+// 	       }
+//    }
+//
+//     @Strict
+//     @NullRestricted
+//     Point p = new Point((short)0, (short)0);
+//
+//      public static void main(String[] args) {
+// 	        LDTest test = new LDTest();
+//      }
+// }
+
+
+class LDTest {
+  0xCAFEBABE;
+  65535; // minor version
+  70; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1
+    Utf8 "LDTest$Point"; // #2
+    Method #1 #4; // #3
+    NameAndType #5 #6; // #4
+    Utf8 "<init>"; // #5
+    Utf8 "(SS)V"; // #6
+    Field #8 #9; // #7
+    class #10; // #8
+    NameAndType #11 #12; // #9
+    Utf8 "LDTest"; // #10
+    Utf8 "p"; // #11
+    Utf8 "LLDTest$Point;"; // #12
+    Method #14 #15; // #13
+    class #16; // #14
+    NameAndType #5 #17; // #15
+    Utf8 "java/lang/Object"; // #16
+    Utf8 "()V"; // #17
+    Method #8 #15; // #18
+    Utf8 "RuntimeVisibleAnnotations"; // #19
+    Utf8 "Ljdk/internal/vm/annotation/NullRestricted;"; // #20
+    Utf8 "RuntimeInvisibleAnnotations"; // #21
+    Utf8 "Ljdk/internal/vm/annotation/Strict;"; // #22
+    Utf8 "Code"; // #23
+    Utf8 "LineNumberTable"; // #24
+    Utf8 "main"; // #25
+    Utf8 "([Ljava/lang/String;)V"; // #26
+    Utf8 "SourceFile"; // #27
+    Utf8 "LDTest.java"; // #28
+    Utf8 "NestMembers"; // #29
+    Utf8 "InnerClasses"; // #30
+    Utf8 "Point"; // #31
+    Utf8 "LoadableDescriptors"; // #32
+    Utf8 "[V"; // #33                        // <== new invalid descriptor
+  } // Constant Pool
+
+  0x0021; // access
+  #8;// this_cpx
+  #14;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+    {  // field
+      0x0800; // access
+      #11; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#19) { // RuntimeVisibleAnnotations
+          [] { // annotations
+            {  //  annotation
+              #20;
+              [] { // element_value_pairs
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+        ;
+        Attr(#21) { // RuntimeInvisibleAnnotations
+          [] { // annotations
+            {  //  annotation
+              #22;
+              [] { // element_value_pairs
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeInvisibleAnnotations
+      } // Attributes
+    }
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #5; // name_index
+      #17; // descriptor_index
+      [] { // Attributes
+        Attr(#23) { // Code
+          5; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2ABB0001590303B7;
+            0x0003B500072AB700;
+            0x0DB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#24) { // LineNumberTable
+              [] { // line_number_table
+                0  14;
+                13  5;
+                17  14;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0009; // access
+      #25; // name_index
+      #26; // descriptor_index
+      [] { // Attributes
+        Attr(#23) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000859B700124C;
+            0xB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#24) { // LineNumberTable
+              [] { // line_number_table
+                0  19;
+                8  20;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#27) { // SourceFile
+      #28;
+    } // end SourceFile
+    ;
+    Attr(#29) { // NestMembers
+      [] { // classes
+        #1;
+      }
+    } // end NestMembers
+    ;
+    Attr(#30) { // InnerClasses
+      [] { // classes
+        #1 #8 #31 24;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#32) { // LoadableDescriptors
+      0x00010021;                        // <== modified index to contant pool
+    } // end LoadableDescriptors
+  } // Attributes
+} // end class LDTest

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/TestIllegalLoadableDescriptors.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/TestIllegalLoadableDescriptors.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @summary test a LoadableDescriptors attribute with an invalid entry
+ * @enablePreview
+ * @compile LDTest.jcod TestIllegalLoadableDescriptors.java
+ * @run main/othervm TestIllegalLoadableDescriptors
+ */
+
+
+public class TestIllegalLoadableDescriptors {
+
+  public static void main(String[] args)  throws ClassNotFoundException {
+    boolean gotException = false;
+      try {
+          Class newClass = Class.forName("LDTest");
+      } catch (java.lang.ClassFormatError e) {
+          gotException = true;
+          if (!e.getMessage().contains("Descriptor from LoadableDescriptors attribute at index \"33\" in class LDTest has illegal signature \"[V")) {
+              throw new RuntimeException( "Wrong ClassFormatError: " + e.getMessage());
+          }
+      }
+      if (!gotException) {
+        throw new RuntimeException("Missing ClassFormatError");
+      }
+  }
+
+}


### PR DESCRIPTION
New unit test to verify the behavior of the JVM when a LoadableDescriptors attribute contains an invalid descriptor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367912](https://bugs.openjdk.org/browse/JDK-8367912): Add unit test for LoadableDescriptors attribute with invalid entries (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1598/head:pull/1598` \
`$ git checkout pull/1598`

Update a local copy of the PR: \
`$ git checkout pull/1598` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1598`

View PR using the GUI difftool: \
`$ git pr show -t 1598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1598.diff">https://git.openjdk.org/valhalla/pull/1598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1598#issuecomment-3304336033)
</details>
