### PR TITLE
8368939: [lworld] TestInliningProtectionDomain fails since jdk-26+11

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -83,7 +83,6 @@ compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/MemoryAccessPro
 compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestHotSpotResolvedJavaField.java 8350208 generic-all
 
 # Valhalla
-compiler/ciReplay/TestInliningProtectionDomain.java 8368939 generic-all
 compiler/regalloc/TestVerifyRegisterAllocator.java 8365895 windows-x64
 compiler/types/TestArrayManyDimensions.java 8365895 windows-x64
 compiler/types/correctness/OffTest.java 8365895 windows-x64

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -153,7 +153,7 @@ class ProtectionDomainTestNoOtherCompilationPrivateString {
         bar(); // Not compiled before separately
     }
 
-    // String should be unresovled for the protection domain of this class because getDeclaredMethods is called in normal run
+    // String should be resovled for the protection domain of this class because getDeclaredMethods is called in normal run
     // when validating main() method. In this process, public methods of this class are visited and its signature classes
     // are resolved. bar() is private and not visited in this process (i.e. no resolution of String). But since main()
     // has String[] as parameter, the String class will be resolved for this protection domain. Inlining of bar() succeeds.

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -153,7 +153,7 @@ class ProtectionDomainTestNoOtherCompilationPrivateString {
         bar(); // Not compiled before separately
     }
 
-    // String should be resovled for the protection domain of this class because getDeclaredMethods is called in normal run
+    // String should be resolved for the protection domain of this class because getDeclaredMethods is called in normal run
     // when validating main() method. In this process, public methods of this class are visited and its signature classes
     // are resolved. bar() is private and not visited in this process (i.e. no resolution of String). But since main()
     // has String[] as parameter, the String class will be resolved for this protection domain. Inlining of bar() succeeds.

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -92,9 +92,9 @@ class ProtectionDomainTestCompiledBefore {
         bar();
     }
 
-    // Integer should be resolved for the protection domain of this class because the separate compilation of bar() in
+    // Thread should be resolved for the protection domain of this class because the separate compilation of bar() in
     // the normal run will resolve all classes in the signature. Inlining succeeds.
-    private static Integer bar() {
+    private static Thread bar() {
         InliningFoo.foo();
         return null;
     }
@@ -111,10 +111,10 @@ class ProtectionDomainTestNoOtherCompilationPublic {
         bar(); // Not compiled before separately
     }
 
-    // Integer should be resolved for the protection domain of this class because getDeclaredMethods is called in normal run
+    // Thread should be resolved for the protection domain of this class because getDeclaredMethods is called in normal run
     // when validating main() method. In this process, all public methods of this class are visited and its signature classes
     // are resolved. Inlining of bar() succeeds.
-    public static Integer bar() {
+    public static Thread bar() {
         InliningFoo.foo();
         return null;
     }
@@ -131,12 +131,12 @@ class ProtectionDomainTestNoOtherCompilationPrivate {
         bar(); // Not compiled before separately
     }
 
-    // Integer should be unresolved for the protection domain of this class even though getDeclaredMethods is called in normal
+    // Thread should be unresolved for the protection domain of this class even though getDeclaredMethods is called in normal
     // run when validating main() method. In this process, only public methods of this class are visited and its signature
     // classes are resolved. Since this method is private, the signature classes are not resolved for this protection domain.
     // Inlining of bar() should fail in normal run with "unresolved signature classes". Therefore, replay compilation should
     // also not inline bar().
-    private static Integer bar() {
+    private static Thread bar() {
         InliningFoo.foo();
         return null;
     }
@@ -153,7 +153,7 @@ class ProtectionDomainTestNoOtherCompilationPrivateString {
         bar(); // Not compiled before separately
     }
 
-    // Integer should be resovled for the protection domain of this class because getDeclaredMethods is called in normal run
+    // String should be unresovled for the protection domain of this class because getDeclaredMethods is called in normal run
     // when validating main() method. In this process, public methods of this class are visited and its signature classes
     // are resolved. bar() is private and not visited in this process (i.e. no resolution of String). But since main()
     // has String[] as parameter, the String class will be resolved for this protection domain. Inlining of bar() succeeds.


### PR DESCRIPTION
## Issue
`compiler/ciReplay/TestInliningProtectionDomain.java` for class `ProtectionDomainTestNoOtherCompilationPrivate` fails because it expects `bar()` not to be inlined but it gets inlined instead.

## Cause
`TestInliningProtectionDomain` checks that ciReplay inlining does not fail with unresolved signature classes. For class `ProtectionDomainTestNoOtherCompilationPrivate` it expects `Integer` in its signature to be unresolved but it is resolved instead. The reason for this is that in valhalla boxing classes are automatically added when registering a loader ([JDK-8364034](https://bugs.openjdk.org/browse/JDK-8364034) (and later [JDK-8364483](https://bugs.openjdk.org/browse/JDK-8364483)):
https://github.com/openjdk/valhalla/blob/708b4f92431df90c115dac840fb8194ec3aac3fe/src/hotspot/share/classfile/systemDictionary.cpp#L215-L217

## Fix
`TestInliningProtectionDomain` should actually use a different class than `Integer` (a class that is not in the migrated value classes set, like `java.lang.Thread`. Changed in all classes for "consistency").

## Testing
Tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368939](https://bugs.openjdk.org/browse/JDK-8368939): [lworld] TestInliningProtectionDomain fails since jdk-26+11 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [51858f4c](https://git.openjdk.org/valhalla/pull/1651/files/51858f4ccb6f5329cab12c96b091075fde4f1bfe)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1651/head:pull/1651` \
`$ git checkout pull/1651`

Update a local copy of the PR: \
`$ git checkout pull/1651` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1651`

View PR using the GUI difftool: \
`$ git pr show -t 1651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1651.diff">https://git.openjdk.org/valhalla/pull/1651.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1651#issuecomment-3361380155)
</details>
