### PR TITLE
8368802: [lworld] C1 compilation fails with SIGSEGV in ciObjArrayKlass::make_impl

### DIFF
--- a/src/hotspot/share/ci/ciObjArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciObjArrayKlass.cpp
@@ -139,14 +139,14 @@ ciObjArrayKlass* ciObjArrayKlass::make_impl(ciKlass* element_klass, bool vm_type
     EXCEPTION_CONTEXT;
     // The element klass is loaded
     Klass* array = element_klass->get_Klass()->array_klass(THREAD);
-    if (array->is_objArray_klass() && vm_type) {
-      assert(!array->is_refArray_klass() && !array->is_flatArray_klass(), "Unexpected refined klass");
-      array = ObjArrayKlass::cast(array)->klass_with_properties(ArrayKlass::ArrayProperties::DEFAULT, THREAD);
-    }
     if (HAS_PENDING_EXCEPTION) {
       CLEAR_PENDING_EXCEPTION;
       CURRENT_THREAD_ENV->record_out_of_memory_failure();
       return ciEnv::unloaded_ciobjarrayklass();
+    }
+    if (array->is_objArray_klass() && vm_type) {
+      assert(!array->is_refArray_klass() && !array->is_flatArray_klass(), "Unexpected refined klass");
+      array = ObjArrayKlass::cast(array)->klass_with_properties(ArrayKlass::ArrayProperties::DEFAULT, THREAD);
     }
     return CURRENT_THREAD_ENV->get_obj_array_klass(array);
   }


### PR DESCRIPTION
If we are OOM, `element_klass->get_Klass()->array_klass(THREAD)` will return `nullptr`. We need to check `HAS_PENDING_EXCEPTION` before using the return value.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368802](https://bugs.openjdk.org/browse/JDK-8368802): [lworld] C1 compilation fails with SIGSEGV in ciObjArrayKlass::make_impl (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1661/head:pull/1661` \
`$ git checkout pull/1661`

Update a local copy of the PR: \
`$ git checkout pull/1661` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1661`

View PR using the GUI difftool: \
`$ git pr show -t 1661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1661.diff">https://git.openjdk.org/valhalla/pull/1661.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1661#issuecomment-3370585391)
</details>
