### PR TITLE
8367412: [lworld] Adapter creation fails with guarantee(chk == -1 || chk == 0) failed: Field too big for insn

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -671,7 +671,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
       __ str(zr, Address(rthread, JavaThread::vm_result_oop_offset()));
       __ ldr(r0, Address(rthread, Thread::pending_exception_offset()));
-      __ b(RuntimeAddress(StubRoutines::forward_exception_entry()));
+      __ far_jump(RuntimeAddress(StubRoutines::forward_exception_entry()));
 
       __ bind(no_exception);
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -129,7 +129,6 @@ containers/docker/TestJcmdWithSideCar.java 8341518 linux-x64
 
 
 # Valhalla
-runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java 8367412 linux-aarch64
 runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java CODETOOLS-7904031 generic-all
 runtime/valhalla/inlinetypes/verifier/StrictStaticFieldsTest.java CODETOOLS-7904031 generic-all
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @enablePreview
  * @compile BigClassTreeClassLoader.java
- * @run junit/othervm -XX:ReservedCodeCacheSize=2G ConcurrentClassLoadingTest
+ * @run junit/othervm/timeout=480 -XX:ReservedCodeCacheSize=2G ConcurrentClassLoadingTest
  */
 
 import java.util.Optional;


### PR DESCRIPTION
We hit a guarantee failure because the immediate of the branch instruction is too large. We should use a `far_jump` instead, like we do for all other jumps to `StubRoutines::forward_exception_entry()`.

I can reproduce this reliably with `test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java` and therefore did not add another regression test.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367412](https://bugs.openjdk.org/browse/JDK-8367412): [lworld] Adapter creation fails with guarantee(chk == -1 || chk == 0) failed: Field too big for insn (**Bug** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1646/head:pull/1646` \
`$ git checkout pull/1646`

Update a local copy of the PR: \
`$ git checkout pull/1646` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1646`

View PR using the GUI difftool: \
`$ git pr show -t 1646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1646.diff">https://git.openjdk.org/valhalla/pull/1646.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1646#issuecomment-3352339126)
</details>
