### PR TITLE
8369260: [lworld] InnerClassLambdaMetafactory.java should use PREVIEW_MINOR_VERSION

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -318,7 +318,7 @@ import sun.invoke.util.Wrapper;
         final byte[] classBytes = ClassFile.of().build(lambdaClassEntry, pool, new Consumer<ClassBuilder>() {
             @Override
             public void accept(ClassBuilder clb) {
-                clb.withVersion(ClassFileFormatVersion.latest().major(), (PreviewFeatures.isEnabled() ? 0xFFFF0000 : 0))
+                clb.withVersion(ClassFileFormatVersion.latest().major(), (PreviewFeatures.isEnabled() ? ClassFile.PREVIEW_MINOR_VERSION : 0))
                    .withFlags(ACC_SUPER | ACC_FINAL | ACC_SYNTHETIC)
                    .withInterfaceSymbols(interfaces);
 


### PR DESCRIPTION
Use the correct constant

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8369260](https://bugs.openjdk.org/browse/JDK-8369260): [lworld] InnerClassLambdaMetafactory.java should use PREVIEW_MINOR_VERSION (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1665/head:pull/1665` \
`$ git checkout pull/1665`

Update a local copy of the PR: \
`$ git checkout pull/1665` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1665`

View PR using the GUI difftool: \
`$ git pr show -t 1665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1665.diff">https://git.openjdk.org/valhalla/pull/1665.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1665#issuecomment-3375791661)
</details>
