### PR TITLE
8368192: Test java/lang/ProcessBuilder/Basic.java#id0 fails with Exception: Stack trace

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -28,7 +28,7 @@
  *      6464154 6523983 6206031 4960438 6631352 6631966 6850957 6850958
  *      4947220 7018606 7034570 4244896 5049299 8003488 8054494 8058464
  *      8067796 8224905 8263729 8265173 8272600 8231297 8282219 8285517
- *      8352533
+ *      8352533 8368192
  * @key intermittent
  * @summary Basic tests for Process and Environment Variable code
  * @modules java.base/java.lang:open
@@ -777,30 +777,29 @@ public class Basic {
         return Pattern.compile(regex).matcher(str).find();
     }
 
-    private static String matchAndExtract(String str, String regex) {
-        Matcher matcher = Pattern.compile(regex).matcher(str);
-        if (matcher.find()) {
-            return matcher.group();
-        } else {
-            return "";
-        }
+    // Return the string with the matching regex removed
+    private static String matchAndRemove(String str, String regex) {
+        return Pattern.compile(regex)
+                .matcher(str)
+                .replaceAll("");
     }
 
     /* Only used for Mac OS X --
-     * Mac OS X (may) add the variable __CF_USER_TEXT_ENCODING to an empty
-     * environment. The environment variable JAVA_MAIN_CLASS_<pid> may also
-     * be set in Mac OS X.
-     * Remove them both from the list of env variables
+     * Mac OS X (may) add the variables: __CF_USER_TEXT_ENCODING, JAVA_MAIN_CLASS_<pid>,
+     * and TMPDIR.
+     * Remove them from the list of env variables
      */
     private static String removeMacExpectedVars(String vars) {
         // Check for __CF_USER_TEXT_ENCODING
-        String cleanedVars = vars.replace("__CF_USER_TEXT_ENCODING="
-                                            +cfUserTextEncoding+",","");
+        String cleanedVars = matchAndRemove(vars,
+                "__CF_USER_TEXT_ENCODING=" + cfUserTextEncoding + ",");
         // Check for JAVA_MAIN_CLASS_<pid>
-        String javaMainClassStr
-                = matchAndExtract(cleanedVars,
-                                    "JAVA_MAIN_CLASS_\\d+=Basic.JavaChild,");
-        return cleanedVars.replace(javaMainClassStr,"");
+        cleanedVars = matchAndRemove(cleanedVars,
+                "JAVA_MAIN_CLASS_\\d+=Basic.JavaChild,");
+        // Check and remove TMPDIR
+        cleanedVars = matchAndRemove(cleanedVars,
+                "TMPDIR=[^,]*,");
+        return cleanedVars;
     }
 
     /* Only used for AIX --


### PR DESCRIPTION
Backport of 8368192 to resolve test failures.

The test fix is included, the change to the problem list is unnecessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368192](https://bugs.openjdk.org/browse/JDK-8368192): Test java/lang/ProcessBuilder/Basic.java#id0 fails with Exception: Stack trace (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1627/head:pull/1627` \
`$ git checkout pull/1627`

Update a local copy of the PR: \
`$ git checkout pull/1627` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1627`

View PR using the GUI difftool: \
`$ git pr show -t 1627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1627.diff">https://git.openjdk.org/valhalla/pull/1627.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1627#issuecomment-3329606545)
</details>
