### PR TITLE
8368875: [lworld] UseParallelGC fails null narrow klass assertion failure

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2373,11 +2373,8 @@ void MoveAndUpdateClosure::do_addr(HeapWord* addr, size_t words) {
     assert(source() != destination(), "inv");
     assert(FullGCForwarding::is_forwarded(cast_to_oop(source())), "inv");
     assert(FullGCForwarding::forwardee(cast_to_oop(source())) == cast_to_oop(destination()), "inv");
-    // Read the klass before the copying, since it might destroy the klass (i.e. overlapping copy)
-    // and if partial copy, the destination klass may not be copied yet
-    Klass* klass = cast_to_oop(source())->klass();
     Copy::aligned_conjoint_words(source(), copy_destination(), words);
-    cast_to_oop(copy_destination())->set_mark(Klass::default_prototype_header(klass));
+    cast_to_oop(copy_destination())->reinit_mark();
   }
 
   update_state(words);

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -383,10 +383,10 @@ oop MemAllocator::finish(HeapWord* mem) const {
   // object zeroing are visible before setting the klass non-null, for
   // concurrent collectors.
   if (UseCompactObjectHeaders) {
-    oopDesc::release_set_mark(mem, Klass::default_prototype_header(_klass));
+    oopDesc::release_set_mark(mem, _klass->prototype_header());
   } else {
     if (EnableValhalla) {
-      oopDesc::set_mark(mem, Klass::default_prototype_header(_klass));
+      oopDesc::set_mark(mem, _klass->prototype_header());
     } else {
       oopDesc::set_mark(mem, markWord::prototype());
     }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -742,7 +742,6 @@ public:
   inline markWord prototype_header() const;
   inline void set_prototype_header(markWord header);
   static ByteSize prototype_header_offset() { return in_ByteSize(offset_of(Klass, _prototype_header)); }
-  static inline markWord default_prototype_header(Klass* k);
   inline void set_prototype_header_klass(narrowKlass klass);
 
   JFR_ONLY(DEFINE_TRACE_ID_METHODS;)

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -90,11 +90,6 @@ inline markWord Klass::prototype_header() const {
   return _prototype_header;
 }
 
-// May no longer be required (was used to avoid a bootstrapping problem...
-inline markWord Klass::default_prototype_header(Klass* k) {
-  return (k == nullptr) ? markWord::prototype() : k->prototype_header();
-}
-
 inline void Klass::set_prototype_header_klass(narrowKlass klass) {
   // Merge narrowKlass in existing prototype header.
   _prototype_header = _prototype_header.set_narrow_klass(klass);

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -306,7 +306,8 @@ class markWord {
 
   // Should this header be preserved during GC?
   bool must_be_preserved() const {
-    return (!is_unlocked() || !has_no_hash() || (EnableValhalla && is_larval_state()));
+    return (!is_unlocked() || !has_no_hash() ||
+      (EnableValhalla && (is_larval_state() || is_inline_type() || is_flat_array() || is_null_free_array())));
   }
 
   // WARNING: The following routines are used EXCLUSIVELY by
@@ -411,26 +412,23 @@ class markWord {
     return (mask_bits(value(), larval_mask_in_place) == larval_pattern);
   }
 
-#ifdef _LP64 // 64 bit encodings only
   bool is_flat_array() const {
+#ifdef _LP64 // 64 bit encodings only
     return (mask_bits(value(), flat_array_mask_in_place) == null_free_flat_array_pattern)
            || (mask_bits(value(), flat_array_mask_in_place) == nullable_flat_array_pattern);
-  }
-
-  bool is_null_free_array() const {
-    return (mask_bits(value(), null_free_array_mask_in_place) == null_free_array_pattern);
-  }
 #else
-  bool is_flat_array() const {
-    fatal("Should not ask this for mark word, ask oopDesc");
     return false;
+#endif
   }
 
   bool is_null_free_array() const {
-    fatal("Should not ask this for mark word, ask oopDesc");
+#ifdef _LP64 // 64 bit encodings only
+    return (mask_bits(value(), null_free_array_mask_in_place) == null_free_array_pattern);
+#else
     return false;
-  }
 #endif
+  }
+
   inline Klass* klass() const;
   inline Klass* klass_or_null() const;
   inline Klass* klass_without_asserts() const;

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -93,6 +93,7 @@ class oopDesc {
   // Used only to re-initialize the mark word (e.g., of promoted
   // objects during a GC) -- requires a valid klass pointer
   inline void init_mark();
+  inline void reinit_mark(); // special for parallelGC
 
   inline Klass* klass() const;
   inline Klass* klass_or_null() const;

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -95,6 +95,17 @@ void oopDesc::init_mark() {
   set_mark(prototype_mark());
 }
 
+// This is for parallel gc, which doesn't always have the klass.
+// markWord::must_be_preserved preserves the original prototype header bits for EnableValhalla,
+// I don't know why serial gc doesn't work the same.
+void oopDesc::reinit_mark() {
+  if (UseCompactObjectHeaders) {
+    set_mark(klass()->prototype_header());
+  } else {
+    set_mark(markWord::prototype());
+  }
+}
+
 Klass* oopDesc::klass() const {
   switch (ObjLayout::klass_mode()) {
     case ObjLayout::Compact:


### PR DESCRIPTION
This seems to pass multiple stressHierarchy test invocations with -XX:+UseParallelGC, and runtime/valhalla/inlinetypes tests. I think there's probably further investigation that needs to be done but hopefully this helps with the parallel GC test failures.
Testing with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368875](https://bugs.openjdk.org/browse/JDK-8368875): [lworld] UseParallelGC fails null narrow klass assertion failure (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1655/head:pull/1655` \
`$ git checkout pull/1655`

Update a local copy of the PR: \
`$ git checkout pull/1655` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1655`

View PR using the GUI difftool: \
`$ git pr show -t 1655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1655.diff">https://git.openjdk.org/valhalla/pull/1655.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1655#issuecomment-3366622745)
</details>
