### PR TITLE
8367588: [lworld] serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java fails with JTREG_TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -223,7 +223,6 @@ resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8365722 generic-al
 serviceability/HeapDump/DuplicateArrayClassesTest.java 8365722 generic-all
 
 resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java 8190936 generic-all
-serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java 8367590 generic-all
 vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/TestDescription.java 8367590 generic-all
 
 #############################################################################

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java
@@ -62,11 +62,13 @@ public class ValueGetSetLocal {
         public void meth(ValueClass obj1,       // slot 1
                          ValueHolder obj2) {    // slot 2
             Object obj3 = obj2;                 // slot 3
-            if (!nTestLocals(Thread.currentThread())) {
+            // SetLocalObject can only set locals for top frame of virtual threads.
+            boolean testSetLocal = !Thread.currentThread().isVirtual();
+            if (!nTestLocals(Thread.currentThread(), testSetLocal)) {
                 throw new RuntimeException("ERROR: nTestLocals failed");
             }
             // nTestLocals sets obj3 = obj1
-            if (!Objects.equals(obj3, obj1)) {
+            if (testSetLocal && !Objects.equals(obj3, obj1)) {
                 throw new RuntimeException("ERROR: obj3 != obj1" + " (obj3 = " + obj3 + ")");
             }
         }
@@ -86,5 +88,5 @@ public class ValueGetSetLocal {
         testObj2.meth(testObj1, testObj2);
     }
 
-    private static native boolean nTestLocals(Thread thread);
+    private static native boolean nTestLocals(Thread thread, boolean testSetLocal);
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/libValueGetSetLocal.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/libValueGetSetLocal.cpp
@@ -94,7 +94,7 @@ static jobject get_this(JNIEnv *jni, jthread thread, jint depth) {
 }
 
 JNIEXPORT jboolean JNICALL
-Java_ValueGetSetLocal_nTestLocals(JNIEnv *jni, jclass thisClass, jthread thread) {
+Java_ValueGetSetLocal_nTestLocals(JNIEnv *jni, jclass thisClass, jthread thread, jboolean testSetLocal) {
   bool result = true;
   const jint depth = 1;
 
@@ -115,8 +115,10 @@ Java_ValueGetSetLocal_nTestLocals(JNIEnv *jni, jclass thisClass, jthread thread)
     result = false;
   }
 
-  // set obj3 = obj1
-  set_local(thread, depth, 3, obj1);
+  if (testSetLocal) {
+    // set obj3 = obj1
+    set_local(thread, depth, 3, obj1);
+  }
 
   return result ? JNI_TRUE : JNI_FALSE;
 }


### PR DESCRIPTION
Fixed the test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8367588](https://bugs.openjdk.org/browse/JDK-8367588): [lworld] serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java fails with JTREG_TEST_THREAD_FACTORY=Virtual (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1648/head:pull/1648` \
`$ git checkout pull/1648`

Update a local copy of the PR: \
`$ git checkout pull/1648` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1648`

View PR using the GUI difftool: \
`$ git pr show -t 1648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1648.diff">https://git.openjdk.org/valhalla/pull/1648.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1648#issuecomment-3354124175)
</details>
