### PR TITLE
8368022: serviceability/dcmd/gc/HeapDumpParallelTest.java fails missing output

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -55,7 +55,7 @@ public class HeapDumpParallelTest {
         dcmdOut.shouldHaveExitValue(0);
         dcmdOut.shouldContain("Heap dump file created");
         OutputAnalyzer appOut = new OutputAnalyzer(app.getProcessStdout());
-        appOut.shouldContain("[heapdump]");
+        appOut.shouldMatch("\\[heapdump *\\]");
         String opts = Arrays.asList(Utils.getTestJavaOpts()).toString();
         if (opts.contains("-XX:+UseSerialGC") || opts.contains("-XX:+UseEpsilonGC")) {
             System.out.println("UseSerialGC detected.");


### PR DESCRIPTION
Updates test to accept different logging variations

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368022](https://bugs.openjdk.org/browse/JDK-8368022): serviceability/dcmd/gc/HeapDumpParallelTest.java fails missing output (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1625/head:pull/1625` \
`$ git checkout pull/1625`

Update a local copy of the PR: \
`$ git checkout pull/1625` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1625`

View PR using the GUI difftool: \
`$ git pr show -t 1625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1625.diff">https://git.openjdk.org/valhalla/pull/1625.diff</a>

</details>
