### PR TITLE
8367729: [lworld] Handle OOME in code cache when generating inline type adapters

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -3104,6 +3104,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(StubId id, address destination
 
 BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
   BufferBlob* buf = BufferBlob::create("inline types pack/unpack", 16 * K);
+  if (buf == nullptr) {
+    return nullptr;
+  }
   CodeBuffer buffer(buf);
   short buffer_locs[20];
   buffer.insts()->initialize_shared_locs((relocInfo*)buffer_locs,

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3906,6 +3906,9 @@ void SharedRuntime::montgomery_square(jint *a_ints, jint *n_ints,
 
 BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
   BufferBlob* buf = BufferBlob::create("inline types pack/unpack", 16 * K);
+  if (buf == nullptr) {
+    return nullptr;
+  }
   CodeBuffer buffer(buf);
   short buffer_locs[20];
   buffer.insts()->initialize_shared_locs((relocInfo*)buffer_locs,

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -403,6 +403,9 @@ void InlineKlass::initialize_calling_convention(TRAPS) {
         }
 
         BufferedInlineTypeBlob* buffered_blob = SharedRuntime::generate_buffered_inline_type_adapter(this);
+        if (buffered_blob == nullptr) {
+          THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), "Out of space in CodeCache for adapters");
+        }
         *((address*)adr_pack_handler()) = buffered_blob->pack_fields();
         *((address*)adr_pack_handler_jobject()) = buffered_blob->pack_fields_jobject();
         *((address*)adr_unpack_handler()) = buffered_blob->unpack_fields();

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
@@ -75,9 +75,9 @@ class ConcurrentClassLoadingTest {
                     // That itself will trigger loading of many field value classes.
                     Class<?> workerClass = Class.forName("Gen" + (DEPTH - 1), false, cl);
                     Object worker = workerClass.getDeclaredConstructor().newInstance();
-                } catch(InterruptedException | BrokenBarrierException e) {
+                } catch (InterruptedException | BrokenBarrierException e) {
                     throw new IllegalStateException("test setup: waiting for barrier saw error", e);
-                } catch(ReflectiveOperationException e) {
+                } catch (ReflectiveOperationException e) {
                     // A ReflectiveOperationException could get thrown if
                     // something goes wrong internally. This should make the test
                     // case fail as it represents a real problem.


### PR DESCRIPTION
Similar to when creating c2i and i2c adapters, we should gracefully handle OOMEs in the code cache when generating Valhalla specific adapters required for the scalarized calling convention.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367729](https://bugs.openjdk.org/browse/JDK-8367729): [lworld] Handle OOME in code cache when generating inline type adapters (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - no project role)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Author)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1645/head:pull/1645` \
`$ git checkout pull/1645`

Update a local copy of the PR: \
`$ git checkout pull/1645` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1645`

View PR using the GUI difftool: \
`$ git pr show -t 1645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1645.diff">https://git.openjdk.org/valhalla/pull/1645.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1645#issuecomment-3351957729)
</details>
