### PR TITLE
8368078: [lworld] tools/javac/flags/ExtendedStandardFlagsOverlayFlagsConflict.java fails with Valhalla

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -138,7 +138,7 @@ public class Flags {
     /** Flag is set for compiler-generated anonymous method symbols
      *  that `own' an initializer block.
      */
-    public static final int BLOCK            = 1<<20;
+    public static final int BLOCK            = 1<<21;
 
     /** Marks a type as a value class */
     public static final int VALUE_CLASS      = 1<<20;


### PR DESCRIPTION
adjusting flags so that flag VALUE_CLASS doesn't class with any other flag

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368078](https://bugs.openjdk.org/browse/JDK-8368078): [lworld] tools/javac/flags/ExtendedStandardFlagsOverlayFlagsConflict.java fails with Valhalla (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1624/head:pull/1624` \
`$ git checkout pull/1624`

Update a local copy of the PR: \
`$ git checkout pull/1624` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1624`

View PR using the GUI difftool: \
`$ git pr show -t 1624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1624.diff">https://git.openjdk.org/valhalla/pull/1624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1624#issuecomment-3325339134)
</details>
