### PR TITLE
8314996: [lworld] java/lang/Thread/virtual/stress/PingPong.java fails since jdk-22+8

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -71,5 +71,5 @@ javax/management/ImplementationVersion/ImplVersionTest.java 0000000 generic-all
 javax/management/remote/mandatory/version/ImplVersionTest.java 0000000 generic-all
 
 # Valhalla
-java/lang/Thread/virtual/stress/PingPong.java 8314996 macosx-all
+java/lang/Thread/virtual/stress/PingPong.java 8342977 generic-all
 java/lang/Thread/virtual/stress/Skynet.java 8342977 generic-all


### PR DESCRIPTION
When running with JTREG_REPEAT_COUNT=1000 I get the same error as skynet in [JDK-8342977](https://bugs.openjdk.org/browse/JDK-8342977), so I'm using that number for the ProblemList-Virtual.txt. This fails intermittently without JTREG_TEST_THREAD_FACTORY=Virtual, so maybe this belongs in ProblemList.txt instead, as well as Skynet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314996](https://bugs.openjdk.org/browse/JDK-8314996): [lworld] java/lang/Thread/virtual/stress/PingPong.java fails since jdk-22+8 (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Author)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1657/head:pull/1657` \
`$ git checkout pull/1657`

Update a local copy of the PR: \
`$ git checkout pull/1657` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1657`

View PR using the GUI difftool: \
`$ git pr show -t 1657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1657.diff">https://git.openjdk.org/valhalla/pull/1657.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1657#issuecomment-3366071702)
</details>
