### PR TITLE
8368523: [lworld] fix testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java after jdk-26+7 merge

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -103,8 +103,6 @@ public class IRNode {
     public static final String START = "(\\d+(\\s){2}(";
     public static final String MID = ".*)+(\\s){2}===.*";
     public static final String END = ")";
-    public static final String STORE_OF_CLASS_POSTFIX = "( \\([^\\)]+\\))?(:|\\+)\\S* \\*" + END;
-    public static final String LOAD_OF_CLASS_POSTFIX = "( \\([^\\)]+\\))?(:|\\+)\\S* \\*" + END;
 
     public static final String IS_REPLACED = "#IS_REPLACED#"; // Is replaced by an additional user-defined string.
 
@@ -3081,13 +3079,25 @@ public class IRNode {
                                                                           CompilePhase.AFTER_LOOP_OPTS));
     }
 
+    // Typename in load/store have the structure:
+    // @fully/qualified/package/name/to/TheClass+12 *
+    // And variation:
+    // - after @, we can have "stable:" or other labels, with optional space after ':'
+    // - the class can actually be a subclass, with $ separator (and it must be ok to give only the deepest one
+    // - after the class name, we can have a comma-separated list of implemented interfaces enclosed in parentheses
+    // - before the offset, we can have something like ":NotNull", either way, seeing "+" or ":" means the end of the type
+    // Worst case, it can be something like:
+    // @bla: bli:a/b/c$d$e (f/g,h/i/j):NotNull+24 *
+    private static final String LOAD_STORE_PREFIX = "@(\\w+: ?)*[\\w/\\$]*\\b";
+    private static final String LOAD_STORE_SUFFIX = "( \\([^\\)]+\\))?(:|\\+)\\S* \\*";
+
     private static void loadOfNodes(String irNodePlaceholder, String irNodeRegex, String loadee) {
-        String regex = START + irNodeRegex + MID + "@(\\w+: ?)*[\\w/]*\\b" + loadee + LOAD_OF_CLASS_POSTFIX;
+        String regex = START + irNodeRegex + MID + LOAD_STORE_PREFIX + loadee + LOAD_STORE_SUFFIX + END;
         beforeMatching(irNodePlaceholder, regex);
     }
 
     private static void storeOfNodes(String irNodePlaceholder, String irNodeRegex, String storee) {
-        String regex = START + irNodeRegex + MID + "@(\\w+: ?)*[\\w/]*\\b" + storee + STORE_OF_CLASS_POSTFIX;
+        String regex = START + irNodeRegex + MID + LOAD_STORE_PREFIX + storee + LOAD_STORE_SUFFIX + END;
         beforeMatching(irNodePlaceholder, regex);
     }
 


### PR DESCRIPTION
Details of how we ended up there are in the JBS issue.

Let's take the mainline version and put it in valhalla... Except that the mainline version doesn't need (and doesn't have) the `loadee` and `storee` parameters, but have the value `IS_REPLACED` for those. It's unfortunate since conflicts may happen again. Should be less bad.

It now passes the tests of `testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java` again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368523](https://bugs.openjdk.org/browse/JDK-8368523): [lworld] fix testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java after jdk-26+7 merge (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1639/head:pull/1639` \
`$ git checkout pull/1639`

Update a local copy of the PR: \
`$ git checkout pull/1639` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1639`

View PR using the GUI difftool: \
`$ git pr show -t 1639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1639.diff">https://git.openjdk.org/valhalla/pull/1639.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1639#issuecomment-3337383971)
</details>
