### PR TITLE
8381574: [lworld] Merge of JDK-8365501 broke the scalarized calling convention for abstract methods

### DIFF
--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -169,11 +169,17 @@ address Method::get_c2i_entry() {
 }
 
 address Method::get_c2i_inline_entry() {
+  if (is_abstract()) {
+    return SharedRuntime::get_handle_wrong_method_abstract_stub();
+  }
   assert(adapter() != nullptr, "must have");
   return adapter()->get_c2i_inline_entry();
 }
 
 address Method::get_c2i_inline_ro_entry() {
+  if (is_abstract()) {
+    return SharedRuntime::get_handle_wrong_method_abstract_stub();
+  }
   assert(adapter() != nullptr, "must have");
   return adapter()->get_c2i_inline_ro_entry();
 }
@@ -1342,20 +1348,12 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
   // called from the vtable.  We need adapters on such methods that get loaded
   // later.  Ditto for mega-morphic itable calls.  If this proves to be a
   // problem we'll make these lazily later.
-  if (is_abstract()) {
-    address wrong_method_abstract = SharedRuntime::get_handle_wrong_method_abstract_stub();
-    h_method->_from_compiled_entry = wrong_method_abstract;
-    h_method->_from_compiled_inline_entry = wrong_method_abstract;
-    h_method->_from_compiled_inline_ro_entry = wrong_method_abstract;
-  } else if (_adapter == nullptr) {
-    (void) make_adapters(h_method, CHECK);
-#ifndef ZERO
-    assert(adapter()->is_linked(), "Adapter must have been linked");
-#endif
-    h_method->_from_compiled_entry = adapter()->get_c2i_entry();
-    h_method->_from_compiled_inline_entry = adapter()->get_c2i_inline_entry();
-    h_method->_from_compiled_inline_ro_entry = adapter()->get_c2i_inline_ro_entry();
+  if (_adapter == nullptr && (!h_method->is_abstract() || InlineTypePassFieldsAsArgs)) {
+    make_adapters(h_method, CHECK);
   }
+  h_method->_from_compiled_entry = h_method->get_c2i_entry();
+  h_method->_from_compiled_inline_entry = h_method->get_c2i_inline_entry();
+  h_method->_from_compiled_inline_ro_entry = h_method->get_c2i_inline_ro_entry();
 
   // ONLY USE the h_method now as make_adapter may have blocked
 
@@ -1374,8 +1372,8 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
   }
 }
 
-address Method::make_adapters(const methodHandle& mh, TRAPS) {
-  assert(!mh->is_abstract(), "abstract methods do not have adapters");
+void Method::make_adapters(const methodHandle& mh, TRAPS) {
+  assert(!mh->is_abstract() || InlineTypePassFieldsAsArgs, "abstract methods do not have adapters");
   PerfTraceTime timer(ClassLoader::perf_method_adapters_time());
 
   // Adapters for compiled code are made eagerly here.  They are fairly
@@ -1389,14 +1387,16 @@ address Method::make_adapters(const methodHandle& mh, TRAPS) {
       // Java exception object.
       vm_exit_during_initialization("Out of space in CodeCache for adapters");
     } else {
-      THROW_MSG_NULL(vmSymbols::java_lang_OutOfMemoryError(), "Out of space in CodeCache for adapters");
+      THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), "Out of space in CodeCache for adapters");
     }
   }
 
-  assert(!mh->has_scalarized_args() || adapter->get_sig_cc() != nullptr, "sigcc should not be null here");
+  assert(!mh->has_scalarized_args() || (adapter->get_sig_cc() != nullptr && adapter->get_sig_cc_ro() != nullptr), "should be initialized");
 
   mh->set_adapter_entry(adapter);
-  return adapter->get_c2i_entry();
+#ifndef ZERO
+  assert(adapter->is_linked(), "Adapter must have been linked");
+#endif
 }
 
 // The verified_code_entry() must be called when a invoke is resolved

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1348,6 +1348,8 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
   // called from the vtable.  We need adapters on such methods that get loaded
   // later.  Ditto for mega-morphic itable calls.  If this proves to be a
   // problem we'll make these lazily later.
+  // With the scalarized calling convention, create adapters for abstract
+  // methods as well because the adapter is used to propagate the signature.
   if (_adapter == nullptr && (!h_method->is_abstract() || InlineTypePassFieldsAsArgs)) {
     make_adapters(h_method, CHECK);
   }

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -133,7 +133,7 @@ class Method : public Metadata {
   void set_constMethod(ConstMethod* xconst)    { _constMethod = xconst; }
 
 
-  static address make_adapters(const methodHandle& mh, TRAPS);
+  static void make_adapters(const methodHandle& mh, TRAPS);
   address from_compiled_entry() const;
   address from_compiled_inline_ro_entry() const;
   address from_compiled_inline_entry() const;

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -182,7 +182,7 @@ JVMState* DirectCallGenerator::generate(JVMState* jvms) {
     // Mark the call node as virtual, sort of:
     call->set_optimized_virtual(true);
   }
-  kit.set_arguments_for_java_call(call, is_late_inline());
+  kit.set_arguments_for_java_call(call);
   if (kit.stopped()) {
     return kit.transfer_exceptions_into_jvms();
   }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2053,7 +2053,7 @@ void GraphKit::set_arguments_for_java_call(CallJavaNode* call) {
       // to be able to access the extended signature later via attached_method_before_pc().
       // For example, see CompiledMethod::preserve_callee_argument_oops().
       call->set_override_symbolic_info(true);
-      // Register an calling convention dependency on the callee method to make sure that this method is deoptimized and
+      // Register a calling convention dependency on the callee method to make sure that this method is deoptimized and
       // re-compiled with a non-scalarized calling convention if the callee method is later marked as mismatched.
       C->dependencies()->assert_mismatch_calling_convention(call->method());
       arg_num++;

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2013,7 +2013,7 @@ Node* GraphKit::load_array_element(Node* ary, Node* idx, const TypeAryPtr* aryty
 
 //-------------------------set_arguments_for_java_call-------------------------
 // Arguments (pre-popped from the stack) are taken from the JVMS.
-void GraphKit::set_arguments_for_java_call(CallJavaNode* call, bool is_late_inline) {
+void GraphKit::set_arguments_for_java_call(CallJavaNode* call) {
   PreserveReexecuteState preexecs(this);
   if (Arguments::is_valhalla_enabled()) {
     // Make sure the call is "re-executed", if buffering of inline type arguments triggers deoptimization.
@@ -2039,12 +2039,11 @@ void GraphKit::set_arguments_for_java_call(CallJavaNode* call, bool is_late_inli
           arg = InlineTypeNode::make_null(_gvn, t->inline_klass());
         } else {
           // During parsing, a method is called with an abstract (or j.l.Object) receiver, the
-          // receiver is a non-scalarized oop. Later on, IGVN reveals that the receiver must be a
-          // value object. The method is devirtualized, and replaced with a direct call with a
-          // scalarized receiver instead.
+          // receiver is a non-scalarized oop. CHA or IGVN might then prove that the receiver
+          // type must be an exact value class. The method is devirtualized, and replaced with
+          // a direct call with a scalarized receiver instead.
           assert(arg_idx == 0 && !call->method()->is_static(), "must be the receiver");
-          assert(C->inlining_incrementally() || C->strength_reduction(), "must be during devirtualization of calls");
-          assert(!is_Parse(), "must be during devirtualization of calls");
+          assert(call->is_optimized_virtual(), "must be during devirtualization of calls");
           arg = InlineTypeNode::make_from_oop(this, arg, t->inline_klass());
         }
       }

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -697,7 +697,7 @@ class GraphKit : public Phase {
 
   // Fill in argument edges for the call from argument(0), argument(1), ...
   // (The next step is to call set_edges_for_java_call.)
-  void  set_arguments_for_java_call(CallJavaNode* call, bool is_late_inline = false);
+  void set_arguments_for_java_call(CallJavaNode* call);
 
   // Fill in non-argument edges for the call.
   // Transform the call, and update the basics: control, i_o, memory.

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1443,7 +1443,8 @@ methodHandle SharedRuntime::resolve_helper(bool is_virtual, bool is_optimized, b
 
   methodHandle callee_method(current, call_info.selected_method());
   // Calls via mismatching methods are always non-scalarized
-  if (caller_nm->is_compiled_by_c1() || call_info.resolved_method()->mismatch()) {
+  bool mismatch = is_optimized ? call_info.selected_method()->mismatch() : call_info.resolved_method()->mismatch();
+  if (caller_nm->is_compiled_by_c1() || mismatch) {
     caller_does_not_scalarize = true;
   }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3200,7 +3200,7 @@ void AdapterHandlerLibrary::verify_adapter_sharing(CompiledEntrySignature& ces, 
 #endif /* ASSERT*/
 
 AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& method) {
-  assert(!method->is_abstract(), "abstract methods do not have adapters");
+  assert(!method->is_abstract() || InlineTypePassFieldsAsArgs, "abstract methods do not have adapters");
   // Use customized signature handler.  Need to lock around updates to
   // the _adapter_handler_table (it is not safe for concurrent readers
   // and a single writer: this could be fixed if it becomes a

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -850,10 +850,16 @@ class AdapterHandlerEntry : public MetaspaceObj {
   bool is_linked() const { return _linked; }
 
   // Support for scalarized inline type calling convention
-  void set_sig_cc(const GrowableArray<SigEntry>* sig)  { _sig_cc = sig; }
-  const GrowableArray<SigEntry>* get_sig_cc()    const { return _sig_cc; }
-  void set_sig_cc_ro(const GrowableArray<SigEntry>* sig)  { _sig_cc_ro = sig; }
-  const GrowableArray<SigEntry>* get_sig_cc_ro()    const { return _sig_cc_ro; }
+  void set_sig_cc(const GrowableArray<SigEntry>* sig) {
+    assert(_sig_cc == nullptr, "Already initialized");
+    _sig_cc = sig;
+  }
+  const GrowableArray<SigEntry>* get_sig_cc() const { return _sig_cc; }
+  void set_sig_cc_ro(const GrowableArray<SigEntry>* sig) {
+    assert(_sig_cc_ro == nullptr, "Already initialized");
+    _sig_cc_ro = sig;
+  }
+  const GrowableArray<SigEntry>* get_sig_cc_ro() const { return _sig_cc_ro; }
 
   uint id() const { return _id; }
   AdapterFingerPrint* fingerprint() const { return _fingerprint; }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -1504,4 +1504,78 @@ public class TestCallingConvention {
     //         // Expected
     //     }
     // }
+
+    static interface Interface60 {
+        public void m(MyValue2 val);
+    }
+
+    static class Impl60_1 implements Interface60 {
+        public void m(MyValue2 val) {
+            Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
+       }
+    }
+
+    static class Impl60_2 implements Interface60 {
+        public void m(MyValue2 val) {
+            Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
+       }
+    }
+
+    static class Impl60_3 implements Interface60 {
+        public void m(MyValue2 val) {
+            Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
+       }
+    }
+
+    // Verify that the scalarized calling convention works for abstract methods
+    @Test
+    @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
+        failOn = {ALLOC})
+    public void test60(Interface60 intf) {
+        intf.m(MyValue2.createWithFieldsInline(rI, rD));
+    }
+
+    @Run(test = "test60")
+    public void test60_verifier() {
+        test60(new Impl60_1());
+        test60(new Impl60_2());
+        test60(new Impl60_3());
+    }
+
+    static abstract value class ValueClass61 {
+        public abstract void m(MyValue2 val);
+    }
+
+    static value class Impl61_1 extends ValueClass61 {
+        public void m(MyValue2 val) {
+            Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
+       }
+    }
+
+    static value class Impl61_2 extends ValueClass61 {
+        public void m(MyValue2 val) {
+            Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
+       }
+    }
+
+    static value class Impl61_3 extends ValueClass61 {
+        public void m(MyValue2 val) {
+            Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
+       }
+    }
+
+    // Same as test60 but with abstract value class
+    @Test
+    @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
+        failOn = {ALLOC})
+    public void test61(ValueClass61 intf) {
+        intf.m(MyValue2.createWithFieldsInline(rI, rD));
+    }
+
+    @Run(test = "test61")
+    public void test61_verifier() {
+        test61(new Impl61_1());
+        test61(new Impl61_2());
+        test61(new Impl61_3());
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -38,6 +38,7 @@ import static compiler.valhalla.inlinetypes.InlineTypeIRNode.STORE_OF_ANY_KLASS;
 import static compiler.valhalla.inlinetypes.InlineTypes.*;
 
 import static compiler.lib.ir_framework.IRNode.ALLOC;
+import static compiler.lib.ir_framework.IRNode.CALL_OF_METHOD;
 import static compiler.lib.ir_framework.IRNode.PREDICATE_TRAP;
 import static compiler.lib.ir_framework.IRNode.UNSTABLE_IF_TRAP;
 
@@ -1512,19 +1513,19 @@ public class TestCallingConvention {
     static class Impl60_1 implements Interface60 {
         public void m(MyValue2 val) {
             Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
-       }
+        }
     }
 
     static class Impl60_2 implements Interface60 {
         public void m(MyValue2 val) {
             Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
-       }
+        }
     }
 
     static class Impl60_3 implements Interface60 {
         public void m(MyValue2 val) {
             Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
-       }
+        }
     }
 
     // Verify that the scalarized calling convention works for abstract methods
@@ -1549,19 +1550,19 @@ public class TestCallingConvention {
     static value class Impl61_1 extends ValueClass61 {
         public void m(MyValue2 val) {
             Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
-       }
+        }
     }
 
     static value class Impl61_2 extends ValueClass61 {
         public void m(MyValue2 val) {
             Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
-       }
+        }
     }
 
     static value class Impl61_3 extends ValueClass61 {
         public void m(MyValue2 val) {
             Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
-       }
+        }
     }
 
     // Same as test60 but with abstract value class
@@ -1577,5 +1578,42 @@ public class TestCallingConvention {
         test61(new Impl61_1());
         test61(new Impl61_2());
         test61(new Impl61_3());
+    }
+
+    public static abstract value class ValueClass62 {
+        public abstract void m(MyValue2 val);
+    }
+
+    public static value class Impl62_1 extends ValueClass62 {
+        @ForceInline
+        public void m(MyValue2 val) {
+            // Empty to keep IR matching in test62 simple
+        }
+    }
+
+    // Hide the second subclass from the IR framework to prevent it from class loading
+    static class Holder {
+        static value class Impl62_2 extends ValueClass62 {
+            public void m(MyValue2 val) {
+                Asserts.assertEQ(val, MyValue2.createWithFieldsInline(rI, rD));
+            }
+        }
+    }
+
+    // Test strength reduction of virtual call to static call with scalarized receiver
+    @Test
+    @IR(failOn = {ALLOC, CALL_OF_METHOD, "m"})
+    public static void test62(ValueClass62 intf, MyValue2 val) {
+        intf.m(val);
+    }
+
+    static boolean alwaysFalse = false;
+
+    @Run(test = "test62")
+    public void test62_verifier(RunInfo info) {
+        test62(new Impl62_1(), MyValue2.createWithFieldsInline(rI, rD));
+        if (!info.isWarmUp()) {
+            test62(new Holder.Impl62_2(), MyValue2.createWithFieldsInline(rI, rD));
+        }
     }
 }


### PR DESCRIPTION
The merge of https://github.com/openjdk/jdk/commit/444a8fa14e8ab016b8aae018054c5dc1eb843fee into Valhalla broke the scalarized calling convention for abstract methods. Unfortunately, we didn't have any tests that caught this so this went unnoticed for a while until @rwestrel wondered why it's so tricky to come up with a test case for [JDK-8381563](https://bugs.openjdk.org/browse/JDK-8381563) :slightly_smiling_face: 

The problem is that no adapters are generated anymore for abstract methods because they are not needed. However, with the scalarized calling convention, we use the adapter to keep track of the scalarized signature. I re-enabled adapter generation if the scalarized calling convention is enabled - overhead should be benign because these are cached/shared after all.

I also added tests to catch similar breakages in the future, refactored some surrounding code and added asserts.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8381574](https://bugs.openjdk.org/browse/JDK-8381574): [lworld] Merge of JDK-8365501 broke the scalarized calling convention for abstract methods (**Bug** - P3)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2311/head:pull/2311` \
`$ git checkout pull/2311`

Update a local copy of the PR: \
`$ git checkout pull/2311` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2311`

View PR using the GUI difftool: \
`$ git pr show -t 2311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2311.diff">https://git.openjdk.org/valhalla/pull/2311.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2311#issuecomment-4206884464)
</details>
