### PR TITLE
[lworld] Run compiler/valhalla/inlinetypes/TestAcmpWithUnstableIf.java without StressUnstableIfTraps until JDK-8367244 is fixed

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpWithUnstableIf.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpWithUnstableIf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpWithUnstableIf.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpWithUnstableIf.java
@@ -27,9 +27,12 @@
  * @summary Test that deoptimization at unstable ifs in acmp works as expected.
  * @library /test/lib
  * @enablePreview
- * @run main/othervm TestAcmpWithUnstableIf
- * @run main/othervm -XX:CompileCommand=compileonly,TestAcmpWithUnstableIf::test* -Xbatch TestAcmpWithUnstableIf
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-StressUnstableIfTraps TestAcmpWithUnstableIf
+ * @run main/othervm -XX:CompileCommand=compileonly,TestAcmpWithUnstableIf::test* -Xbatch
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:-StressUnstableIfTraps TestAcmpWithUnstableIf
  */
+
+// TODO 8367244: Remove -XX:-StressUnstableIfTraps again.
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;


### PR DESCRIPTION
`compiler/valhalla/inlinetypes/TestAcmpWithUnstableIf.java` crashes when run with `StressUnstableIfTraps` in the CI ([JDK-8367244](https://bugs.openjdk.org/browse/JDK-8367244)).

To reduce the noise in the CI, I'm temporarily passing `-XX:-StressUnstableIfTraps` to disable the stress mode.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - no project role) ⚠️ Review applies to [7d33fbd1](https://git.openjdk.org/valhalla/pull/1635/files/7d33fbd19cbcd29899d332ea60bef73513a1a56f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1635/head:pull/1635` \
`$ git checkout pull/1635`

Update a local copy of the PR: \
`$ git checkout pull/1635` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1635`

View PR using the GUI difftool: \
`$ git pr show -t 1635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1635.diff">https://git.openjdk.org/valhalla/pull/1635.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1635#issuecomment-3334847821)
</details>
