### PR TITLE
8367415: Fully encapsulate array allocation in oopFactory

### DIFF
--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -117,7 +117,7 @@ objArrayOop oopFactory::new_objArray(Klass* klass, int length, ArrayKlass::Array
   return ObjArrayKlass::cast(ak)->allocate_instance(length, properties, THREAD);
 }
 
-refArrayOop oopFactory::new_refArray(Klass* array_klass, int length, TRAPS) {
+objArrayOop oopFactory::new_refArray(Klass* array_klass, int length, TRAPS) {
   RefArrayKlass* rak = RefArrayKlass::cast(array_klass);  // asserts is refArray_klass().
   return rak->allocate_instance(length, rak->properties(), THREAD);
 }

--- a/src/hotspot/share/memory/oopFactory.hpp
+++ b/src/hotspot/share/memory/oopFactory.hpp
@@ -59,7 +59,7 @@ class oopFactory: AllStatic {
   static objArrayOop     new_objArray(Klass* klass, int length, ArrayKlass::ArrayProperties properties, TRAPS);
 
   // Allocate refArray instance given a refArrayKlass.
-  static refArrayOop     new_refArray(Klass* array_klass, int length, TRAPS);
+  static objArrayOop     new_refArray(Klass* array_klass, int length, TRAPS);
 
   // Value arrays...
   // LWorld:


### PR DESCRIPTION
This should fix the build failure.  Builds locally, but am testing in tier1 on many platforms (in progress).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367415](https://bugs.openjdk.org/browse/JDK-8367415): Fully encapsulate array allocation in oopFactory (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1628/head:pull/1628` \
`$ git checkout pull/1628`

Update a local copy of the PR: \
`$ git checkout pull/1628` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1628`

View PR using the GUI difftool: \
`$ git pr show -t 1628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1628.diff">https://git.openjdk.org/valhalla/pull/1628.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1628#issuecomment-3329879135)
</details>
