### PR TITLE
8368519: [lworld]: TestRedundantLea.java#Spill fails 

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
@@ -371,17 +371,17 @@ class SpillTest {
         phase = {CompilePhase.FINAL_CODE},
         applyIfPlatform = {"mac", "false"})
     // Negative test
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=2"},
+    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, ">=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    @IR(failOn = {IRNode.DECODE_HEAP_OOP_NOT_NULL},
+    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "<=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     // Test that the peephole removes a spill.
-    @IR(counts = {IRNode.MEM_TO_REG_SPILL_COPY, ">=20"},
+    @IR(counts = {IRNode.MEM_TO_REG_SPILL_COPY, ">=18"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    @IR(counts = {IRNode.MEM_TO_REG_SPILL_COPY, ">=18"},
+    @IR(counts = {IRNode.MEM_TO_REG_SPILL_COPY, ">=16"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     String test() {


### PR DESCRIPTION
The test case `compiler/codegen/TestRedundantLea.java#Spill`, recently introduced in #1605, fails due to too strict node counts. This PR relaxes those node counts to account for differences in code generation between platforms and machines.

Testing:
 - [x] tier1,tier2 plus stress testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368519](https://bugs.openjdk.org/browse/JDK-8368519): [lworld]: TestRedundantLea.java#Spill fails (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1631/head:pull/1631` \
`$ git checkout pull/1631`

Update a local copy of the PR: \
`$ git checkout pull/1631` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1631`

View PR using the GUI difftool: \
`$ git pr show -t 1631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1631.diff">https://git.openjdk.org/valhalla/pull/1631.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1631#issuecomment-3333729404)
</details>
