### PR TITLE
8367398: JCmdTestDynamicDump.java crashes on Windows with assert(m != nullptr) failed: nullptr mirror

### DIFF
--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -345,7 +345,7 @@ void ObjArrayKlass::remove_unshareable_info() {
 
 void ObjArrayKlass::remove_java_mirror() {
   ArrayKlass::remove_java_mirror();
-  if (_next_refined_array_klass != nullptr) {
+  if (_next_refined_array_klass != nullptr && !CDSConfig::is_dumping_dynamic_archive()) {
     _next_refined_array_klass->remove_java_mirror();
   }
 }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -138,7 +138,6 @@ runtime/valhalla/inlinetypes/verifier/StrictStaticFieldsTest.java CODETOOLS-7904
 
 runtime/cds/TestDefaultArchiveLoading.java#coops_nocoh            8366774           generic-all
 runtime/cds/TestDefaultArchiveLoading.java#nocoops_nocoh          8366774           generic-all
-runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java                  8367398           windows-x64
 
 # Valhalla + COH
 compiler/c2/autovectorization/TestIndexOverflowIR.java                          8348568 generic-all


### PR DESCRIPTION
We avoid archiving refined objArrayKlasses in the dynamic archive due to issues mapping different dimensions of an array across the static and dynamic archives. One check was missed leading to a crash on Windows which is fixed in this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367398](https://bugs.openjdk.org/browse/JDK-8367398): JCmdTestDynamicDump.java crashes on Windows with assert(m != nullptr) failed: nullptr mirror (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1629/head:pull/1629` \
`$ git checkout pull/1629`

Update a local copy of the PR: \
`$ git checkout pull/1629` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1629`

View PR using the GUI difftool: \
`$ git pr show -t 1629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1629.diff">https://git.openjdk.org/valhalla/pull/1629.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1629#issuecomment-3330418638)
</details>
