### PR TITLE
8348972: [lworld] C1/C2: Update Valhalla with UseCompactObjectHeaders for oop->klass load/stores

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -185,14 +185,20 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
   assert_different_registers(obj, klass, len);
 
   if (UseCompactObjectHeaders || EnableValhalla) {
+    // COH: Markword contains class pointer which is only known at runtime.
+    // Valhalla: Could have value class which has a different prototype header to a normal object.
+    // In both cases, we need to fetch dynamically.
     ldr(t1, Address(klass, Klass::prototype_header_offset()));
     str(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
   } else {
+    // Otherwise: Can use the statically computed prototype header which is the same for every object.
     mov(t1, checked_cast<int32_t>(markWord::prototype().value()));
     str(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
   }
 
   if (!UseCompactObjectHeaders) {
+    // COH: Markword already contains class pointer. Nothing else to do.
+    // Otherwise: Fetch klass pointer following the markword
     if (UseCompressedClassPointers) { // Take care not to kill klass
       encode_klass_not_null(t1, klass);
       strw(t1, Address(obj, oopDesc::klass_offset_in_bytes()));

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7167,13 +7167,13 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
         mov(tmp1, klass);
       }
       store_klass(buffer_obj, klass);
+      klass = tmp1;
     }
     // 3. Initialize its fields with an inline class specific handler
     if (vk != nullptr) {
       far_call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.
     } else {
-      // tmp1 holds klass preserved above
-      ldr(tmp1, Address(tmp1, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+      ldr(tmp1, Address(klass, InstanceKlass::adr_inlineklass_fixed_block_offset()));
       ldr(tmp1, Address(tmp1, InlineKlass::pack_handler_offset()));
       blr(tmp1);
     }

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -163,17 +163,25 @@ void C1_MacroAssembler::try_allocate(Register obj, Register var_size_in_bytes, i
 void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register len, Register t1, Register t2) {
   assert_different_registers(obj, klass, len, t1, t2);
   if (UseCompactObjectHeaders || EnableValhalla) {
+    // COH: Markword contains class pointer which is only known at runtime.
+    // Valhalla: Could have value class which has a different prototype header to a normal object.
+    // In both cases, we need to fetch dynamically.
     movptr(t1, Address(klass, Klass::prototype_header_offset()));
     movptr(Address(obj, oopDesc::mark_offset_in_bytes()), t1);
   } else {
+    // Otherwise: Can use the statically computed prototype header which is the same for every object.
     movptr(Address(obj, oopDesc::mark_offset_in_bytes()), checked_cast<int32_t>(markWord::prototype().value()));
   }
-  if (UseCompressedClassPointers) { // Take care not to kill klass
-    movptr(t1, klass);
-    encode_klass_not_null(t1, rscratch1);
-    movl(Address(obj, oopDesc::klass_offset_in_bytes()), t1);
-  } else if (!UseCompactObjectHeaders) {
-    movptr(Address(obj, oopDesc::klass_offset_in_bytes()), klass);
+  if (!UseCompactObjectHeaders) {
+    // COH: Markword already contains class pointer. Nothing else to do.
+    // Otherwise: Fetch klass pointer following the markword
+    if (UseCompressedClassPointers) { // Take care not to kill klass
+      movptr(t1, klass);
+      encode_klass_not_null(t1, rscratch1);
+      movl(Address(obj, oopDesc::klass_offset_in_bytes()), t1);
+    } else {
+      movptr(Address(obj, oopDesc::klass_offset_in_bytes()), klass);
+    }
   }
 
   if (len->is_valid()) {

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -310,9 +310,13 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
 
     uint shift  = exact_log2(type2aelembytes(dest_elem));
     if (ary_dest->is_flat()) {
+      assert(ary_src->is_flat(), "src and dest must be flat");
       shift = ary_src->flat_log_elem_size();
+      src_elem = T_FLAT_ELEMENT;
+      dest_elem = T_FLAT_ELEMENT;
     }
-    uint header = arrayOopDesc::base_offset_in_bytes(dest_elem);
+
+    const uint header = arrayOopDesc::base_offset_in_bytes(dest_elem);
 
     src_offset = Compile::conv_I2X_index(phase, src_offset, ary_src->size());
     if (src_offset->is_top()) {

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -826,13 +826,20 @@ bool ArrayCopyNode::modifies(intptr_t offset_lo, intptr_t offset_hi, PhaseValues
   BasicType ary_elem = ary_t->isa_aryptr()->elem()->array_element_basic_type();
   if (is_reference_type(ary_elem, true)) ary_elem = T_OBJECT;
 
-  uint header = arrayOopDesc::base_offset_in_bytes(ary_elem);
-  uint elemsize = ary_t->is_flat() ? ary_t->flat_elem_size() : type2aelembytes(ary_elem);
+  uint header;
+  uint elem_size;
+  if (ary_t->is_flat()) {
+    header = arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT);
+    elem_size = ary_t->flat_elem_size();
+  } else {
+    header = arrayOopDesc::base_offset_in_bytes(ary_elem);
+    elem_size = type2aelembytes(ary_elem);
+  }
 
-  jlong dest_pos_plus_len_lo = (((jlong)dest_pos_t->_lo) + len_t->_lo) * elemsize + header;
-  jlong dest_pos_plus_len_hi = (((jlong)dest_pos_t->_hi) + len_t->_hi) * elemsize + header;
-  jlong dest_pos_lo = ((jlong)dest_pos_t->_lo) * elemsize + header;
-  jlong dest_pos_hi = ((jlong)dest_pos_t->_hi) * elemsize + header;
+  jlong dest_pos_plus_len_lo = (((jlong)dest_pos_t->_lo) + len_t->_lo) * elem_size + header;
+  jlong dest_pos_plus_len_hi = (((jlong)dest_pos_t->_hi) + len_t->_hi) * elem_size + header;
+  jlong dest_pos_lo = ((jlong)dest_pos_t->_lo) * elem_size + header;
+  jlong dest_pos_hi = ((jlong)dest_pos_t->_hi) * elem_size + header;
 
   if (must_modify) {
     if (offset_lo >= dest_pos_hi && offset_hi < dest_pos_plus_len_lo) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3796,7 +3796,8 @@ Node* GraphKit::mark_word_test(Node* obj, uintptr_t mask_val, bool eq, bool chec
   // Load markword
   Node* mark_adr = basic_plus_adr(obj, oopDesc::mark_offset_in_bytes());
   Node* mark = make_load(nullptr, mark_adr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
-  if (check_lock) {
+  if (check_lock && !UseCompactObjectHeaders) {
+    // COH: Locking does not override the markword with a tagged pointer. We can directly read from the markword.
     // Check if obj is locked
     Node* locked_bit = MakeConX(markWord::unlocked_value);
     locked_bit = _gvn.transform(new AndXNode(locked_bit, mark));

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1847,6 +1847,7 @@ Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
                                       const TypeInt* sizetype, Node* ctrl) {
   const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
   uint shift;
+  uint header;
   if (arytype->is_flat() && arytype->klass_is_exact()) {
     // We can only determine the flat array layout statically if the klass is exact. Otherwise, we could have different
     // value classes at runtime with a potentially different layout. The caller needs to fall back to call
@@ -1854,11 +1855,11 @@ Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
     // might mess with other GVN transformations in between. Thus, we just continue in the else branch normally, even
     // though we don't need the address node in this case and throw it away again.
     shift = arytype->flat_log_elem_size();
-    assert(elembt == T_FLAT_ELEMENT, "basic type must be T_FLAT_ELEMENT");
+    header = arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT);
   } else {
     shift = exact_log2(type2aelembytes(elembt));
+    header = arrayOopDesc::base_offset_in_bytes(elembt);
   }
-  uint header = arrayOopDesc::base_offset_in_bytes(elembt);
 
   // short-circuit a common case (saves lots of confusing waste motion)
   jint idx_con = find_int_con(idx, -1);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1854,6 +1854,7 @@ Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
     // might mess with other GVN transformations in between. Thus, we just continue in the else branch normally, even
     // though we don't need the address node in this case and throw it away again.
     shift = arytype->flat_log_elem_size();
+    assert(elembt == T_FLAT_ELEMENT, "basic type must be T_FLAT_ELEMENT");
   } else {
     shift = exact_log2(type2aelembytes(elembt));
   }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -898,15 +898,18 @@ bool PhaseMacroExpand::add_array_elems_to_safepoint(AllocateNode* alloc, const T
   BasicType basic_elem_type = elem_type->array_element_basic_type();
 
   intptr_t elem_size;
+  uint header_size;
   if (array_type->is_flat()) {
     elem_size = array_type->flat_elem_size();
+    header_size = arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT);
   } else {
     elem_size = type2aelembytes(basic_elem_type);
+    header_size = arrayOopDesc::base_offset_in_bytes(basic_elem_type);
   }
 
   int n_elems = alloc->in(AllocateNode::ALength)->get_int();
   for (int elem_idx = 0; elem_idx < n_elems; elem_idx++) {
-    intptr_t elem_offset = arrayOopDesc::base_offset_in_bytes(basic_elem_type) + elem_idx * elem_size;
+    intptr_t elem_offset = header_size + elem_idx * elem_size;
     const TypeAryPtr* elem_adr_type = array_type->with_offset(elem_offset);
     Node* elem_val;
     if (array_type->is_flat()) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2663,11 +2663,22 @@ void PhaseMacroExpand::expand_mh_intrinsic_return(CallStaticJavaNode* call) {
                                       AllocateInstancePrefetchLines);
     // Allocation succeed, initialize buffered inline instance header firstly,
     // and then initialize its fields with an inline class specific handler
-    Node* mark_node = makecon(TypeRawPtr::make((address)markWord::inline_type_prototype().value()));
-    fast_oop_rawmem = make_store(fast_oop_ctrl, fast_oop_rawmem, fast_oop, oopDesc::mark_offset_in_bytes(), mark_node, T_ADDRESS);
-    fast_oop_rawmem = make_store(fast_oop_ctrl, fast_oop_rawmem, fast_oop, oopDesc::klass_offset_in_bytes(), klass_node, T_METADATA);
-    if (UseCompressedClassPointers) {
-      fast_oop_rawmem = make_store(fast_oop_ctrl, fast_oop_rawmem, fast_oop, oopDesc::klass_gap_offset_in_bytes(), intcon(0), T_INT);
+    Node* mark_word_node;
+    if (UseCompactObjectHeaders) {
+      // COH: We need to load the prototype from the klass at runtime since it encodes the klass pointer already.
+      mark_word_node = make_load(fast_oop_ctrl, fast_oop_rawmem, klass_node, in_bytes(Klass::prototype_header_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);
+    } else {
+      // Otherwise, use the static prototype.
+      mark_word_node = makecon(TypeRawPtr::make((address)markWord::inline_type_prototype().value()));
+    }
+
+    fast_oop_rawmem = make_store(fast_oop_ctrl, fast_oop_rawmem, fast_oop, oopDesc::mark_offset_in_bytes(), mark_word_node, T_ADDRESS);
+    if (!UseCompactObjectHeaders) {
+      // COH: Everything is encoded in the mark word, so nothing left to do.
+      fast_oop_rawmem = make_store(fast_oop_ctrl, fast_oop_rawmem, fast_oop, oopDesc::klass_offset_in_bytes(), klass_node, T_METADATA);
+      if (UseCompressedClassPointers) {
+        fast_oop_rawmem = make_store(fast_oop_ctrl, fast_oop_rawmem, fast_oop, oopDesc::klass_gap_offset_in_bytes(), intcon(0), T_INT);
+      }
     }
     Node* fixed_block  = make_load(fast_oop_ctrl, fast_oop_rawmem, klass_node, in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);
     Node* pack_handler = make_load(fast_oop_ctrl, fast_oop_rawmem, fixed_block, in_bytes(InlineKlass::pack_handler_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -58,6 +58,11 @@ void PhaseMacroExpand::insert_mem_bar(Node** ctrl, Node** mem, int opcode, int a
 
 Node* PhaseMacroExpand::array_element_address(Node* ary, Node* idx, BasicType elembt) {
   uint shift  = exact_log2(type2aelembytes(elembt));
+  const TypeAryPtr* array_type = _igvn.type(ary)->isa_aryptr();
+  if (array_type != nullptr && array_type->is_aryptr()->is_flat()) {
+    // Use T_FLAT_ELEMENT to get proper alignment with COH when fetching the array element address.
+    elembt = T_FLAT_ELEMENT;
+  }
   uint header = arrayOopDesc::base_offset_in_bytes(elembt);
   Node* base =  basic_plus_adr(ary, header);
 #ifdef _LP64

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1190,7 +1190,6 @@ Node* LoadNode::can_see_arraycopy_value(Node* st, PhaseGVN* phase) const {
       BasicType ary_elem = ary_t->isa_aryptr()->elem()->array_element_basic_type();
       if (is_reference_type(ary_elem, true)) ary_elem = T_OBJECT;
 
-      uint header = arrayOopDesc::base_offset_in_bytes(ary_elem);
       uint shift  = ary_t->is_flat() ? ary_t->flat_log_elem_size() : exact_log2(type2aelembytes(ary_elem));
 
       Node* diff = phase->transform(new SubINode(ac->in(ArrayCopyNode::SrcPos), ac->in(ArrayCopyNode::DestPos)));

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5660,7 +5660,7 @@ const TypePtr* TypeAryPtr::add_field_offset_and_offset(intptr_t offset) const {
       adj = _offset.get();
       offset += _offset.get();
     }
-    uint header = arrayOopDesc::base_offset_in_bytes(T_OBJECT);
+    uint header = arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT);
     if (_field_offset.get() != OffsetBot && _field_offset.get() != OffsetTop) {
       offset += _field_offset.get();
       if (_offset.get() == OffsetBot || _offset.get() == OffsetTop) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -139,40 +139,6 @@ runtime/cds/TestDefaultArchiveLoading.java#coops_nocoh            8366774       
 runtime/cds/TestDefaultArchiveLoading.java#nocoops_nocoh          8366774           generic-all
 runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java                  8367398           windows-x64
 
-# Valhalla + COH
-compiler/c2/autovectorization/TestIndexOverflowIR.java                          8348568 generic-all
-compiler/c2/irTests/stringopts/TestArrayCopySelect.java                         8348568 generic-all
-compiler/c2/irTests/TestVectorConditionalMove.java                              8348568 generic-all
-compiler/c2/irTests/TestVectorizationMismatchedAccess.java                      8348568 generic-all
-compiler/c2/irTests/TestVectorizationNotRun.java                                8348568 generic-all
-compiler/c2/TestCastX2NotProcessedIGVN.java                                     8348568 generic-all
-compiler/loopopts/superword/TestAlignVector.java                                8348568 generic-all
-compiler/loopopts/superword/TestAlignVector.java#NoAlignVector-COH              8348568 generic-all
-compiler/loopopts/superword/TestAlignVector.java#VerifyAlignVector-COH          8348568 generic-all
-compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java       8348568 generic-all
-compiler/loopopts/superword/TestMulAddS2I.java                                  8348568 generic-all
-compiler/loopopts/superword/TestScheduleReordersScalarMemops.java               8348568 generic-all
-compiler/loopopts/superword/TestSplitPacks.java                                 8348568 generic-all
-compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java     8348568 generic-all
-compiler/vectorization/TestFloatConversionsVector.java                          8348568 generic-all
-compiler/vectorization/runner/ArrayTypeConvertTest.java                         8348568 generic-all
-compiler/vectorization/runner/LoopCombinedOpTest.java                           8348568 generic-all
-compiler/vectorization/runner/VectorizationTestRunner.java                      8348568 generic-all
-runtime/FieldLayout/TestOopMapSizeMinimal.java#no_coops_ccptr_coh               8348568 generic-all
-
-gc/stress/gcbasher/TestGCBasherWithParallel.java                                8348568 generic-all
-
-gtest/CompressedKlassGtest.java#use-zero-based-encoding-coh                     8348568 generic-all
-gtest/CompressedKlassGtest.java#use-zero-based-encoding-coh-large-class-space   8348568 generic-all
-gtest/MetaspaceGtests.java#UseCompactObjectHeaders                              8348568 generic-all
-
-runtime/CompressedOops/CompressedClassPointersEncodingScheme.java               8348568 generic-all
-runtime/FieldLayout/BaseOffsets.java#no-coops-with-coh                          8348568 generic-all
-runtime/FieldLayout/BaseOffsets.java#with-coop--with-coh                        8348568 generic-all
-runtime/cds/TestDefaultArchiveLoading.java#coops_coh                            8348568 generic-all
-runtime/cds/TestDefaultArchiveLoading.java#nocoops_coh                          8348568 generic-all
-runtime/cds/appcds/TestZGCWithCDS.java                                          8348568 generic-all
-
 # Valhalla + AOT
 runtime/cds/appcds/methodHandles/MethodHandlesGeneralTest.java#aot              8367408 generic-all
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -3081,6 +3081,48 @@ public class TestArrays {
         }
     }
 
+    static value class Test127aValue {
+        int x;
+
+        Test127aValue(int x) {
+            this.x = x;
+        }
+
+        public String toString() {
+            return "x: " + x;
+        }
+    }
+
+    static Test127aValue valueTest127a = new Test127aValue(34);
+    static final Test127aValue[] srcTest127a = (Test127aValue[])ValueClass.newNullRestrictedNonAtomicArray(Test127aValue.class, 8, valueTest127a);
+    static final Test127aValue[] destTest127a = (Test127aValue[])ValueClass.newNullRestrictedNonAtomicArray(Test127aValue.class, 8, valueTest127a);
+
+
+    @Test
+    public void test127a(int srcPos, int destPos, int len) {
+        System.arraycopy(srcTest127a, srcPos, destTest127a, destPos, len);
+    }
+
+    // Ensure that System.arraycopy() is working properly with COH.
+    @Run(test = "test127a")
+    @Warmup(10000)
+    public void test127a_verifier() {
+        test127a(0,1, 7);
+        for (int i = 0; i < 7; ++i) {
+            Asserts.assertEQ(srcTest127a[i], destTest127a[i + 1]);
+        }
+        Asserts.assertEQ(valueTest127a, destTest127a[0]);
+    }
+
+    static void verifyTest127a(Object[] src, Object[] dst, int len, int offset) {
+        for (int i = 0; i < len; ++i) {
+            Asserts.assertEQ(src[i], dst[i + offset]);
+        }
+        for (int i = 0; i < len; ++i) {
+            Asserts.assertEQ(src[i], dst[i + offset]);
+        }
+    }
+
     // Verify that copyOf with known source and unknown destination class is optimized
     @Test
     @IR(applyIf = {"UseArrayFlattening", "true"},


### PR DESCRIPTION
This patch fixes various issues in C1 and C2 (11 bugs in total) when running with `-XX:+UseCompactObjectHeaders`.

Most of the bugs could either be traced back to:
- Unconditionally assuming old layout with klass pointer following immediately the mark word.
- Small mistakes when merging JEP 450.
- Using the wrong basic type `T_OBJECT` for flat arrays instead of `T_FLAT_ELEMENT`. In Valhalla, we require that the elements of an array are aligned:https://github.com/openjdk/valhalla/blob/04efe5c66b70b9dca1a5c538c9a04e7ad93c107a/src/hotspot/share/oops/arrayOop.hpp#L94-L97
https://github.com/openjdk/valhalla/blob/04efe5c66b70b9dca1a5c538c9a04e7ad93c107a/src/hotspot/share/oops/arrayOop.hpp#L57-L61
When we now wrongly use `T_OBJECT`, it is not a problem with default flags (using compressed klass pointers and no COH): An array has a 12 byte header + 4 byte length which is 16 bytes in total - no alignment required. But with COH, we now have a header of 8 bytes + 4 byte length. We now require alignment but when we pass in `T_OBJECT`, we miss the alignment which leads to crashes down the line. I went through all the uses of `base_offset_in_bytes()` and fixed more such issues.

To review: I made separate commits for each fixed bug, each message summarizing the found issue. To better understand individual changes of the patch, it might help to look at the commits separately.

**Testing:**
- Apart from one bug, I could trigger them with existing tests. So, I have not added new tests for these issues separately.
- One bug only manifested with a new test (`test127a`) which I added with this patch.
- tier1-5 + compiler stress:
  - No additional flags, i.e. (mostly) without COH: Looks good and only known failures
  - With explicitly setting COH:
    - A lot of CDS related failures on which @matias9927 is working ([JDK-8367959](https://bugs.openjdk.org/browse/JDK-8367959))
    - Test timeout with `TestIntrinsics`: Unrelated to COH but only triggering with COH ([JDK-8368274](https://bugs.openjdk.org/browse/JDK-8368274)).
    - Otherwise, looks good with only known failures.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348972](https://bugs.openjdk.org/browse/JDK-8348972): [lworld] C1/C2: Update Valhalla with UseCompactObjectHeaders for oop-&gt;klass load/stores (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1632/head:pull/1632` \
`$ git checkout pull/1632`

Update a local copy of the PR: \
`$ git checkout pull/1632` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1632`

View PR using the GUI difftool: \
`$ git pr show -t 1632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1632.diff">https://git.openjdk.org/valhalla/pull/1632.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1632#issuecomment-3333397342)
</details>
