### PR TITLE
8360656: [lworld] UnsafeTest.java fails with -XX:ForceNonTearable=*

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -49,6 +49,7 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
  * @enablePreview
+ * @requires vm.flagless
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UseSerialGC -Xmx128m -XX:+UseFieldFlattening
@@ -64,6 +65,7 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
  * @enablePreview
+ * @requires vm.flagless
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UseG1GC -Xmx128m -XX:+UseFieldFlattening
@@ -79,6 +81,7 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
  * @enablePreview
+ * @requires vm.flagless
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UseParallelGC -Xmx128m -XX:+UseFieldFlattening
@@ -94,6 +97,7 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
  * @enablePreview
+ * @requires vm.flagless
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m
@@ -110,6 +114,7 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
  * @enablePreview
+ * @requires vm.flagless
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xint -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java
@@ -34,6 +34,7 @@ import jdk.internal.vm.annotation.LooselyConsistentValue;
  * @test
  * @summary Test of VM.newNullRestrictedArray API
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.value

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -34,6 +34,7 @@ package runtime.valhalla.inlinetypes;
  * @library /test/lib
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
+ * @requires vm.flagless
  * @compile Point.java UnsafeTest.java
  * @run main/othervm -Xint -XX:+UseNullableValueFlattening -XX:+UseArrayFlattening -XX:+UseFieldFlattening -XX:+PrintInlineLayout runtime.valhalla.inlinetypes.UnsafeTest
  */


### PR DESCRIPTION
Some tests expect specific layouts and fail when an additional option is passed to the VM and changes those layouts.
Adding a flagless requirement to these tests to prevent such failures from happening.

Tested of Mach5 tiers 1 to 3 with the -XX:ForceNonTearable=* VM flag.