### PR TITLE
JDK-8367338: [lworld] compiler/gcbarriers/TestImplicitNullChecks.java fails

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -87,7 +87,6 @@ compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
 compiler/codegen/TestRedundantLea.java#StringInflate  8367518 generic-all
 compiler/codegen/TestRedundantLea.java#StoreNParallel 8367518 generic-all
 compiler/codegen/TestRedundantLea.java#StoreNSerial   8367518 generic-all
-compiler/gcbarriers/TestImplicitNullChecks.java 8367338 generic-all
 compiler/regalloc/TestVerifyRegisterAllocator.java 8365895 windows-x64
 compiler/types/TestArrayManyDimensions.java 8365895 windows-x64
 compiler/types/correctness/OffTest.java 8365895 windows-x64


### PR DESCRIPTION
# Issue
IR checks of `testCompareAndExchange`, `testCompareAndSwap` and `testGetAndSet` of  `compiler/gcbarriers/TestImplicitNullChecks.java` fail because they expect no  `NULL_CHECK` in the final core graph but it encounters a few in each test instead.

# Cause
The tests in question simply call 3 different `VarHandle` functions (one each) but these don't get inlined as intrinsics directly. They instead rely on inline methods (with some conditional statements) that eventually call a method that gets intrinsified and some of the inlined code can result in null checks after being compiled.
For instance `testCompareAndExchange` inlines `Unsafe::compareAndExchangeReference`
https://github.com/openjdk/valhalla/blob/1ecd2e95a158c80186d4334ca3f0673f660d5042/src/java.base/share/classes/jdk/internal/misc/Unsafe.java#L1723-L1742
which calls `compareAndSetReference` or `compareAndExchangeReference` but `if (valueType.isValue() || isValueObject(expected))` adds a null check for `valueType`.
This happens only in Valhalla because of a Valhalla specific issue ([JDK-8351569](https://bugs.openjdk.org/browse/JDK-8351569) that modified the behaviour of certain VarHandle functions.

# Fix
The goal of the tests is to test that there are no null checks with compare-and-exchange operations with ZGC and G1 and there are still a couple of `VarHandle` compare-and-exchange methods that are intrinsified directly. We can use those method instead of the current ones.

# Testing
Tier 1-3+
