### PR TITLE
8374147: [lworld] Cleanup markword bit masks and constants

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2370,7 +2370,7 @@ void MacroAssembler::null_check(Register reg, int offset) {
 
 void MacroAssembler::test_markword_is_inline_type(Register markword, Label& is_inline_type) {
   assert_different_registers(markword, rscratch2);
-  mov(rscratch2, markWord::inline_type_mask_in_place);
+  mov(rscratch2, markWord::inline_type_pattern_mask);
   andr(markword, markword, rscratch2);
   mov(rscratch2, markWord::inline_type_pattern);
   cmp(markword, rscratch2);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -524,7 +524,7 @@ void C2_MacroAssembler::fast_unlock(Register obj, Register reg_rax, Register t, 
 
     // Try to unlock. Transition lock bits 0b00 => 0b01
     movptr(reg_rax, mark);
-    andptr(reg_rax, ~(int32_t)markWord::lock_mask);
+    andptr(reg_rax, ~(int32_t)markWord::lock_mask_in_place);
     orptr(mark, markWord::unlocked_value);
     lock(); cmpxchgptr(mark, Address(obj, oopDesc::mark_offset_in_bytes()));
     jcc(Assembler::notEqual, push_and_slow_path);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2384,7 +2384,7 @@ void MacroAssembler::null_check(Register reg, int offset) {
 }
 
 void MacroAssembler::test_markword_is_inline_type(Register markword, Label& is_inline_type) {
-  andptr(markword, markWord::inline_type_mask_in_place);
+  andptr(markword, markWord::inline_type_pattern_mask);
   cmpptr(markword, markWord::inline_type_pattern);
   jcc(Assembler::equal, is_inline_type);
 }

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -141,6 +141,7 @@ class markWord {
 
   #define mask_in_place(bits, shift) (right_n_bits(bits) << (shift))
 
+  // Helper to make sure that _bit_in_place constants only refers to one bit.
   #define bit_in_place(bits, shift) []() {                  \
       static_assert((bits) == 1 NOT_LP64(|| (bits) == 0));  \
       return mask_in_place((bits), (shift));                \
@@ -151,7 +152,7 @@ class markWord {
   static const uintptr_t self_fwd_bit_in_place    = bit_in_place(self_fwd_bits, self_fwd_shift);
   static const uintptr_t age_mask_in_place        = mask_in_place(age_bits, age_shift);
   static const uintptr_t inline_type_bit_in_place = bit_in_place(inline_type_bits, inline_type_shift);
-  static const uintptr_t null_free_array_bit_in_place = bit_in_place(null_free_array_bits,  null_free_array_shift);
+  static const uintptr_t null_free_array_bit_in_place = bit_in_place(null_free_array_bits, null_free_array_shift);
   static const uintptr_t flat_array_bit_in_place  = bit_in_place(flat_array_bits, flat_array_shift);
   static const uintptr_t valhalla_reserved_bit_in_place = bit_in_place(valhalla_reserved_bits, valhalla_reserved_shift);
   static const uintptr_t hash_mask_in_place       = mask_in_place(hash_bits, hash_shift);

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -30,6 +30,7 @@
 #include "oops/compressedKlass.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "runtime/globals.hpp"
+#include "utilities/powerOfTwo.hpp"
 
 // The markWord describes the header of an object.
 //
@@ -139,26 +140,24 @@ class markWord {
   static const int valhalla_reserved_shift        = flat_array_shift + flat_array_bits;
   static const int hash_shift                     = valhalla_reserved_shift + valhalla_reserved_bits;
 
-  #define mask_in_place(bits, shift) (right_n_bits(bits) << (shift))
-
-  // Helper to make sure that _bit_in_place constants only refer to one bit.
-  #define bit_in_place(bits, shift) []() {                  \
-      static_assert((bits) == 1 NOT_LP64(|| (bits) == 0));  \
-      return mask_in_place((bits), (shift));                \
-    }()
-
   // Masks (in-place)
-  static const uintptr_t lock_mask_in_place       = mask_in_place(lock_bits, lock_shift);
-  static const uintptr_t self_fwd_bit_in_place    = bit_in_place(self_fwd_bits, self_fwd_shift);
-  static const uintptr_t age_mask_in_place        = mask_in_place(age_bits, age_shift);
-  static const uintptr_t inline_type_bit_in_place = bit_in_place(inline_type_bits, inline_type_shift);
-  static const uintptr_t null_free_array_bit_in_place = bit_in_place(null_free_array_bits, null_free_array_shift);
-  static const uintptr_t flat_array_bit_in_place  = bit_in_place(flat_array_bits, flat_array_shift);
-  static const uintptr_t valhalla_reserved_bit_in_place = bit_in_place(valhalla_reserved_bits, valhalla_reserved_shift);
-  static const uintptr_t hash_mask_in_place       = mask_in_place(hash_bits, hash_shift);
+  static const uintptr_t lock_mask_in_place       = right_n_bits(lock_bits) << lock_shift;
+  static const uintptr_t self_fwd_bit_in_place    = right_n_bits(self_fwd_bits) << self_fwd_shift;
+  static const uintptr_t age_mask_in_place        = right_n_bits(age_bits) << age_shift;
+  static const uintptr_t inline_type_bit_in_place = right_n_bits(inline_type_bits) << inline_type_shift;
+  static const uintptr_t null_free_array_bit_in_place = right_n_bits(null_free_array_bits) << null_free_array_shift;
+  static const uintptr_t flat_array_bit_in_place  = right_n_bits(flat_array_bits) << flat_array_shift;
+  static const uintptr_t valhalla_reserved_bit_in_place = right_n_bits(valhalla_reserved_bits) << valhalla_reserved_shift;
+  static const uintptr_t hash_mask_in_place       = right_n_bits(hash_bits) << hash_shift;
 
-  #undef mask_in_place
-  #undef bit_in_place
+  // Verify that _bit_in_place refers to constants with only one bit.
+  static_assert(is_power_of_2(self_fwd_bit_in_place));
+#ifdef _LP64
+  static_assert(is_power_of_2(inline_type_bit_in_place));
+  static_assert(is_power_of_2(null_free_array_bit_in_place));
+  static_assert(is_power_of_2(flat_array_bit_in_place));
+  static_assert(is_power_of_2(valhalla_reserved_bit_in_place));
+#endif
 
   // Masks (unshifted)
   static const uintptr_t lock_mask                = lock_mask_in_place >> lock_shift;

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -30,7 +30,6 @@
 #include "oops/compressedKlass.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "runtime/globals.hpp"
-#include "utilities/vmEnums.hpp"
 
 // The markWord describes the header of an object.
 //
@@ -38,49 +37,49 @@
 //
 //  32 bits:
 //  --------
-//             hash:25 ------------->|  age:4  self-fwd:1  lock:2 (normal object)
+//             hash:25              age:4  self-fwd:1  lock:2
 //
-//  64 bits:
-//  --------
-//  unused:22  hash:31 -->| valhalla:4  age:4  self-fwd:1  lock:2 (normal object)
+//  64 bits (without compact headers):
+//  ----------------------------------
+//  unused:22  hash:31  valhalla:4  age:4  self-fwd:1  lock:2
 //
 //  64 bits (with compact headers):
 //  -------------------------------
-//  klass:22   hash:31 -->| valhalla:4  age:4  self-fwd:1  lock:2 (normal object)
+//  klass:22   hash:31  valhalla:4  age:4  self-fwd:1  lock:2
 //
-//  - hash contains the identity hash value: largest value is
-//    31 bits, see os::random().  Also, 64-bit vm's require
-//    a hash value no bigger than 32 bits because they will not
-//    properly generate a mask larger than that: see library_call.cpp
+//  - hash - contains the identity hash value: largest value is 31 bits, see
+//    os::random().  Also, 64-bit VMs require a hash value no bigger than 32
+//    bits because they will not properly generate a mask larger than that:
+//    see library_call.cpp
 //
-//  - the two lock bits are used to describe three states: locked/unlocked and monitor.
+//  - valhalla - only supported on 64-bit VMs
+//
+//    * inline types:      A value class instance
+//    * flat arrays:       An array with flattened value class elements
+//    * null-free arrays:  An array instance without null elements
+//    * valhalla reserved: Reserved for future use
+//
+//    Inline types cannot be locked and do not have an identity hash.
+//
+//  - age - used by some GCs to track the age of objects.
+//
+//  - self-fwd - used by some GCs to indicate in-place forwarding.
+//
+//    Note the position of 'self-fwd' is not by accident. When forwarding an
+//    object to a new heap position, HeapWord alignment guarantees the lower
+//    bits, including 'self-fwd' are 0. "is_self_forwarded()" will be correctly
+//    set to false. Otherwise encode_pointer_as_mark() may have 'self-fwd' set.
+//
+//  - lock bits are used to describe lock states: locked/unlocked/monitor-locked
+//    and to indicate that an object has been GC marked / forwarded.
 //
 //    [header          | 00]  locked             locked regular object header (fast-locking in use)
 //    [header          | 01]  unlocked           regular object header
-//    [ptr             | 10]  monitor            inflated lock (header is swapped out, UseObjectMonitorTable == false)
 //    [header          | 10]  monitor            inflated lock (UseObjectMonitorTable == true)
-//    [ptr             | 11]  marked             used to mark an object
-//
-//  VALHALLA EXTENSIONS:
-//
-//  N.B.: 32 bit mode is not supported, this section assumes 64 bit systems.
-//
-//  Project Valhalla uses markWord bits to denote the following oops (listed least to most significant):
-//  * inline types: have alternative bytecode behavior, e.g. can not be locked
-//  * flat arrays: load/decode of klass layout helper is expensive for aaload
-//  * "null free" arrays: load/decode of klass layout helper again for aaload
-//  * valhalla reserved:
-//
-//  Inline types cannot be locked, monitored or inflating.
-//
-//  Note the position of 'self-fwd' is not by accident. When forwarding an
-//  object to a new heap position, HeapWord alignment guarantees the lower
-//  bits, including 'self-fwd' are 0. "is_self_forwarded()" will be correctly
-//  set to false. Otherwise encode_pointer_as_mark() may have 'self-fwd' set.
+//    [ptr             | 10]  monitor            inflated lock (UseObjectMonitorTable == false, header is swapped out)
+//    [ptr             | 11]  marked             used to mark an object (header is swapped out)
 
-class BasicLock;
 class ObjectMonitor;
-class JavaThread;
 class outputStream;
 
 class markWord {
@@ -116,11 +115,11 @@ class markWord {
   uintptr_t value() const { return _value; }
 
   // Constants, in least significant bit order
+
+  // Number of bits
   static const int lock_bits                      = 2;
   static const int self_fwd_bits                  = 1;
-  // instance state
   static const int age_bits                       = 4;
-  // prototype header bits (fast path instead of klass layout_helper)
   static const int inline_type_bits               = LP64_ONLY(1) NOT_LP64(0);
   static const int null_free_array_bits           = LP64_ONLY(1) NOT_LP64(0);
   static const int flat_array_bits                = LP64_ONLY(1) NOT_LP64(0);
@@ -128,6 +127,7 @@ class markWord {
   static const int max_hash_bits                  = BitsPerWord - age_bits - lock_bits - inline_type_bits - valhalla_reserved_bits - flat_array_bits - null_free_array_bits - self_fwd_bits;
   static const int hash_bits                      = max_hash_bits > 31 ? 31 : max_hash_bits;
 
+  // Shifts
   static const int lock_shift                     = 0;
   static const int self_fwd_shift                 = lock_shift + lock_bits;
   static const int age_shift                      = self_fwd_shift + self_fwd_bits;
@@ -137,26 +137,36 @@ class markWord {
   static const int valhalla_reserved_shift        = flat_array_shift + flat_array_bits;
   static const int hash_shift                     = valhalla_reserved_shift + valhalla_reserved_bits;
 
-  static const uintptr_t lock_mask                = right_n_bits(lock_bits);
-  static const uintptr_t lock_mask_in_place       = lock_mask << lock_shift;
-  static const uintptr_t self_fwd_mask            = right_n_bits(self_fwd_bits);
-  static const uintptr_t self_fwd_mask_in_place   = self_fwd_mask << self_fwd_shift;
-  static const uintptr_t inline_type_bit_in_place = right_n_bits(inline_type_bits) << inline_type_shift;
-  static const uintptr_t inline_type_mask_in_place = inline_type_bit_in_place + lock_mask;
-  static const uintptr_t null_free_array_bit_in_place  = (right_n_bits(null_free_array_bits) << null_free_array_shift);
-  static const uintptr_t flat_array_bit_in_place  = right_n_bits(flat_array_bits) << flat_array_shift;
-  static const uintptr_t age_mask                 = right_n_bits(age_bits);
-  static const uintptr_t age_mask_in_place        = age_mask << age_shift;
-  static const uintptr_t valhalla_reserved_mask   = right_n_bits(valhalla_reserved_bits);
-  static const uintptr_t valhalla_reserved_mask_in_place = right_n_bits(valhalla_reserved_mask) << valhalla_reserved_shift;
-  static const uintptr_t hash_mask                = right_n_bits(hash_bits);
-  static const uintptr_t hash_mask_in_place       = hash_mask << hash_shift;
+  #define mask_in_place(bits, shift) (right_n_bits(bits) << (shift))
+
+  #define bit_in_place(bits, shift) []() {                  \
+      static_assert((bits) == 1 NOT_LP64(|| (bits) == 0));  \
+      return mask_in_place((bits), (shift));                \
+    }()
+
+  // Masks (in-place)
+  static const uintptr_t lock_mask_in_place       = mask_in_place(lock_bits, lock_shift);
+  static const uintptr_t self_fwd_bit_in_place    = bit_in_place(self_fwd_bits, self_fwd_shift);
+  static const uintptr_t inline_type_bit_in_place = bit_in_place(inline_type_bits, inline_type_shift);
+  static const uintptr_t null_free_array_bit_in_place = bit_in_place(null_free_array_bits,  null_free_array_shift);
+  static const uintptr_t flat_array_bit_in_place  = bit_in_place(flat_array_bits, flat_array_shift);
+  static const uintptr_t age_mask_in_place        = mask_in_place(age_bits, age_shift);
+  static const uintptr_t valhalla_reserved_bit_in_place = bit_in_place(valhalla_reserved_bits, valhalla_reserved_shift);
+  static const uintptr_t hash_mask_in_place       = mask_in_place(hash_bits, hash_shift);
+
+  #undef mask_in_place
+  #undef bit_in_place
+
+  // Masks (unshifted)
+  static const uintptr_t lock_mask                = lock_mask_in_place >> lock_shift;
+  static const uintptr_t age_mask                 = age_mask_in_place >> age_shift;
+  static const uintptr_t hash_mask                = hash_mask_in_place >> hash_shift;
 
 #ifdef _LP64
   // Used only with compact headers:
   // We store the (narrow) Klass* in the bits 43 to 64.
 
-  // These are for bit-precise extraction of the narrow Klass* from the 64-bit Markword
+  // These are for bit-precise extraction of the narrow Klass* from the 64-bit markWord
   static constexpr int klass_offset_in_bytes      = 4;
   static constexpr int klass_shift                = hash_shift + hash_bits;
   static constexpr int klass_shift_at_offset      = klass_shift - klass_offset_in_bytes * BitsPerByte;
@@ -165,13 +175,13 @@ class markWord {
   static constexpr uintptr_t klass_mask_in_place  = klass_mask << klass_shift;
 #endif
 
-
   static const uintptr_t locked_value             = 0;
   static const uintptr_t unlocked_value           = 1;
   static const uintptr_t monitor_value            = 2;
   static const uintptr_t marked_value             = 3;
 
   static const uintptr_t inline_type_pattern      = inline_type_bit_in_place | unlocked_value;
+  static const uintptr_t inline_type_pattern_mask = inline_type_bit_in_place | lock_mask_in_place;
 
   static const uintptr_t no_hash                  = 0 ;  // no hash value assigned
   static const uintptr_t no_hash_in_place         = (uintptr_t)no_hash << hash_shift;
@@ -184,7 +194,7 @@ class markWord {
 
   bool is_inline_type() const {
 #ifdef _LP64 // 64 bit encodings only
-    return (mask_bits(value(), inline_type_mask_in_place) == inline_type_pattern);
+    return (mask_bits(value(), inline_type_pattern_mask) == inline_type_pattern);
 #else
     return false;
 #endif
@@ -209,13 +219,13 @@ class markWord {
 
   bool is_forwarded() const {
     // Returns true for normal forwarded (0b011) and self-forwarded (0b1xx).
-    return mask_bits(value(), lock_mask_in_place | self_fwd_mask_in_place) >= static_cast<intptr_t>(marked_value);
+    return mask_bits(value(), lock_mask_in_place | self_fwd_bit_in_place) >= static_cast<intptr_t>(marked_value);
   }
 
   // Should this header be preserved during GC?
   bool must_be_preserved() const {
     // The reserved bits are only guaranteed to be unset if the mark word is "unlocked"
-    LP64_ONLY(assert(!is_unlocked() || mask_bits(value(),  valhalla_reserved_mask_in_place) == 0,
+    LP64_ONLY(assert(!is_unlocked() || mask_bits(value(),  valhalla_reserved_bit_in_place) == 0,
                      "Reserved bits should not be used. _value: " PTR_FORMAT, _value));
     return !is_unlocked() || !has_no_hash();
   }
@@ -320,7 +330,8 @@ class markWord {
   inline narrowKlass narrow_klass() const;
   inline markWord set_narrow_klass(narrowKlass narrow_klass) const;
 
-  // Prototype mark for initialization
+  // Prototype marks for initialization
+
   static markWord prototype() {
     return markWord(unlocked_value);
   }
@@ -350,20 +361,19 @@ class markWord {
   // Prepare address of oop for placement into mark
   inline static markWord encode_pointer_as_mark(void* p) { return from_pointer(p).set_marked(); }
 
-  inline void* decode_pointer() const {
-    return (void*) (clear_lock_bits().value());
-  }
+  // Recover address of oop from encoded form used in mark
+  inline void* decode_pointer() const { return (void*)clear_lock_bits().value(); }
 
   inline bool is_self_forwarded() const {
-    return mask_bits(value(), self_fwd_mask_in_place) != 0;
+    return mask_bits(value(), self_fwd_bit_in_place) != 0;
   }
 
   inline markWord set_self_forwarded() const {
-    return markWord(value() | self_fwd_mask_in_place);
+    return markWord(value() | self_fwd_bit_in_place);
   }
 
   inline markWord unset_self_forwarded() const {
-    return markWord(value() & ~self_fwd_mask_in_place);
+    return markWord(value() & ~self_fwd_bit_in_place);
   }
 
   inline oop forwardee() const {

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -141,7 +141,7 @@ class markWord {
 
   #define mask_in_place(bits, shift) (right_n_bits(bits) << (shift))
 
-  // Helper to make sure that _bit_in_place constants only refers to one bit.
+  // Helper to make sure that _bit_in_place constants only refer to one bit.
   #define bit_in_place(bits, shift) []() {                  \
       static_assert((bits) == 1 NOT_LP64(|| (bits) == 0));  \
       return mask_in_place((bits), (shift));                \

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -47,29 +47,6 @@
 //  -------------------------------
 //  klass:22   hash:31  valhalla:4  age:4  self-fwd:1  lock:2
 //
-//  - hash - contains the identity hash value: largest value is 31 bits, see
-//    os::random().  Also, 64-bit VMs require a hash value no bigger than 32
-//    bits because they will not properly generate a mask larger than that:
-//    see library_call.cpp
-//
-//  - valhalla - only supported on 64-bit VMs
-//
-//    * inline types:      A value class instance
-//    * flat arrays:       An array with flattened value class elements
-//    * null-free arrays:  An array instance without null elements
-//    * valhalla reserved: Reserved for future use
-//
-//    Inline types cannot be locked and do not have an identity hash.
-//
-//  - age - used by some GCs to track the age of objects.
-//
-//  - self-fwd - used by some GCs to indicate in-place forwarding.
-//
-//    Note the position of 'self-fwd' is not by accident. When forwarding an
-//    object to a new heap position, HeapWord alignment guarantees the lower
-//    bits, including 'self-fwd' are 0. "is_self_forwarded()" will be correctly
-//    set to false. Otherwise encode_pointer_as_mark() may have 'self-fwd' set.
-//
 //  - lock bits are used to describe lock states: locked/unlocked/monitor-locked
 //    and to indicate that an object has been GC marked / forwarded.
 //
@@ -78,6 +55,31 @@
 //    [header          | 10]  monitor            inflated lock (UseObjectMonitorTable == true)
 //    [ptr             | 10]  monitor            inflated lock (UseObjectMonitorTable == false, header is swapped out)
 //    [ptr             | 11]  marked             used to mark an object (header is swapped out)
+//
+//  - self-fwd - used by some GCs to indicate in-place forwarding.
+//
+//    Note the position of 'self-fwd' is not by accident. When forwarding an
+//    object to a new heap position, HeapWord alignment guarantees the lower
+//    bits, including 'self-fwd' are 0. "is_self_forwarded()" will be correctly
+//    set to false. Otherwise encode_pointer_as_mark() may have 'self-fwd' set.
+//
+//  - age - used by some GCs to track the age of objects.
+//
+//  - valhalla - only supported on 64-bit VMs
+//
+//    * inline types:      A value class instance
+//    * flat arrays:       An array with flattened value class elements
+//    * null-free arrays:  An array instance without null elements
+//    * valhalla reserved: Reserved for future use
+//
+//    Inline types cannot be locked and does not have an identity hash.
+//
+//  - hash - contains the identity hash value: largest value is 31 bits, see
+//    os::random().  Also, 64-bit VMs require a hash value no bigger than 32
+//    bits because they will not properly generate a mask larger than that:
+//    see library_call.cpp
+//
+//  - klass - klass identifier used when UseCompactObjectHeaders == true
 
 class ObjectMonitor;
 class outputStream;

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -72,7 +72,7 @@
 //    * null-free arrays:  An array instance without null elements
 //    * valhalla reserved: Reserved for future use
 //
-//    Inline types cannot be locked and does not have an identity hash.
+//    Inline types cannot be locked and do not have an identity hash.
 //
 //  - hash - contains the identity hash value: largest value is 31 bits, see
 //    os::random().  Also, 64-bit VMs require a hash value no bigger than 32

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -149,10 +149,10 @@ class markWord {
   // Masks (in-place)
   static const uintptr_t lock_mask_in_place       = mask_in_place(lock_bits, lock_shift);
   static const uintptr_t self_fwd_bit_in_place    = bit_in_place(self_fwd_bits, self_fwd_shift);
+  static const uintptr_t age_mask_in_place        = mask_in_place(age_bits, age_shift);
   static const uintptr_t inline_type_bit_in_place = bit_in_place(inline_type_bits, inline_type_shift);
   static const uintptr_t null_free_array_bit_in_place = bit_in_place(null_free_array_bits,  null_free_array_shift);
   static const uintptr_t flat_array_bit_in_place  = bit_in_place(flat_array_bits, flat_array_shift);
-  static const uintptr_t age_mask_in_place        = mask_in_place(age_bits, age_shift);
   static const uintptr_t valhalla_reserved_bit_in_place = bit_in_place(valhalla_reserved_bits, valhalla_reserved_shift);
   static const uintptr_t hash_mask_in_place       = mask_in_place(hash_bits, hash_shift);
 


### PR DESCRIPTION
@caspernorrbin Started cleaning up markWord.hpp with https://github.com/openjdk/valhalla/pull/2238, but while reviewing that patch I realized that it would be good to make a number of simplifications before proceeding. I talked that through with Casper and @Arraying. Those changes have now been done, and I've taken a pass through markWord.hpp to updated the code in the spirit of what Casper did and some of the things we three talked about.

I've also made updates and clarifications to the comments.

One main thing about this proposal is that I want it to be crystal clear when we talk about bit and when we talk about a mask. To make sure that the bit constants only ever refers to one bit I've added helpers to verify that this is the case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8374147](https://bugs.openjdk.org/browse/JDK-8374147): [lworld] Cleanup markword bit masks and constants (**Enhancement** - P4)


### Reviewers
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - no project role) ⚠️ Review applies to [5dd422ab](https://git.openjdk.org/valhalla/pull/2310/files/5dd422ab4118648c61aef72704cf54bad06fb5a1)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Contributors
 * Casper Norrbin `<cnorrbin@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2310/head:pull/2310` \
`$ git checkout pull/2310`

Update a local copy of the PR: \
`$ git checkout pull/2310` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2310`

View PR using the GUI difftool: \
`$ git pr show -t 2310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2310.diff">https://git.openjdk.org/valhalla/pull/2310.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2310#issuecomment-4206867212)
</details>
