### PR TITLE
8368812: [lworld] remove test ExtendedStandardFlagsOverlayFlagsConflict.java from problem list

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -62,7 +62,6 @@ tools/javac/annotations/typeAnnotations/referenceinfos/NestedTypes.java         
 tools/javac/warnings/suppress/TypeAnnotations.java                              8057683    generic-all    improve ordering of errors with type annotations
 tools/javac/modules/SourceInSymlinkTest.java                                    8180263    windows-all    fails when run on a subst drive
 
-tools/javac/flags/ExtendedStandardFlagsOverlayFlagsConflict.java                8368078    generic-all
 tools/javac/processing/model/element/TestValueClasses.java                      8368081    generic-all
 
 ###########################################################################


### PR DESCRIPTION
simple PR removing one test from the problem list

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368812](https://bugs.openjdk.org/browse/JDK-8368812): [lworld] remove test ExtendedStandardFlagsOverlayFlagsConflict.java from problem list (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1641/head:pull/1641` \
`$ git checkout pull/1641`

Update a local copy of the PR: \
`$ git checkout pull/1641` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1641`

View PR using the GUI difftool: \
`$ git pr show -t 1641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1641.diff">https://git.openjdk.org/valhalla/pull/1641.diff</a>

</details>
