### PR TITLE
8368800: [lworld] Early larval frame and strict should be guarded by preview

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -99,6 +99,7 @@ public class Annotate {
     private final Symtab syms;
     private final TypeEnvs typeEnvs;
     private final Types types;
+    private final Preview preview;
 
     private final Attribute theUnfinishedDefaultValue;
     private final String sourceName;
@@ -120,6 +121,7 @@ public class Annotate {
         syms = Symtab.instance(context);
         typeEnvs = TypeEnvs.instance(context);
         types = Types.instance(context);
+        preview = Preview.instance(context);
 
         theUnfinishedDefaultValue =  new Attribute.Error(syms.errType);
 
@@ -390,6 +392,7 @@ public class Annotate {
                     && toAnnotate.kind == VAR
                     && toAnnotate.owner.kind == TYP
                     && types.isSameType(c.type, syms.strictType)) {
+                preview.checkSourceLevel(pos.get(c), Feature.VALUE_CLASSES);
                 toAnnotate.flags_field |= Flags.STRICT;
                 // temporary hack to indicate that a class has at least one strict field
                 toAnnotate.owner.flags_field |= Flags.HAS_STRICT;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -135,7 +135,6 @@ public class Gen extends JCTree.Visitor {
         this.stackMap = StackMapFormat.JSR202;
         annotate = Annotate.instance(context);
         qualifiedSymbolCache = new HashMap<>();
-        generateEarlyLarvalFrame = options.isSet("generateEarlyLarvalFrame");
         Preview preview = Preview.instance(context);
         Source source = Source.instance(context);
         allowValueClasses = (!preview.isPreview(Source.Feature.VALUE_CLASSES) || preview.isEnabled()) &&
@@ -149,7 +148,6 @@ public class Gen extends JCTree.Visitor {
     private final boolean genCrt;
     private final boolean debugCode;
     private boolean disableVirtualizedPrivateInvoke;
-    private boolean generateEarlyLarvalFrame;
     private final boolean allowValueClasses;
 
     /** Code buffer, set by genMethod.
@@ -1095,7 +1093,7 @@ public class Gen extends JCTree.Visitor {
                                         syms,
                                         types,
                                         poolWriter,
-                                        generateEarlyLarvalFrame);
+                                        allowValueClasses);
             items = new Items(poolWriter, code, syms, types);
             if (code.debugCode) {
                 System.err.println(meth + " for body " + tree);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/RedefineStrictFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/RedefineStrictFieldsTest.java
@@ -28,7 +28,7 @@
  * @library /test/lib
  * @run main RedefineClassHelper
  * @modules java.base/jdk.internal.vm.annotation
- * @compile -XDforcePreview -XDgenerateEarlyLarvalFrame -XDnoLocalProxyVars StrictFieldsOld.java StrictFieldsNew.java
+ * @compile -XDnoLocalProxyVars StrictFieldsOld.java StrictFieldsNew.java
  * @run main/othervm -Xverify:remote -javaagent:redefineagent.jar RedefineStrictFieldsTest
  */
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
  * @compile BadChild.jasm
  *          BadChild1.jasm
  *          ControlFlowChildBad.jasm
@@ -32,7 +33,7 @@
  *          EndsInEarlyLarval.jcod
  *          StrictFieldsNotSubset.jcod
  *          InvalidIndexInEarlyLarval.jcod
- * @compile --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED -XDgenerateEarlyLarvalFrame -XDnoLocalProxyVars StrictInstanceFieldsTest.java
+ * @compile -XDnoLocalProxyVars StrictInstanceFieldsTest.java
  * @run main/othervm -Xlog:verification StrictInstanceFieldsTest
  */
 

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -747,8 +747,7 @@ class ValueObjectCompilationTests extends CompilationTestCase {
         // testing experimental @Strict annotation
         String[] previousOptions = getCompileOptions();
         try {
-            String[] testOptions = {"--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED"};
-            setCompileOptions(testOptions);
+            setCompileOptions(PREVIEW_OPTIONS_PLUS_VM_ANNO);
             for (String source : List.of(
                     """
                     import jdk.internal.vm.annotation.Strict;
@@ -1453,7 +1452,6 @@ class ValueObjectCompilationTests extends CompilationTestCase {
             String[] testOptions = {
                     "--enable-preview",
                     "-source", Integer.toString(Runtime.version().feature()),
-                    "-XDgenerateEarlyLarvalFrame",
                     "-XDnoLocalProxyVars",
                     "-XDdebug.stackmap",
                     "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED"


### PR DESCRIPTION
Early larval frame should be generated by the value classes preview settings. To prevent strict presence without early larvals, add a preview check to block strict without value objects preview enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368800](https://bugs.openjdk.org/browse/JDK-8368800): [lworld] Early larval frame and strict should be guarded by preview (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1637/head:pull/1637` \
`$ git checkout pull/1637`

Update a local copy of the PR: \
`$ git checkout pull/1637` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1637`

View PR using the GUI difftool: \
`$ git pr show -t 1637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1637.diff">https://git.openjdk.org/valhalla/pull/1637.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1637#issuecomment-3340444732)
</details>
