### PR TITLE
8368076: [lworld] tools/javac/ObjectEarlyContext/T8361481.java bogus 'before supertype constructor' error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1236,7 +1236,7 @@ public class Attr extends JCTree.Visitor {
 
                 // Attribute method body.
                 attribStat(tree.body, localEnv);
-                if (isConstructor) {
+                if (localEnv.info.ctorPrologue) {
                     ListBuffer<JCTree> prologueCode = new ListBuffer<>();
                     for (JCTree stat : tree.body.stats) {
                         prologueCode.add(stat);

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -63,7 +63,6 @@ tools/javac/warnings/suppress/TypeAnnotations.java                              
 tools/javac/modules/SourceInSymlinkTest.java                                    8180263    windows-all    fails when run on a subst drive
 
 tools/javac/flags/ExtendedStandardFlagsOverlayFlagsConflict.java                8368078    generic-all
-tools/javac/ObjectEarlyContext/T8361481.java                                    8368076    generic-all
 tools/javac/processing/model/element/TestValueClasses.java                      8368081    generic-all
 
 ###########################################################################


### PR DESCRIPTION
fixing bug found during merges. The issue was not provoked by the merge, basically we need to make a check more general, see inlined comment

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368076](https://bugs.openjdk.org/browse/JDK-8368076): [lworld] tools/javac/ObjectEarlyContext/T8361481.java bogus 'before supertype constructor' error (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1617/head:pull/1617` \
`$ git checkout pull/1617`

Update a local copy of the PR: \
`$ git checkout pull/1617` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1617`

View PR using the GUI difftool: \
`$ git pr show -t 1617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1617.diff">https://git.openjdk.org/valhalla/pull/1617.diff</a>

</details>
