### PR TITLE
8368002: [lworld] Crash in ThawBase::remove_top_compiled_frame_from_chunk

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1961,7 +1961,7 @@ protected:
   void clear_chunk(stackChunkOop chunk);
   template<bool check_stub>
   int remove_top_compiled_frame_from_chunk(stackChunkOop chunk, int &argsize);
-  int remove_scalarized_frames(StackChunkFrameStream<ChunkFrames::CompiledOnly>& scfs, stackChunkOop chunk, int &argsize);
+  int remove_scalarized_frames(StackChunkFrameStream<ChunkFrames::CompiledOnly>& scfs, int &argsize);
   void copy_from_chunk(intptr_t* from, intptr_t* to, int size);
 
   void thaw_lockstack(stackChunkOop chunk);
@@ -2072,8 +2072,7 @@ inline void ThawBase::clear_chunk(stackChunkOop chunk) {
   chunk->set_max_thawing_size(0);
 }
 
-int ThawBase::remove_scalarized_frames(StackChunkFrameStream<ChunkFrames::CompiledOnly>& f, stackChunkOop chunk, int &argsize) {
-  DEBUG_ONLY(intptr_t* const chunk_sp = chunk->start_address() + chunk->sp();)
+int ThawBase::remove_scalarized_frames(StackChunkFrameStream<ChunkFrames::CompiledOnly>& f, int &argsize) {
   intptr_t* top = f.sp();
 
   while (f.cb()->as_nmethod()->needs_stack_repair()) {
@@ -2116,13 +2115,13 @@ int ThawBase::remove_top_compiled_frame_from_chunk(stackChunkOop chunk, int &arg
     }
 
     if (f.cb()->as_nmethod()->needs_stack_repair()) {
-      frame_size += remove_scalarized_frames(f, chunk, argsize);
+      frame_size += remove_scalarized_frames(f, argsize);
     } else {
       frame_size += f.cb()->frame_size();
       argsize = f.stack_argsize();
     }
   } else if (f.cb()->as_nmethod()->needs_stack_repair()) {
-    frame_size = remove_scalarized_frames(f, chunk, argsize);
+    frame_size = remove_scalarized_frames(f, argsize);
   }
 
   f.next(SmallRegisterMap::instance(), true /* stop */);


### PR DESCRIPTION
Please review this small fix. When thawing in the fast path, the top frame could be a runtime stub due to preempting on monitorenter. In the changes for JDK-8336845 I missed this, leading to a crash when dereferencing the nullptr returned by `f.cb()->as_nmethod_or_null()` in `ThawBase::remove_top_compiled_frame_from_chunk`.

I was able to reproduce the failure locally and verified it is now fixed. I did run into a pre-existing crash with Jetty (filed JDK-8368099). I also run all tests in java/lang/Thread/virtual stressing this path, tests Fuzz.java and TestVirtualThreads.java, plus extra mach5 tier testing.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368002](https://bugs.openjdk.org/browse/JDK-8368002): [lworld] Crash in ThawBase::remove_top_compiled_frame_from_chunk (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1603/head:pull/1603` \
`$ git checkout pull/1603`

Update a local copy of the PR: \
`$ git checkout pull/1603` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1603`

View PR using the GUI difftool: \
`$ git pr show -t 1603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1603.diff">https://git.openjdk.org/valhalla/pull/1603.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1603#issuecomment-3312596326)
</details>
