### PR TITLE
8368782: [lworld] C2: fatal error: no reachable node should have no use

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2694,7 +2694,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       Node *ii = in(i);
       Node *new_in = MemNode::optimize_memory_chain(ii, at, nullptr, phase);
       if (ii != new_in ) {
-        set_req(i, new_in);
+        set_req_X(i, new_in, phase->is_IterGVN());
         progress = this;
       }
     }


### PR DESCRIPTION
`test9()` in `TestLWorld.java` is crashing intermittently when running with `StressLoopPeeling`.

The problem can be traced back to a node that is not re-added to the IGVN worklist in `PhiNode::Ideal()`:
<img width="282" height="198" alt="graph" src="https://github.com/user-attachments/assets/e8597cf1-d49f-4c8d-b248-184b25f30fba" />

We are processing `3786 Phi` and update its input `3748 Phi` to another node. As a result, `3748 Phi` loses it's last output and is now dead. It should be re-added to the IGVN worklist to be cleaned up. But that does not happen because we use `set_req()` on `3786 Phi` instead of `set_req_X()` when replacing the input `3748 Phi`. As a result, the dead node stays in the graph and eventually triggers the "no dead use" assert.

The fix is straight forward to use `set_req_X()` which ensures that a now dead input node is pushed to the IGVN worklist again and cleaned up later.

The affected code is also wrong in mainline but has never triggered there. Therefore, I suggest to wait and not eagerly upstream it to mainline for now.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8368782](https://bugs.openjdk.org/browse/JDK-8368782): [lworld] C2: fatal error: no reachable node should have no use (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1662/head:pull/1662` \
`$ git checkout pull/1662`

Update a local copy of the PR: \
`$ git checkout pull/1662` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1662`

View PR using the GUI difftool: \
`$ git pr show -t 1662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1662.diff">https://git.openjdk.org/valhalla/pull/1662.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1662#issuecomment-3371362907)
</details>
