### PR TITLE
8381854: [lworld] Add acmp maps test to the FieldLayoutAnalyzer

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1664,12 +1664,12 @@ void FieldLayoutBuilder::epilogue() {
       }
       st.print("Non-oop acmp map <offset,size>: ");
       for (int i = 0 ; i < _nonoop_acmp_map->length(); i++) {
-        st.print("<%d,%d>, ", _nonoop_acmp_map->at(i)._offset,  _nonoop_acmp_map->at(i)._size);
+        st.print("<%d,%d> ", _nonoop_acmp_map->at(i)._offset,  _nonoop_acmp_map->at(i)._size);
       }
       st.print_cr("");
       st.print("oop acmp map: ");
       for (int i = 0 ; i < _oop_acmp_map->length(); i++) {
-        st.print("%d, ", _oop_acmp_map->at(i));
+        st.print("%d ", _oop_acmp_map->at(i));
       }
       st.print_cr("");
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
@@ -849,7 +849,7 @@ public class FieldLayoutAnalyzer {
     checkAcmpMap();
   }
 
-  void postPrecessing() {
+  void postProcessing() {
     // Abstract value class don't have a first field offset in the log, and this information is needed
     // in the verification of acmp maps. The log doesn't contain the information needed to identify
     // abstract value classes, so the value is computed for all classes with an uninitialized fieldFieldOffset field
@@ -889,6 +889,6 @@ public class FieldLayoutAnalyzer {
       System.out.println("Error while processing line: " + lo.getCurrentLine());
       throw t;
     }
-    postPrecessing();
+    postProcessing();
   }
  }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
@@ -27,10 +27,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-
-
 import jdk.test.lib.Asserts;
-
 
 public class FieldLayoutAnalyzer {
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
@@ -25,15 +25,12 @@ package runtime.valhalla.inlinetypes.field_layout;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.management.RuntimeErrorException;
 
 import jdk.test.lib.Asserts;
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
+
 
 public class FieldLayoutAnalyzer {
 
@@ -108,6 +105,8 @@ public class FieldLayoutAnalyzer {
     }
   }
 
+  static public record AcmpMapSegment(int offset, int size) {}
+
   static public record FieldBlock (int offset,
                             BlockType type,
                             int size,
@@ -136,6 +135,7 @@ public class FieldLayoutAnalyzer {
     }
 
     boolean isFlat() { return type == BlockType.FLAT; } // Warning: always return false for inherited fields, even flat ones
+    boolean isRegular() { return type == BlockType.REGULAR; }
     boolean hasNullMarker() { return layoutKind.hasNullMarker(); }
 
     static FieldBlock parseField(String line) {
@@ -204,10 +204,14 @@ public class FieldLayoutAnalyzer {
     String[] lines;
     ArrayList<FieldBlock> staticFields;
     ArrayList<FieldBlock> nonStaticFields;
+    ArrayList<AcmpMapSegment> nonOopAcmpMap;
+    ArrayList<Integer> oopAcmpMap;
 
     private ClassLayout() {
       staticFields = new ArrayList<FieldBlock>();
       nonStaticFields = new ArrayList<FieldBlock>();
+      nonOopAcmpMap = new ArrayList<AcmpMapSegment>();
+      oopAcmpMap = new ArrayList<Integer>();
     }
 
     boolean hasNullFreeNonAtomicLayout() { return nullFreeNonAtomicLayoutSize != -1; }
@@ -375,9 +379,25 @@ public class FieldLayoutAnalyzer {
         } else {
           cl.nullMarkerOffset = -1;
         }
+        // Non-oop acmp map <offset,size>: <12,1> <16,4> ...
         Asserts.assertTrue(lo.getCurrentLine().startsWith("Non-oop acmp map <offset,size>"), lo.getCurrentLine());
+        String[] acmp_nonoop_line = lo.getCurrentLine().split("\\s+");
+        Asserts.assertTrue(acmp_nonoop_line.length >= 4, "Wrong format for non-oop acmp map line: " + lo.getCurrentLine());
+        for (int i = 4; i < acmp_nonoop_line.length; i++) {
+          String[] offset_size = acmp_nonoop_line[i].split(",");
+          Asserts.assertTrue(offset_size.length == 2, "Wrong format for acmp map entry: " + acmp_nonoop_line[i]);
+          int offset = Integer.parseInt(offset_size[0].substring(1)); // skipping '<'
+          int size = Integer.parseInt(offset_size[1].substring(0, offset_size[1].length() - 1)); // skipping '>'
+          cl.nonOopAcmpMap.add(new AcmpMapSegment(offset, size));
+        }
         lo.moveToNextLine();
+        // oop acmp map: 12 16 ...
         Asserts.assertTrue(lo.getCurrentLine().startsWith("oop acmp map"), lo.getCurrentLine());
+        String[] acmp_oop_line = lo.getCurrentLine().split("\\s+");
+        Asserts.assertTrue(acmp_oop_line.length >= 3, "Wrong format for oop acmp map line: " + lo.getCurrentLine());
+        for (int i = 3; i < acmp_oop_line.length; i++) {
+          cl.oopAcmpMap.add(Integer.parseInt(acmp_oop_line[i]));
+        }
         lo.moveToNextLine();
       } else {
         cl.isValue = false;
@@ -745,6 +765,79 @@ public class FieldLayoutAnalyzer {
     }
   }
 
+  void addFlatFieldToBitMap(ClassLayout cl, boolean[] bitmap, int offset, LayoutKind layoutKind) {
+    if (cl.superName != null) {
+      ClassLayout superLayout = getClassLayout(cl.superName);
+      addClassToBitMap(superLayout, bitmap, offset);
+    }
+    int fieldOffset = offset - cl.firstFieldOffset;
+    for (FieldBlock fb : cl.nonStaticFields) {
+      if (fb.isRegular() && fb.name().compareTo("\".empty\"") != 0) {
+        for (int i = fieldOffset + fb.offset(); i < fieldOffset + fb.offset() + fb.size(); i++) {
+          Asserts.assertFalse(bitmap[i], "Overlap in field at offset " + i + " of class " + cl.name);
+          bitmap[i] = true;
+        }
+      } else if (fb.isFlat()) {
+        ClassLayout fcl = getClassLayout(fb.fieldClass);
+        addFlatFieldToBitMap(fcl, bitmap, fieldOffset + fb.offset(), fb.layoutKind);
+      }
+    }
+    if (layoutKind.hasNullMarker()) {
+      Asserts.assertTrue(cl.hasNullMarker());
+      int nullMarkerOffset = fieldOffset + cl.nullMarkerOffset;
+      Asserts.assertFalse(bitmap[nullMarkerOffset], "Overlap in null marker at offset " + nullMarkerOffset + " of class " + cl.name);
+      bitmap[nullMarkerOffset] = true;
+    }
+  }
+
+  void addClassToBitMap(ClassLayout layout, boolean[] bitmap, int baseOffset) {
+    if (layout.superName != null) {
+      ClassLayout superLayout = getClassLayout(layout.superName);
+      addClassToBitMap(superLayout, bitmap, baseOffset);
+    }
+    if (baseOffset != 0) {
+      baseOffset = baseOffset - layout.firstFieldOffset;
+    }
+    for (FieldBlock block : layout.nonStaticFields) {
+      if (block.isRegular() && block.name().compareTo("\".empty\"") != 0) {
+        for (int i =  baseOffset + block.offset(); i <  baseOffset +block.offset() + block.size(); i++) {
+          Asserts.assertFalse(bitmap[i], "Overlap in field at offset " + i + " of class " + layout.name);
+          bitmap[i] = true;
+        }
+      } else if (block.isFlat()) {
+        ClassLayout cl = getClassLayout(block.fieldClass);
+        addFlatFieldToBitMap(cl, bitmap, baseOffset + block.offset(), block.layoutKind);
+      }
+    }
+  }
+
+  void checkAcmpMap() {
+    for (ClassLayout layout : layouts) {
+      if (!layout.isValue) continue;
+      System.out.println("Checking acmp map of class " + layout.name);
+      boolean[] acmpBitMap = new boolean[layout.instanceSize];
+      for (AcmpMapSegment segment : layout.nonOopAcmpMap) {
+        for (int i = segment.offset; i < segment.offset + segment.size; i++) {
+          Asserts.assertFalse(acmpBitMap[i], "Overlap in non-oop acmp map at offset " + i + " of class " + layout.name);
+          acmpBitMap[i] = true;
+        }
+      }
+      for (Integer offset : layout.oopAcmpMap) {
+        for (int i = offset; i < offset + oopSize; i++) {
+          Asserts.assertFalse(acmpBitMap[i], "Overlap in acmp map at offset " + i + " of class " + layout.name);
+          acmpBitMap[i] = true;
+        }
+      }
+      boolean[] fieldBitMap = new boolean[layout.instanceSize];
+      addClassToBitMap(layout, fieldBitMap, 0);
+      for (int i = 0; i < layout.instanceSize; i++) {
+          Asserts.assertTrue(acmpBitMap[i] == fieldBitMap[i], "AcmpMap inconsistency at offset " + i + " of class " + layout.name +
+                             " acmpBitMap = " + acmpBitMap[i] + " fieldBitMap = " + fieldBitMap[i]);
+
+      }
+    }
+  }
+
   public void check() {
     checkOffsets();
     checkNoOverlap();
@@ -753,6 +846,26 @@ public class FieldLayoutAnalyzer {
     checkSubClasses();
     checkNullMarkers();
     checkBufferedLayout();
+    checkAcmpMap();
+  }
+
+  void postPrecessing() {
+    // Abstract value class don't have a first field offset in the log, and this information is needed
+    // in the verification of acmp maps. The log doesn't contain the information needed to identify
+    // abstract value classes, so the value is computed for all classes with an uninitialized fieldFieldOffset field
+    for (ClassLayout layout : layouts) {
+      if (layout.firstFieldOffset == 0) {
+        int firstOffset = 0;
+        for (FieldBlock block : layout.nonStaticFields) {
+          if (block.isRegular() || block.isFlat() || block.type() == BlockType.INHERITED) {
+            if (block.offset() < firstOffset || firstOffset == 0) {
+              firstOffset = block.offset();
+            }
+          }
+        }
+        layout.firstFieldOffset = firstOffset;
+      }
+    }
   }
 
   private void generate(LogOutput lo) {
@@ -775,5 +888,6 @@ public class FieldLayoutAnalyzer {
       System.out.println("Error while processing line: " + lo.getCurrentLine());
       throw t;
     }
+    postPrecessing();
   }
  }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldLayoutAnalyzer.java
@@ -381,11 +381,11 @@ public class FieldLayoutAnalyzer {
         }
         // Non-oop acmp map <offset,size>: <12,1> <16,4> ...
         Asserts.assertTrue(lo.getCurrentLine().startsWith("Non-oop acmp map <offset,size>"), lo.getCurrentLine());
-        String[] acmp_nonoop_line = lo.getCurrentLine().split("\\s+");
-        Asserts.assertTrue(acmp_nonoop_line.length >= 4, "Wrong format for non-oop acmp map line: " + lo.getCurrentLine());
-        for (int i = 4; i < acmp_nonoop_line.length; i++) {
-          String[] offset_size = acmp_nonoop_line[i].split(",");
-          Asserts.assertTrue(offset_size.length == 2, "Wrong format for acmp map entry: " + acmp_nonoop_line[i]);
+        String[] acmpNonoopLine = lo.getCurrentLine().split("\\s+");
+        Asserts.assertTrue(acmpNonoopLine.length >= 4, "Wrong format for non-oop acmp map line: " + lo.getCurrentLine());
+        for (int i = 4; i < acmpNonoopLine.length; i++) {
+          String[] offset_size = acmpNonoopLine[i].split(",");
+          Asserts.assertTrue(offset_size.length == 2, "Wrong format for acmp map entry: " + acmpNonoopLine[i]);
           int offset = Integer.parseInt(offset_size[0].substring(1)); // skipping '<'
           int size = Integer.parseInt(offset_size[1].substring(0, offset_size[1].length() - 1)); // skipping '>'
           cl.nonOopAcmpMap.add(new AcmpMapSegment(offset, size));
@@ -393,10 +393,10 @@ public class FieldLayoutAnalyzer {
         lo.moveToNextLine();
         // oop acmp map: 12 16 ...
         Asserts.assertTrue(lo.getCurrentLine().startsWith("oop acmp map"), lo.getCurrentLine());
-        String[] acmp_oop_line = lo.getCurrentLine().split("\\s+");
-        Asserts.assertTrue(acmp_oop_line.length >= 3, "Wrong format for oop acmp map line: " + lo.getCurrentLine());
-        for (int i = 3; i < acmp_oop_line.length; i++) {
-          cl.oopAcmpMap.add(Integer.parseInt(acmp_oop_line[i]));
+        String[] acmpOopLine = lo.getCurrentLine().split("\\s+");
+        Asserts.assertTrue(acmpOopLine.length >= 3, "Wrong format for oop acmp map line: " + lo.getCurrentLine());
+        for (int i = 3; i < acmpOopLine.length; i++) {
+          cl.oopAcmpMap.add(Integer.parseInt(acmpOopLine[i]));
         }
         lo.moveToNextLine();
       } else {
@@ -772,7 +772,7 @@ public class FieldLayoutAnalyzer {
     }
     int fieldOffset = offset - cl.firstFieldOffset;
     for (FieldBlock fb : cl.nonStaticFields) {
-      if (fb.isRegular() && fb.name().compareTo("\".empty\"") != 0) {
+      if (fb.isRegular() && !fb.name().equals("\".empty\"")) {
         for (int i = fieldOffset + fb.offset(); i < fieldOffset + fb.offset() + fb.size(); i++) {
           Asserts.assertFalse(bitmap[i], "Overlap in field at offset " + i + " of class " + cl.name);
           bitmap[i] = true;
@@ -799,8 +799,8 @@ public class FieldLayoutAnalyzer {
       baseOffset = baseOffset - layout.firstFieldOffset;
     }
     for (FieldBlock block : layout.nonStaticFields) {
-      if (block.isRegular() && block.name().compareTo("\".empty\"") != 0) {
-        for (int i =  baseOffset + block.offset(); i <  baseOffset +block.offset() + block.size(); i++) {
+      if (block.isRegular() && !block.name().equals("\".empty\"")) {
+        for (int i = baseOffset + block.offset(); i <  baseOffset +block.offset() + block.size(); i++) {
           Asserts.assertFalse(bitmap[i], "Overlap in field at offset " + i + " of class " + layout.name);
           bitmap[i] = true;
         }
@@ -860,6 +860,7 @@ public class FieldLayoutAnalyzer {
           if (block.isRegular() || block.isFlat() || block.type() == BlockType.INHERITED) {
             if (block.offset() < firstOffset || firstOffset == 0) {
               firstOffset = block.offset();
+              break;
             }
           }
         }


### PR DESCRIPTION
Add acmp_maps verification to the FieldLayoutAnalyzer.
The FieldLayoutAnalyzer recomputes the memory segments used by fields from the available layout descriptions, and compare the results to the acmp_maps computed by the JVM.
The verification is automatically performed for all tests calling the `check()` method of the FieldLayoutAnalyzer (like the ValueRandomLayoutTest.java).

Tested repeatedly with ValueRandomLayoutTest.java on Mach5.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

Thanks,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8381854](https://bugs.openjdk.org/browse/JDK-8381854): [lworld] Add acmp maps test to the FieldLayoutAnalyzer (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer) ⚠️ Review applies to [1ac3b7e7](https://git.openjdk.org/valhalla/pull/2312/files/1ac3b7e7a14e6196db861cf1398c7488df39cb59)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2312/head:pull/2312` \
`$ git checkout pull/2312`

Update a local copy of the PR: \
`$ git checkout pull/2312` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2312`

View PR using the GUI difftool: \
`$ git pr show -t 2312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2312.diff">https://git.openjdk.org/valhalla/pull/2312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2312#issuecomment-4207454596)
</details>
