### PR TITLE
8367415: Fully encapsulate array allocation in oopFactory

### DIFF
--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -39,6 +39,7 @@
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oop.inline.hpp"
+#include "oops/refArrayKlass.hpp"
 #include "oops/typeArrayKlass.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "runtime/handles.inline.hpp"
@@ -111,13 +112,14 @@ typeArrayOop oopFactory::new_typeArray_nozero(BasicType type, int length, TRAPS)
 }
 
 objArrayOop oopFactory::new_objArray(Klass* klass, int length, ArrayKlass::ArrayProperties properties, TRAPS) {
-  assert(klass->is_klass(), "must be instance class");
-  if (klass->is_array_klass()) {
-    assert(properties == ArrayKlass::ArrayProperties::DEFAULT, "properties only apply to single dimension arrays");
-    return ArrayKlass::cast(klass)->allocate_arrayArray(1, length, THREAD);
-  } else {
-    return InstanceKlass::cast(klass)->allocate_objArray(length, properties, THREAD);
-  }
+  assert(!klass->is_array_klass() || properties == ArrayKlass::ArrayProperties::DEFAULT, "properties only apply to single dimension arrays");
+  ArrayKlass* ak = klass->array_klass(CHECK_NULL);
+  return ObjArrayKlass::cast(ak)->allocate_instance(length, properties, THREAD);
+}
+
+refArrayOop oopFactory::new_refArray(Klass* array_klass, int length, TRAPS) {
+  RefArrayKlass* rak = RefArrayKlass::cast(array_klass);  // asserts is refArray_klass().
+  return rak->allocate_instance(length, rak->properties(), THREAD);
 }
 
 objArrayOop oopFactory::new_objArray(Klass* klass, int length, TRAPS) {

--- a/src/hotspot/share/memory/oopFactory.hpp
+++ b/src/hotspot/share/memory/oopFactory.hpp
@@ -58,6 +58,9 @@ class oopFactory: AllStatic {
   static objArrayOop     new_objArray(Klass* klass, int length, TRAPS);
   static objArrayOop     new_objArray(Klass* klass, int length, ArrayKlass::ArrayProperties properties, TRAPS);
 
+  // Allocate refArray instance given a refArrayKlass.
+  static refArrayOop     new_refArray(Klass* array_klass, int length, TRAPS);
+
   // Value arrays...
   // LWorld:
   //    - Q-type signature allocation should use this path.

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -218,17 +218,6 @@ GrowableArray<Klass*>* ArrayKlass::compute_secondary_supers(int num_extra_slots,
   return nullptr;
 }
 
-objArrayOop ArrayKlass::allocate_arrayArray(int n, int length, TRAPS) {
-  check_array_allocation_length(length, arrayOopDesc::max_array_length(T_ARRAY), CHECK_NULL);
-  size_t size = refArrayOopDesc::object_size(length);
-  ArrayKlass* ak = array_klass(n + dimension(), CHECK_NULL);
-  ObjArrayKlass* oak = ObjArrayKlass::cast(ak)->klass_with_properties(ArrayProperties::DEFAULT, CHECK_NULL);
-  objArrayOop o = (objArrayOop)Universe::heap()->array_allocate(oak, size, length,
-                                                                /* do_zero */ true, CHECK_NULL);
-  // initialization to null not necessary, area already cleared
-  return o;
-}
-
 oop ArrayKlass::component_mirror() const {
   return java_lang_Class::component_mirror(java_mirror());
 }

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,6 @@ class ArrayKlass: public Klass {
   // Sizes points to the first dimension of the array, subsequent dimensions
   // are always in higher memory.  The callers of these set that up.
   virtual oop multi_allocate(int rank, jint* sizes, TRAPS);
-  objArrayOop allocate_arrayArray(int n, int length, TRAPS);
 
   // find field according to JVM spec 5.4.3.2, returns the klass in which the field is defined
   Klass* find_field(Symbol* name, Symbol* sig, fieldDescriptor* fd) const;

--- a/src/hotspot/share/oops/flatArrayKlass.hpp
+++ b/src/hotspot/share/oops/flatArrayKlass.hpp
@@ -35,6 +35,8 @@
  * Array of inline types, gives a layout of typeArrayOop, but needs oops iterators
  */
 class FlatArrayKlass : public ObjArrayKlass {
+  friend class Deoptimization;
+  friend class oopFactory;
   friend class VMStructs;
 
  public:
@@ -98,7 +100,9 @@ class FlatArrayKlass : public ObjArrayKlass {
   size_t oop_size(oop obj) const;
 
   // Oop Allocation
+ private:
   objArrayOop allocate_instance(int length, ArrayProperties props, TRAPS);
+ public:
   oop multi_allocate(int rank, jint* sizes, TRAPS);
 
   // Naming

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1853,11 +1853,6 @@ bool InstanceKlass::is_same_or_direct_interface(Klass *k) const {
   return false;
 }
 
-objArrayOop InstanceKlass::allocate_objArray(int length, ArrayKlass::ArrayProperties props, TRAPS) {
-  ArrayKlass* ak = array_klass(CHECK_NULL);
-  return ObjArrayKlass::cast(ak)->allocate_instance(length, props, CHECK_NULL);
-}
-
 instanceOop InstanceKlass::register_finalizer(instanceOop i, TRAPS) {
   if (TraceFinalizerRegistration) {
     tty->print("Registered ");

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -917,7 +917,6 @@ public:
   // additional member function to return a handle
   instanceHandle allocate_instance_handle(TRAPS);
 
-  objArrayOop allocate_objArray(int lenght, ArrayKlass::ArrayProperties props, TRAPS);
   // Helper function
   static instanceOop register_finalizer(instanceOop i, TRAPS);
 

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -54,15 +54,18 @@ class ObjArrayKlass : public ArrayKlass {
   ObjArrayKlass(int n, Klass* element_klass, Symbol* name, KlassKind kind, ArrayKlass::ArrayProperties props, markWord mw);
   static ObjArrayKlass* allocate_klass(ClassLoaderData* loader_data, int n, Klass* k, Symbol* name, ArrayKlass::ArrayProperties props, TRAPS);
 
+  static ArrayDescription array_layout_selection(Klass* element, ArrayProperties properties);
+  virtual objArrayOop allocate_instance(int length, ArrayProperties props, TRAPS);
+
  public:
   // For dummy objects
   ObjArrayKlass() {}
 
-  // Compiler/Interpreter offset
-  static ByteSize element_klass_offset() { return in_ByteSize(offset_of(ObjArrayKlass, _element_klass)); }
-
   virtual Klass* element_klass() const      { return _element_klass; }
   virtual void set_element_klass(Klass* k)  { _element_klass = k; }
+
+  // Compiler/Interpreter offset
+  static ByteSize element_klass_offset() { return in_ByteSize(offset_of(ObjArrayKlass, _element_klass)); }
 
   ObjArrayKlass* next_refined_array_klass() const      { return _next_refined_array_klass; }
   inline ObjArrayKlass* next_refined_array_klass_acquire() const;
@@ -89,9 +92,7 @@ class ObjArrayKlass : public ArrayKlass {
   static ObjArrayKlass* allocate_objArray_klass(ClassLoaderData* loader_data,
                                                 int n, Klass* element_klass, TRAPS);
 
-  static ArrayDescription array_layout_selection(Klass* element, ArrayProperties properties);
-
-  virtual objArrayOop allocate_instance(int length, ArrayProperties props, TRAPS);
+ public:
   oop multi_allocate(int rank, jint* sizes, TRAPS);
 
   // Copying

--- a/src/hotspot/share/oops/refArrayKlass.hpp
+++ b/src/hotspot/share/oops/refArrayKlass.hpp
@@ -34,6 +34,8 @@ class ClassLoaderData;
 // RefArrayKlass is the klass for arrays of references
 
 class RefArrayKlass : public ObjArrayKlass {
+  friend class Deoptimization;
+  friend class oopFactory;
   friend class VMStructs;
   friend class JVMCIVMStructs;
 
@@ -59,8 +61,10 @@ class RefArrayKlass : public ObjArrayKlass {
                                                 int n, Klass* element_klass,
                                                 ArrayKlass::ArrayProperties props, TRAPS);
 
+ private:
   objArrayOop allocate_instance(int length, ArrayProperties props, TRAPS);
 
+ public:
   // Copying TODO FIXME make copying method in objArrayKlass virtual and default implementation invalid (ShouldNotReachHere())
   void copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos, int length, TRAPS);
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -416,8 +416,7 @@ JRT_BLOCK_ENTRY(void, OptoRuntime::new_array_C(Klass* array_type, int len, oopDe
     result = oopFactory::new_typeArray(elem_type, len, THREAD);
   } else {
     Handle holder(current, array_type->klass_holder()); // keep the array klass alive
-    RefArrayKlass* array_klass = RefArrayKlass::cast(array_type);
-    result = array_klass->allocate_instance(len, RefArrayKlass::cast(array_type)->properties(), THREAD);
+    result = oopFactory::new_refArray(array_type, len, THREAD);
     if (array_type->is_null_free_array_klass() && !h_init_val.is_null()) {
       // Null-free arrays need to be initialized
       for (int i = 0; i < len; i++) {


### PR DESCRIPTION
This makes oopFactory and deoptimization the only friends of private ArrayKlass::allocate_instance.  This is similar to the PR https://github.com/openjdk/jdk/pull/27372 in mainline with some extra handling for new_refArray (rather than calling RefArrayKlass::allocate_instance() directly.
Tested with tier1-4.