### PR TITLE
8369066: [lworld] UncaughtNativeExceptionTest.java fails with UnsupportedClassVersionError

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test id
+ * @test
  * @enablePreview
  * @requires os.family == "windows"
  * @library /test/lib
@@ -57,6 +57,7 @@ public class UncaughtNativeExceptionTest {
         OutputAnalyzer output = ProcessTools.executeTestJava(
                 // executeTestJava doesn't seem to forward 'java.library.path'
                 "-Djava.library.path=" + System.getProperty("java.library.path"),
+                "--enable-preview",
                 Crasher.class.getName());
 
         File hsErrFile = HsErrFileUtils.openHsErrFileFromOutput(output);


### PR DESCRIPTION
The `--enable-preview` was not propagated correctly to the sub-process used in this test so this option was added explicitly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8369066](https://bugs.openjdk.org/browse/JDK-8369066): [lworld] UncaughtNativeExceptionTest.java fails with UnsupportedClassVersionError (**Bug** - P4)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1663/head:pull/1663` \
`$ git checkout pull/1663`

Update a local copy of the PR: \
`$ git checkout pull/1663` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1663`

View PR using the GUI difftool: \
`$ git pr show -t 1663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1663.diff">https://git.openjdk.org/valhalla/pull/1663.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1663#issuecomment-3372331331)
</details>
