### PR TITLE
ProblemList MemoryAccessProviderTest.java and TestHotSpotResolvedJavaField.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,6 +82,8 @@ compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
 
+compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/MemoryAccessProviderTest.java 8350208 generic-all
+compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestHotSpotResolvedJavaField.java 8350208 generic-all
 
 # Valhalla
 compiler/codegen/TestRedundantLea.java#StringInflate  8367518 generic-all


### PR DESCRIPTION
[JDK-8350208: CTW: GraphKit::add_safepoint_edges asserts "not enough operands for reexecution"](https://bugs.openjdk.org/browse/JDK-8350208)

First done in #1532 but it seems it was reverted by accident during the merge of jdk-26+5, probably during conflict resolution:

https://github.com/openjdk/valhalla/commit/09637e0e5970fc79f8edf7c458cd1a8e66f30463#diff-5dd1b912c2b1268bbd9aba3669bdda0abd4bcdcad523470959238b02bb1bcfd7

The valhalla side of it is tracked here: [JDK-8365989: [lworld] Un-ProblemList MemoryAccessProviderTest.java and TestHotSpotResolvedJavaField.java once JDK-8350208 is solved in mainline](https://bugs.openjdk.org/browse/JDK-8365989)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1614/head:pull/1614` \
`$ git checkout pull/1614`

Update a local copy of the PR: \
`$ git checkout pull/1614` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1614`

View PR using the GUI difftool: \
`$ git pr show -t 1614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1614.diff">https://git.openjdk.org/valhalla/pull/1614.diff</a>

</details>
