### PR TITLE
8368081: [lworld] tools/javac/processing/model/element/TestValueClasses.java `failing at line 8`

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -61,9 +61,6 @@ tools/javac/annotations/typeAnnotations/referenceinfos/Lambda.java              
 tools/javac/annotations/typeAnnotations/referenceinfos/NestedTypes.java         8057687    generic-all    emit correct byte code an attributes for type annotations
 tools/javac/warnings/suppress/TypeAnnotations.java                              8057683    generic-all    improve ordering of errors with type annotations
 tools/javac/modules/SourceInSymlinkTest.java                                    8180263    windows-all    fails when run on a subst drive
-
-tools/javac/processing/model/element/TestValueClasses.java                      8368081    generic-all
-
 ###########################################################################
 #
 # javap

--- a/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
+++ b/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
@@ -117,7 +117,7 @@ public class TestValueClasses extends TestRunner {
                 "- compiler.note.proc.messager:     constructor modifiers: []",
                 "- compiler.note.proc.messager: visiting: ValueRecord Modifiers: [value, final]",
                 "- compiler.note.proc.messager:     constructor modifiers: []",
-                "- compiler.note.preview.filename: Interface.java, DEFAULT",
+                "- compiler.note.preview.filename: DEFAULT",
                 "- compiler.note.preview.recompile"
         );
 


### PR DESCRIPTION
simple PR, fixing test failing after merge

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368081](https://bugs.openjdk.org/browse/JDK-8368081): [lworld] tools/javac/processing/model/element/TestValueClasses.java `failing at line 8` (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1642/head:pull/1642` \
`$ git checkout pull/1642`

Update a local copy of the PR: \
`$ git checkout pull/1642` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1642`

View PR using the GUI difftool: \
`$ git pr show -t 1642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1642.diff">https://git.openjdk.org/valhalla/pull/1642.diff</a>

</details>
