### PR TITLE
8367589: [lworld] com/sun/jdi/valhalla tests fail with JTREG_TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -866,9 +866,6 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java 8367346 ge
 
 jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java 8366820 generic-all
 
-com/sun/jdi/valhalla/FieldWatchpointsTest.java 8366806 generic-all
-com/sun/jdi/valhalla/ValueArrayReferenceTest.java 8366806 generic-all
-com/sun/jdi/valhalla/ValueClassTypeTest.java 8366806 generic-all
 sun/tools/jhsdb/BasicLauncherTest.java 8366806 generic-all
 sun/tools/jhsdb/HeapDumpTest.java 8366806 generic-all
 sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8366806 generic-all

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -558,9 +558,10 @@ abstract public class TestScaffold extends TargetAdapter {
         // and set property 'test.thread.factory' so test could use DebuggeeWrapper.isVirtual() method
         String testThreadFactoryName = DebuggeeWrapper.getTestThreadFactoryName();
         if (testThreadFactoryName != null && !argInfo.targetAppCommandLine.isEmpty()) {
-            argInfo.targetVMArgs += "-D" + DebuggeeWrapper.PROPERTY_NAME + "=" + testThreadFactoryName;
+            argInfo.targetVMArgs += "-D" + DebuggeeWrapper.PROPERTY_NAME + "=" + testThreadFactoryName + " ";
             argInfo.targetAppCommandLine = DebuggeeWrapper.class.getName() + ' ' + argInfo.targetAppCommandLine;
-        } else if ("true".equals(System.getProperty("test.enable.preview"))) {
+        }
+        if ("true".equals(System.getProperty("test.enable.preview"))) {
             // the test specified @enablePreview.
             argInfo.targetVMArgs += "--enable-preview ";
         }


### PR DESCRIPTION
Fixed issue with test class (TestScaffold) when it does not correctly handle "enablePreview" (does not pass "--enable-preview" to child debuggee process)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367589](https://bugs.openjdk.org/browse/JDK-8367589): [lworld] com/sun/jdi/valhalla tests fail with JTREG_TEST_THREAD_FACTORY=Virtual (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1620/head:pull/1620` \
`$ git checkout pull/1620`

Update a local copy of the PR: \
`$ git checkout pull/1620` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1620`

View PR using the GUI difftool: \
`$ git pr show -t 1620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1620.diff">https://git.openjdk.org/valhalla/pull/1620.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1620#issuecomment-3325271590)
</details>
