### PR TITLE
8368884: [lworld] java.util.Objects.equals should be inlined

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -60,6 +60,7 @@ public final class Objects {
      * @param b an object to be compared with {@code a} for equality
      * @see Object#equals(Object)
      */
+    @ForceInline
     public static boolean equals(Object a, Object b) {
         if (PreviewFeatures.isEnabled()) {
             // With --enable-preview avoid acmp


### PR DESCRIPTION
Add @ForceInline to java.util.Objects.equals

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368884](https://bugs.openjdk.org/browse/JDK-8368884): [lworld] java.util.Objects.equals should be inlined (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1643/head:pull/1643` \
`$ git checkout pull/1643`

Update a local copy of the PR: \
`$ git checkout pull/1643` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1643`

View PR using the GUI difftool: \
`$ git pr show -t 1643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1643.diff">https://git.openjdk.org/valhalla/pull/1643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1643#issuecomment-3349051911)
</details>
