### PR TITLE
8369044: [lworld] Interpreter does not emit barrier at the end of java.lang.Object::<init>

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2310,7 +2310,8 @@ void TemplateTable::_return(TosState state)
   // Issue a StoreStore barrier after all stores but before return
   // from any constructor for any class with a final field.  We don't
   // know if this is a finalizer, so we always do so.
-  if (_desc->bytecode() == Bytecodes::_return)
+  if (_desc->bytecode() == Bytecodes::_return
+      || _desc->bytecode() == Bytecodes::_return_register_finalizer)
     __ membar(MacroAssembler::StoreStore);
 
   if (_desc->bytecode() != Bytecodes::_return_register_finalizer) {

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -2103,7 +2103,8 @@ void TemplateTable::_return(TosState state) {
   // Issue a StoreStore barrier after all stores but before return
   // from any constructor for any class with a final field. We don't
   // know if this is a finalizer, so we always do so.
-  if (_desc->bytecode() == Bytecodes::_return) {
+  if (_desc->bytecode() == Bytecodes::_return
+      || _desc->bytecode() == Bytecodes::_return_register_finalizer) {
     __ membar(MacroAssembler::StoreStore);
   }
 


### PR DESCRIPTION
The rewriting of the _return bytecode in j.l.Object.<init> method was preventing the generation of the barrier, this fix solves the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8369044](https://bugs.openjdk.org/browse/JDK-8369044): [lworld] Interpreter does not emit barrier at the end of java.lang.Object::&lt;init&gt; (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1652/head:pull/1652` \
`$ git checkout pull/1652`

Update a local copy of the PR: \
`$ git checkout pull/1652` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1652`

View PR using the GUI difftool: \
`$ git pr show -t 1652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1652.diff">https://git.openjdk.org/valhalla/pull/1652.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1652#issuecomment-3361234752)
</details>
