### PR TITLE
8379694: [lworld] Add value class test coverage to java.util.Arrays

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -173,7 +173,8 @@ jdk_util = \
     :jdk_stream
 
 valhalla_adopted = \
-    java/util/Collections/AddAll.java
+    java/util/Collections/AddAll.java \
+    java/util/Arrays
 
 # All util components not part of some other util category
 jdk_util_other = \

--- a/test/jdk/java/util/Arrays/ArrayObjectMethods.java
+++ b/test/jdk/java/util/Arrays/ArrayObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,19 @@
  * @summary Basic test for content-based array object methods
  * @author  Josh Bloch, Martin Buchholz
  * @key randomness
+ * @library /test/lib
  */
 
 import java.util.*;
 import java.io.*;
 
+import jdk.test.lib.valueclass.AsValueClass;
+
 public class ArrayObjectMethods {
+
+    @AsValueClass
+    record V(int x, int y) implements Serializable {}
+
     int[] sizes = {0, 10, 100, 200, 1000};
 
     void test(String[] args) throws Throwable {
@@ -290,11 +297,11 @@ class Rnd {
     }
 
     public static Object nextObject() {
-        switch(rnd.nextInt(10)) {
+        switch(rnd.nextInt(12)) {
             case 0:  return null;
             case 1:  return "foo";
-            case 2:  case 3: case 4:
-                     return Double.valueOf(nextDouble());
+            case 2: case 3: case 4: return Double.valueOf(nextDouble());
+            case 5: case 6: return nextV();
             default: return Integer.valueOf(nextInt());
         }
     }
@@ -362,6 +369,17 @@ class Rnd {
         return result;
     }
 
+    public static ArrayObjectMethods.V nextV() {
+        return new ArrayObjectMethods.V(nextInt(), nextInt());
+    }
+
+    public static ArrayObjectMethods.V[] vArray(int length) {
+        ArrayObjectMethods.V[] result = new ArrayObjectMethods.V[length];
+        for (int i = 0; i < length; i++)
+            result[i] = nextV();
+        return result;
+    }
+
     // Calling this for length >> 100 is likely to run out of memory!  It
     // should be perhaps be tuned to allow for longer arrays
     public static Object[] nestedObjectArray(int length) {
@@ -385,6 +403,10 @@ class Rnd {
                 case 7:  result[i] = doubleArray(length/2);
                          break;
                 case 8:  result[i] = longArray(length/2);
+                         break;
+                case 9:  result[i] = vArray(length/2);
+                         break;
+                case 10: result[i] = nextV();
                          break;
                 default: result[i] = Rnd.nextObject();
             }

--- a/test/jdk/java/util/Arrays/ArraysEqCmpTest.java
+++ b/test/jdk/java/util/Arrays/ArraysEqCmpTest.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8033148 8141409
  * @summary tests for array equals and compare
+ * @library /test/lib
  * @run junit ArraysEqCmpTest
 */
-
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -43,6 +43,8 @@ import java.util.function.BiFunction;
 import java.util.function.LongFunction;
 import java.util.stream.IntStream;
 
+import jdk.test.lib.valueclass.AsValueClass;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -56,6 +58,15 @@ public class ArraysEqCmpTest {
     static final int MAX_WIDTH = 512;
 
     static final Map<Class, Integer> typeToWidth;
+
+    @AsValueClass
+    record Point(int x, int y) implements Comparable<Point> {
+        @Override
+        public int compareTo(Point o) {
+            int r = Integer.compare(this.x, o.x);
+            return (r != 0) ? r : Integer.compare(this.y, o.y);
+        }
+    }
 
     static {
         typeToWidth = new HashMap<>();
@@ -588,6 +599,24 @@ public class ArraysEqCmpTest {
                 ((double[]) a)[i] = pv;
             }
         }
+
+        static class ValuePoints extends ArrayType<Point[]> {
+            public ValuePoints() {
+                super(Point[].class);
+            }
+
+            @Override
+            void set(Object a, int i, Object v) {
+                if (v == null) {
+                    ((Point[]) a)[i] = null;
+                } else if (v instanceof Point) {
+                    ((Point[]) a)[i] = (Point) v;
+                } else if (v instanceof Integer) {
+                    int val = (Integer) v;
+                    ((Point[]) a)[i] = new Point(val, val);
+                } else throw new IllegalStateException();
+            }
+        }
     }
 
     static Object[][] arrayTypes;
@@ -609,6 +638,7 @@ public class ArraysEqCmpTest {
                     new Object[]{new ArrayType.Longs(true)},
                     new Object[]{new ArrayType.Floats()},
                     new Object[]{new ArrayType.Doubles()},
+                    new Object[]{new ArrayType.ValuePoints()}
             };
         }
         return arrayTypes;
@@ -639,6 +669,7 @@ public class ArraysEqCmpTest {
             objectArrayTypes = new Object[][]{
                     new Object[]{new ArrayType.BoxedIntegers()},
                     new Object[]{new ArrayType.BoxedIntegersWithReverseComparator()},
+                    new Object[]{new ArrayType.ValuePoints()},
             };
         }
         return objectArrayTypes;
@@ -767,37 +798,37 @@ public class ArraysEqCmpTest {
         // One ref
         Integer one = 1;
         testArrayType(arrayType,
-                      (at, s) -> {
-                          Integer[] a = (Integer[]) at.construct(s);
-                          for (int x = 0; x < s; x++) {
-                              a[x] = one;
-                          }
-                          return a;
-                      },
-                      cloner);
+                    (at, s) -> {
+                        Object a = at.construct(s);
+                            for (int x = 0; x < s; x++) {
+                                at.set(a, x, one);
+                            }
+                        return a;
+                    },
+                    cloner);
 
         // All ref
         testArrayType(arrayType,
-                      (at, s) -> {
-                          Integer[] a = (Integer[]) at.construct(s);
-                          for (int x = 0; x < s; x++) {
-                              a[x] = Integer.valueOf(s);
-                          }
-                          return a;
-                      },
-                      cloner);
+                    (at, s) -> {
+                        Object a = at.construct(s);
+                        for (int x = 0; x < s; x++) {
+                            at.set(a, x, s);
+                        }
+                        return a;
+                    },
+                    cloner);
 
         // Some same ref
         testArrayType(arrayType,
-                      (at, s) -> {
-                          Integer[] a = (Integer[]) at.construct(s);
-                          for (int x = 0; x < s; x++) {
-                              int v = x % 8;
-                              a[x] = v == 1 ? one : new Integer(v);
-                          }
-                          return a;
-                      },
-                      cloner);
+                    (at, s) -> {
+                        Object a = at.construct(s);
+                        for (int x = 0; x < s; x++) {
+                            int v = x % 8;
+                            at.set(a, x, v == 1 ? one : v);
+                        }
+                        return a;
+                    },
+                    cloner);
     }
 
     @ParameterizedTest

--- a/test/jdk/java/util/Arrays/AsList.java
+++ b/test/jdk/java/util/Arrays/AsList.java
@@ -25,13 +25,18 @@
  * @test
  * @bug 8155600
  * @summary Tests for Arrays.asList()
+ * @library /test/lib
  * @run junit AsList
  */
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.IntStream;
+
+import jdk.test.lib.valueclass.AsValueClass;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,6 +46,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AsList {
+
+    @AsValueClass
+    record V(int x) {}
+
     /*
      * Iterator contract test
      */
@@ -74,7 +83,12 @@ public class AsList {
             { new Object[] { null, null, null } },
             { new Object[] { 1, 2, 3, null, 4 } },
             { new Object[] { "a", "a", "a", "a" } },
-            { IntStream.range(0, 100).boxed().toArray() }
+            { IntStream.range(0, 100).boxed().toArray() },
+            { new Object[] { new V(1), new V(2), null, new V(3) } },
+            { new Object[] { Integer.valueOf(1), Integer.valueOf(2), null, Integer.valueOf(3) } },
+            { new Object[] { LocalDate.of(2000, 1, 1), LocalDate.of(2000, 12, 31), LocalDate.now() } },
+            { new Object[] { Optional.of(1), Optional.empty(), Optional.of("a") } },
+            { new Object[] { Boolean.TRUE, Boolean.FALSE, null } }
         };
     }
 }

--- a/test/jdk/java/util/Arrays/Big.java
+++ b/test/jdk/java/util/Arrays/Big.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 5045582
  * @summary arrays larger than 1<<30
  * @author Martin Buchholz
+ * @library /test/lib
  */
 
 // A proper regression test for 5045582 requires too much memory.
@@ -34,7 +35,17 @@
 
 import java.util.*;
 
+import jdk.test.lib.valueclass.AsValueClass;
+
 public class Big {
+
+    @AsValueClass
+    record Point(int x, int y) implements Comparable<Point> {
+        public int compareTo(Point o) {
+            int c = Integer.compare(x, o.x);
+            return c != 0 ? c : Integer.compare(y, o.y);
+        }
+    }
 
     private static void realMain(String[] args) throws Throwable {
         final int shift = intArg(args, 0, 10); // "30" is real test
@@ -93,6 +104,34 @@ public class Big {
             equal(a[n-2],  44);
             equal(a[n-3],  43);
             equal(a[n-4],   0);
+        }
+
+        // To test value record arrays larger than 1<<30, you need ~25GB. Run like:
+        // java --enable-preview -Xms25g -Xmx25g Big 30 4
+        if ((tasks & 0x4) != 0) {
+            System.out.println("Point[]");
+            System.gc();
+            Point[] a = new Point[n];
+            Point ZERO = new Point(0, 0);
+            Arrays.fill(a, ZERO);
+            a[0]   = new Point(-44, -44);
+            a[1]   = new Point(-43, -43);
+            a[n-2] = new Point(+43, +43);
+            a[n-1] = new Point(+44, +44);
+            for (int i : new int[] { 0, 1, n-2, n-1 })
+                try { equal(i, Arrays.binarySearch(a, a[i])); }
+                catch (Throwable t) { unexpected(t); }
+            for (int i : new int[] { n-2, n-1 })
+                try { equal(i, Arrays.binarySearch(a, n-5, n, a[i])); }
+                catch (Throwable t) { unexpected(t); }
+
+            a[n-19] = new Point(45, 45);
+            try { Arrays.sort(a, n-29, n); }
+            catch (Throwable t) { unexpected(t); }
+            equal(a[n-1], new Point(45, 45));
+            equal(a[n-2], new Point(44, 44));
+            equal(a[n-3], new Point(43, 43));
+            equal(a[n-4], new Point(0, 0));
         }
     }
 

--- a/test/jdk/java/util/Arrays/CopyMethods.java
+++ b/test/jdk/java/util/Arrays/CopyMethods.java
@@ -27,10 +27,14 @@
  * @summary Test for array cloning and slicing methods.
  * @author  John Rose
  * @key randomness
+ * @library /test/lib
  */
 
+import java.time.LocalDate;
 import java.util.*;
 import java.lang.reflect.*;
+
+import jdk.test.lib.valueclass.AsValueClass;
 
 public class CopyMethods {
     static int muzzle;  // if !=0, suppresses ("muzzles") messages
@@ -41,6 +45,9 @@ public class CopyMethods {
 
     static int testCasesRun = 0;
     static long consing = 0;
+
+    @AsValueClass
+    record Point(int x, int y) {}
 
     // very simple tests, mainly to test the framework itself
     static void simpleTests() {
@@ -353,6 +360,9 @@ public class CopyMethods {
     static float   coerceToFloat(int x) { return x; }
     static double  coerceToDouble(int x) { return x; }
     static boolean coerceToBoolean(int x) { return (x&1) != 0; }
+    static Point coerceToPoint(int x) { return (x == 0) ? null : new Point(x, x); }
+    static LocalDate coerceToLocalDate(int x) { return (x == 0) ? null : LocalDate.ofEpochDay(x); }
+    static Optional coerceToOptional(int x) { return (x == 0) ? null : Optional.of(x); }
 
     static Integer[] copyOfIntegerArray(Object[] a, int len) {
         // This guy exercises the API based on a type-token.
@@ -370,7 +380,8 @@ public class CopyMethods {
                         {   Object.class, String.class, Integer.class,
                             byte.class, short.class, int.class, long.class,
                             char.class, float.class, double.class,
-                            boolean.class
+                            boolean.class, LocalDate.class, Optional.class,
+                            Point.class,
                         });
     static final HashMap<Class<?>,Method> coercers;
     static final HashMap<Class<?>,Method> cloners;
@@ -417,6 +428,12 @@ public class CopyMethods {
         cloners.put(Integer.class, cia);
         assert(ciar != null);
         cloneRangers.put(Integer.class, ciar);
+        cloners.put(Point.class, cloners.get(Object.class));
+        cloneRangers.put(Point.class, cloneRangers.get(Object.class));
+        cloners.put(LocalDate.class, cloners.get(Object.class));
+        cloneRangers.put(LocalDate.class, cloneRangers.get(Object.class));
+        cloners.put(Optional.class, cloners.get(Object.class));
+        cloneRangers.put(Optional.class, cloneRangers.get(Object.class));
         nullValues = new HashMap<Class<?>,Object>();
         for (Class<?> c : allTypes) {
             nullValues.put(c, invoke(coercers.get(c), 0));

--- a/test/jdk/java/util/Arrays/Correct.java
+++ b/test/jdk/java/util/Arrays/Correct.java
@@ -26,10 +26,13 @@
  * @bug 4726380 8037097
  * @summary Check that different sorts give equivalent results.
  * @key randomness
+ * @library /test/lib
  * @run junit Correct
  */
 
 import java.util.*;
+
+import jdk.test.lib.valueclass.AsValueClass;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -44,6 +47,26 @@ public class Correct {
     static final int ITERATIONS = 1000;
     static final int TEST_SIZE = 1000;
 
+    @AsValueClass
+    record Point(int x, int y) implements Comparable<Point> {
+        public int compareTo(Point o) {
+            int c = Integer.compare(x, o.x);
+            return c != 0 ? c : Integer.compare(y, o.y);
+        }
+    }
+
+    @Test
+    public void testDefaultSortPoint() {
+        for (int i=0; i<ITERATIONS; i++) {
+            int size = rnd.nextInt(TEST_SIZE) + 1;
+            Point[] array1 = getPointArray(size);
+            Point[] array2 = Arrays.copyOf(array1, array1.length);
+            Arrays.sort(array1, array1.length/3, array1.length/2);
+            stupidSort(array2, array2.length/3, array2.length/2);
+            Assertions.assertArrayEquals(array2, array1, "Arrays did not match. size=" + size);
+        }
+    }
+
     @Test
     public void testDefaultSort() {
         for (int i=0; i<ITERATIONS; i++) {
@@ -54,6 +77,27 @@ public class Correct {
             stupidSort(array2, array2.length/3, array2.length/2);
             Assertions.assertArrayEquals(array2, array1, "Arrays did not match. size=" + size);
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("pointComparators")
+    public void testComparatorSortPoint(Comparator<Point> comparator) {
+        for (int i=0; i<ITERATIONS; i++) {
+            int size = rnd.nextInt(TEST_SIZE) + 1;
+            Point[] array1 = getPointArray(size);
+            Point[] array2 = Arrays.copyOf(array1, array1.length);
+            Arrays.sort(array1, array1.length/3, array1.length/2, comparator);
+            stupidSort(array2, array2.length/3, array2.length/2, comparator);
+            Assertions.assertArrayEquals(array2, array1, "Arrays did not match. size=" + size);
+        }
+    }
+
+    static Point[] getPointArray(int size) {
+        Point[] blah = new Point[size];
+        for (int x=0; x<size; x++) {
+            blah[x] = new Point(rnd.nextInt(), rnd.nextInt());
+        }
+        return blah;
     }
 
     @ParameterizedTest
@@ -75,6 +119,44 @@ public class Correct {
             blah[x] = new Integer(rnd.nextInt());
         }
         return blah;
+    }
+
+    static void stupidSort(Point[] a1, int from, int to) {
+        if (from > to - 1)
+            return;
+
+        for (int x=from; x<to; x++) {
+            Point lowest = a1[x];
+            int lowestIndex = x;
+            for (int y=x + 1; y<to; y++) {
+                if (a1[y].compareTo(lowest) < 0) {
+                    lowest = a1[y];
+                    lowestIndex = y;
+                }
+            }
+            if (lowestIndex != x) {
+                swap(a1, x, lowestIndex);
+            }
+        }
+    }
+
+    static void stupidSort(Point[] a1, int from, int to, Comparator<Point> comparator) {
+        if (from > to - 1)
+            return;
+
+        for (int x=from; x<to; x++) {
+            Point lowest = a1[x];
+            int lowestIndex = x;
+            for (int y=x + 1; y<to; y++) {
+                if (comparator.compare(a1[y], lowest) < 0) {
+                    lowest = a1[y];
+                    lowestIndex = y;
+                }
+            }
+            if (lowestIndex != x) {
+                swap(a1, x, lowestIndex);
+            }
+        }
     }
 
     static void stupidSort(Integer[] a1, int from, int to) {
@@ -119,6 +201,17 @@ public class Correct {
         T t = x[a];
         x[a] = x[b];
         x[b] = t;
+    }
+
+    public static Iterator<Object[]> pointComparators() {
+        Object[][] comparators = new Object[][] {
+            new Object[] { Comparator.naturalOrder() },
+            new Object[] { Comparator.<Point>naturalOrder().reversed() },
+            new Object[] { Comparator.comparingInt(Point::x).thenComparingInt(Point::y) },
+            new Object[] { Comparator.comparingInt(Point::y).thenComparingInt(Point::x) }
+        };
+
+        return Arrays.asList(comparators).iterator();
     }
 
     public static Iterator<Object[]> comparators() {

--- a/test/jdk/java/util/Arrays/Correct.java
+++ b/test/jdk/java/util/Arrays/Correct.java
@@ -71,8 +71,8 @@ public class Correct {
     public void testDefaultSort() {
         for (int i=0; i<ITERATIONS; i++) {
             int size = rnd.nextInt(TEST_SIZE) + 1;
-            Integer[] array1 = getIntegerArray(size);
-            Integer[] array2 = Arrays.copyOf(array1, array1.length);
+            Comparable[] array1 = getIntegerArray(size);
+            Comparable[] array2 = Arrays.copyOf(array1, array1.length);
             Arrays.sort(array1, array1.length/3, array1.length/2);
             stupidSort(array2, array2.length/3, array2.length/2);
             Assertions.assertArrayEquals(array2, array1, "Arrays did not match. size=" + size);
@@ -108,7 +108,7 @@ public class Correct {
             Integer[] array1 = getIntegerArray(size);
             Integer[] array2 = Arrays.copyOf(array1, array1.length);
             Arrays.sort(array1, array1.length/3, array1.length/2, comparator);
-            stupidSort(array2, array2.length/3, array2.length/2, comparator);
+            stupidSort((Object[])array2, array2.length/3, array2.length/2, comparator);
             Assertions.assertArrayEquals(array2, array1, "Arrays did not match. size=" + size);
         }
     }
@@ -121,12 +121,12 @@ public class Correct {
         return blah;
     }
 
-    static void stupidSort(Point[] a1, int from, int to) {
+    static void stupidSort(Comparable[] a1, int from, int to) {
         if (from > to - 1)
             return;
 
         for (int x=from; x<to; x++) {
-            Point lowest = a1[x];
+            Comparable lowest = a1[x];
             int lowestIndex = x;
             for (int y=x + 1; y<to; y++) {
                 if (a1[y].compareTo(lowest) < 0) {
@@ -140,50 +140,13 @@ public class Correct {
         }
     }
 
-    static void stupidSort(Point[] a1, int from, int to, Comparator<Point> comparator) {
+    @SuppressWarnings("unchecked")
+    static void stupidSort(Object[] a1, int from, int to, Comparator comparator) {
         if (from > to - 1)
             return;
 
         for (int x=from; x<to; x++) {
-            Point lowest = a1[x];
-            int lowestIndex = x;
-            for (int y=x + 1; y<to; y++) {
-                if (comparator.compare(a1[y], lowest) < 0) {
-                    lowest = a1[y];
-                    lowestIndex = y;
-                }
-            }
-            if (lowestIndex != x) {
-                swap(a1, x, lowestIndex);
-            }
-        }
-    }
-
-    static void stupidSort(Integer[] a1, int from, int to) {
-        if (from > to - 1 )
-          return;
-
-        for (int x=from; x<to; x++) {
-            Integer lowest = a1[x];
-            int lowestIndex = x;
-            for (int y=x + 1; y<to; y++) {
-                if (((Comparable)a1[y]).compareTo((Comparable)lowest) < 0) {
-                    lowest = a1[y];
-                    lowestIndex = y;
-                }
-            }
-            if (lowestIndex != x) {
-                swap(a1, x, lowestIndex);
-            }
-        }
-    }
-
-    static void stupidSort(Integer[] a1, int from, int to, Comparator<Integer> comparator) {
-        if (from > to - 1 )
-          return;
-
-        for (int x=from; x<to; x++) {
-            Integer lowest = a1[x];
+            Object lowest = a1[x];
             int lowestIndex = x;
             for (int y=x + 1; y<to; y++) {
                 if (comparator.compare(a1[y], lowest) < 0) {

--- a/test/jdk/java/util/Arrays/Fill.java
+++ b/test/jdk/java/util/Arrays/Fill.java
@@ -26,6 +26,7 @@
  * @bug 4229892
  * @summary Arrays.fill(Object[], ...) should throw ArrayStoreException
  * @author Martin Buchholz
+ * @library /test/lib
  */
 
 import java.io.*;
@@ -33,7 +34,13 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import jdk.test.lib.valueclass.AsValueClass;
+
 public class Fill {
+
+    @AsValueClass
+    static record MyValue(int value) {};
+
     private static void realMain(String[] args) throws Throwable {
         try {
             Arrays.fill(new Integer[3], "foo");
@@ -51,6 +58,20 @@ public class Fill {
 
         try {
             Arrays.fill(new Integer[3], 0, 4, "foo");
+            fail("Expected ArrayIndexOutOfBoundsException");
+        }
+        catch (ArrayIndexOutOfBoundsException e) { pass(); }
+        catch (Throwable t) { unexpected(t); }
+
+        try {
+            Arrays.fill(new MyValue[3], "foo");
+            fail("Expected ArrayStoreException");
+        }
+        catch (ArrayStoreException e) { pass(); }
+        catch (Throwable t) { unexpected(t); }
+
+        try {
+            Arrays.fill(new MyValue[3], 0, 4, "foo");
             fail("Expected ArrayIndexOutOfBoundsException");
         }
         catch (ArrayIndexOutOfBoundsException e) { pass(); }

--- a/test/jdk/java/util/Arrays/HashCode.java
+++ b/test/jdk/java/util/Arrays/HashCode.java
@@ -36,7 +36,10 @@ import jdk.test.lib.valueclass.AsValueClass;
 public class HashCode {
 
     @AsValueClass
-    record Point(int x, int y) {}
+    static class Point {
+        int x, y;
+        Point(int x, int y) {this.x = x; this.y = y;}
+    }
 
     private static String[] tests = { "", " ", "a", "abcdefg",
             "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way- in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.  -- Charles Dickens, Tale of Two Cities",
@@ -191,14 +194,16 @@ public class HashCode {
         Point[] b = {new Point(1, 2), new Point(3, 4)}; // distinct instances, same fields
         int hashA = Arrays.hashCode(a);
         int hashB = Arrays.hashCode(b);
-        if (hashA != hashB) {
-            throw new RuntimeException("testValueClassArrayHashCode: expected equal hash codes " +
-                "for equal value class arrays, got " + hashA + " and " + hashB);
-        }
-        // Consistency with repeated calls (no identity hash interference)
-        if (hashA != Arrays.hashCode(a)) {
-            throw new RuntimeException("testValueClassArrayHashCode: " +
-                "hash code not consistent across repeated calls");
+        if (Point.class.isValue()) {
+            if (hashA != hashB) {
+                throw new RuntimeException("testValueClassArrayHashCode: expected equal hash codes " +
+                    "for equal value class arrays, got " + hashA + " and " + hashB);
+            }
+            // Repeated calls should produce the same array hash code
+            if (hashA != Arrays.hashCode(a)) {
+                throw new RuntimeException("testValueClassArrayHashCode: " +
+                    "hash code not consistent across repeated calls");
+            }
         }
     }
 }

--- a/test/jdk/java/util/Arrays/HashCode.java
+++ b/test/jdk/java/util/Arrays/HashCode.java
@@ -24,14 +24,20 @@
 /**
  * @test
  * @summary Basic array hashCode functionality
+ * @library /test/lib
  * @run main/othervm --add-exports java.base/jdk.internal.util=ALL-UNNAMED
  *     --add-opens java.base/jdk.internal.util=ALL-UNNAMED -Xcomp -Xbatch HashCode
  */
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import jdk.test.lib.valueclass.AsValueClass;
 
 public class HashCode {
+
+    @AsValueClass
+    record Point(int x, int y) {}
+
     private static String[] tests = { "", " ", "a", "abcdefg",
             "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way- in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.  -- Charles Dickens, Tale of Two Cities",
             "C'était le meilleur des temps, c'était le pire des temps, c'était l'âge de la sagesse, c'était l'âge de la folie, c'était l'époque de la croyance, c'était l'époque de l'incrédulité, c'était la saison de la Lumière, c'était C'était la saison des Ténèbres, c'était le printemps de l'espoir, c'était l'hiver du désespoir, nous avions tout devant nous, nous n'avions rien devant nous, nous allions tous directement au Ciel, nous allions tous directement dans l'autre sens bref, la période ressemblait tellement à la période actuelle, que certaines de ses autorités les plus bruyantes ont insisté pour qu'elle soit reçue, pour le bien ou pour le mal, au degré superlatif de la comparaison seulement. -- Charles Dickens, Tale of Two Cities (in French)",
@@ -167,8 +173,32 @@ public class HashCode {
             failed = true;
         }
 
+        try {
+            testValueClassArrayHashCode();
+            System.out.println("value class array hashCode tests passed");
+        } catch (RuntimeException e) {
+            System.out.println(e.getMessage());
+            failed = true;
+        }
+
         if (failed) {
             throw new RuntimeException("Some tests failed");
+        }
+    }
+
+    private static void testValueClassArrayHashCode() {
+        Point[] a = {new Point(1, 2), new Point(3, 4)};
+        Point[] b = {new Point(1, 2), new Point(3, 4)}; // distinct instances, same fields
+        int hashA = Arrays.hashCode(a);
+        int hashB = Arrays.hashCode(b);
+        if (hashA != hashB) {
+            throw new RuntimeException("testValueClassArrayHashCode: expected equal hash codes " +
+                "for equal value class arrays, got " + hashA + " and " + hashB);
+        }
+        // Consistency with repeated calls (no identity hash interference)
+        if (hashA != Arrays.hashCode(a)) {
+            throw new RuntimeException("testValueClassArrayHashCode: " +
+                "hash code not consistent across repeated calls");
         }
     }
 }

--- a/test/jdk/java/util/Arrays/SetAllTest.java
+++ b/test/jdk/java/util/Arrays/SetAllTest.java
@@ -25,15 +25,17 @@
  * @test
  * @bug 8012650
  * @summary Unit test for setAll, parallelSetAll variants
+ * @library /test/lib
  * @run junit SetAllTest
  */
-
 
 import java.util.Arrays;
 import java.util.function.IntFunction;
 import java.util.function.IntToDoubleFunction;
 import java.util.function.IntToLongFunction;
 import java.util.function.IntUnaryOperator;
+
+import jdk.test.lib.valueclass.AsValueClass;
 
 import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -94,6 +96,24 @@ public class SetAllTest {
         { "fill", 3, fillDouble, new double[] { 3.14, 3.14, 3.14 }}
     };
 
+    @AsValueClass
+    record Point(int x, int y) { }
+
+    private static final IntFunction<Point> toPoint = i -> new Point(i, i * 2);
+    private static final IntFunction<Point> fillPoint = i -> new Point(0, 0);
+    private static final Point[] pr0  = {};
+    private static final Point[] pr1  = { new Point(0, 0) };
+    private static final Point[] pr10 = { new Point(0,0), new Point(1, 2), new Point(2, 4),
+            new Point(3, 6), new Point(4, 8), new Point(5, 10), new Point(6, 12),
+            new Point(7, 14), new Point(8, 16), new Point(9, 18) };
+
+    private Object[][] pointData = new Object[][] {
+            { "empty", 0, toPoint, pr0 },
+            { "one",   1, toPoint, pr1 },
+            { "ten",  10, toPoint, pr10 },
+            { "fill",  3, fillPoint, new Point[] { new Point(0,0), new Point(0,0), new Point(0,0) }}
+    };
+
     public Object[][] stringTests() { return stringData; }
 
     public Object[][] intTests() { return intData; }
@@ -101,6 +121,8 @@ public class SetAllTest {
     public Object[][] longTests() { return longData; }
 
     public Object[][] doubleTests() { return doubleData; }
+
+    public Object[][] pointTests() { return pointData; }
 
     @ParameterizedTest
     @MethodSource("stringTests")
@@ -162,6 +184,18 @@ public class SetAllTest {
         result = new double[size];
         Arrays.parallelSetAll(result, generator);
         assertDoubleArrayEquals(result, expected, 0.05, "setAll(double[], IntToDoubleFunction) case " + name + " failed.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("pointTests")
+    public void testSetAllPoint(String name, int size, IntFunction<Point> generator, Point[] expected) {
+        Point[] result = new Point[size];
+        Arrays.setAll(result, generator);
+        Assertions.assertArrayEquals(expected, result, "setAll(Point[], IntFunction<Point>) case " + name + " failed.");
+
+        result = new Point[size];
+        Arrays.parallelSetAll(result, generator);
+        Assertions.assertArrayEquals(expected, result, "parallelSetAll(Point[], IntFunction<Point>) case " + name + " failed.");
     }
 
     @Test
@@ -274,6 +308,36 @@ public class SetAllTest {
         }
         try {
             Arrays.parallelSetAll(ar, null);
+            fail("Arrays.parallelSetAll(array, null) should throw NPE");
+        } catch (NullPointerException npe) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testPointSetNulls() {
+        Point[] ar = new Point[2];
+
+        try {
+            Arrays.setAll((Point[]) null, (IntFunction<Point>) i -> new Point(i, i));
+            fail("Arrays.setAll(null, foo) should throw NPE");
+        } catch (NullPointerException npe) {
+            // expected
+        }
+        try {
+            Arrays.parallelSetAll((Point[]) null, (IntFunction<Point>) i -> new Point(i, i));
+            fail("Arrays.parallelSetAll(null, foo) should throw NPE");
+        } catch (NullPointerException npe) {
+            // expected
+        }
+        try {
+            Arrays.setAll(ar, (IntFunction<Point>) null);
+            fail("Arrays.setAll(array, null) should throw NPE");
+        } catch (NullPointerException npe) {
+            // expected
+        }
+        try {
+            Arrays.parallelSetAll(ar, (IntFunction<Point>) null);
             fail("Arrays.parallelSetAll(array, null) should throw NPE");
         } catch (NullPointerException npe) {
             // expected

--- a/test/jdk/java/util/Arrays/SetAllTest.java
+++ b/test/jdk/java/util/Arrays/SetAllTest.java
@@ -125,7 +125,7 @@ public class SetAllTest {
 
     public Object[][] pointTests() { return pointData; }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}, size={1}, data={3}")
     @MethodSource("stringTests")
     public void testSetAllString(String name, int size, IntFunction<String> generator, String[] expected) {
         String[] result = new String[size];
@@ -138,7 +138,7 @@ public class SetAllTest {
         Assertions.assertArrayEquals(expected, result, "parallelSetAll(String[], IntFunction<String>) case " + name + " failed.");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}, size={1}, data={3}")
     @MethodSource("intTests")
     public void testSetAllInt(String name, int size, IntUnaryOperator generator, int[] expected) {
         int[] result = new int[size];
@@ -151,7 +151,7 @@ public class SetAllTest {
         Assertions.assertArrayEquals(expected, result, "parallelSetAll(int[], IntUnaryOperator) case " + name + " failed.");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}, size={1}, data={3}")
     @MethodSource("longTests")
     public void testSetAllLong(String name, int size, IntToLongFunction generator, long[] expected) {
         long[] result = new long[size];
@@ -174,7 +174,7 @@ public class SetAllTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}, size={1}, data={3}")
     @MethodSource("doubleTests")
     public void testSetAllDouble(String name, int size, IntToDoubleFunction generator, double[] expected) {
         double[] result = new double[size];
@@ -187,7 +187,7 @@ public class SetAllTest {
         assertDoubleArrayEquals(result, expected, 0.05, "setAll(double[], IntToDoubleFunction) case " + name + " failed.");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}, size={1}, data={3}")
     @MethodSource("pointTests")
     public void testSetAllPoint(String name, int size, IntFunction<Point> generator, Point[] expected) {
         Point[] result = new Point[size];

--- a/test/jdk/java/util/Arrays/SetAllTest.java
+++ b/test/jdk/java/util/Arrays/SetAllTest.java
@@ -38,6 +38,7 @@ import java.util.function.IntUnaryOperator;
 import jdk.test.lib.valueclass.AsValueClass;
 
 import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -318,29 +319,13 @@ public class SetAllTest {
     public void testPointSetNulls() {
         Point[] ar = new Point[2];
 
-        try {
-            Arrays.setAll((Point[]) null, (IntFunction<Point>) i -> new Point(i, i));
-            fail("Arrays.setAll(null, foo) should throw NPE");
-        } catch (NullPointerException npe) {
-            // expected
-        }
-        try {
-            Arrays.parallelSetAll((Point[]) null, (IntFunction<Point>) i -> new Point(i, i));
-            fail("Arrays.parallelSetAll(null, foo) should throw NPE");
-        } catch (NullPointerException npe) {
-            // expected
-        }
-        try {
-            Arrays.setAll(ar, (IntFunction<Point>) null);
-            fail("Arrays.setAll(array, null) should throw NPE");
-        } catch (NullPointerException npe) {
-            // expected
-        }
-        try {
-            Arrays.parallelSetAll(ar, (IntFunction<Point>) null);
-            fail("Arrays.parallelSetAll(array, null) should throw NPE");
-        } catch (NullPointerException npe) {
-            // expected
-        }
+        assertThrows(NullPointerException.class, () -> Arrays.setAll(
+            (Point[]) null, (IntFunction<Point>) i -> new Point(i, i)));
+        assertThrows(NullPointerException.class, () -> Arrays.parallelSetAll(
+            (Point[]) null, (IntFunction<Point>) i -> new Point(i, i)));
+        assertThrows(NullPointerException.class, () -> Arrays.setAll(
+            ar, (IntFunction<Point>) null));
+        assertThrows(NullPointerException.class, () -> Arrays.parallelSetAll(
+            ar, (IntFunction<Point>) null));
     }
 }

--- a/test/jdk/java/util/Arrays/Sorting.java
+++ b/test/jdk/java/util/Arrays/Sorting.java
@@ -23,8 +23,9 @@
 
 /*
  * @test
- * @compile/module=java.base java/util/SortingHelper.java
  * @bug 6880672 6896573 6899694 6976036 7013585 7018258 8003981 8226297
+ * @library /test/lib
+ * @compile/module=java.base java/util/SortingHelper.java
  * @build Sorting
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_arraySort,_arrayPartition Sorting -shortrun
  * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=CompileThresholdScaling,java.util.DualPivotQuicksort::sort,0.0001 Sorting -shortrun
@@ -39,6 +40,8 @@ import java.io.PrintStream;
 import java.util.Comparator;
 import java.util.Random;
 import java.util.SortingHelper;
+
+import jdk.test.lib.valueclass.AsValueClass;
 
 public class Sorting {
 
@@ -70,6 +73,13 @@ public class Sorting {
     private final int[] lengths;
     private Object[] gold;
     private Object[] test;
+
+    @AsValueClass
+    record Point(int x, int y) implements Comparable<Point> {
+        public int compareTo(Point p) {
+            return Integer.compare(x * x + y * y, p.x * p.x + p.y * p.y);
+        }
+    }
 
     public static void main(String[] args) {
         long start = System.currentTimeMillis();
@@ -142,7 +152,26 @@ public class Sorting {
         for (TestRandom random : randoms) {
             testRange(length, random);
             testStability(length, random);
+            testValueClass(length, random);
         }
+    }
+
+    private void testValueClass(int length, TestRandom random) {
+        printTestName("Test value class (Point[])", random, length);
+
+        Point[] points = new Point[length];
+        for (int i = 0; i < length; i++) {
+            points[i] = new Point(random.nextInt(10) - 5, random.nextInt(10) - 5);
+        }
+
+        sortingHelper.sort(points);
+        checkSorted(points);
+
+        Comparator<Point> byXThenY = Comparator.comparingInt(Point::x).thenComparingInt(Point::y);
+        sortingHelper.sort(points, byXThenY);
+        checkSorted(points, byXThenY);
+
+        out.println();
     }
 
     private void testEmptyArray() {
@@ -342,6 +371,22 @@ public class Sorting {
             if (a[i].getKey() > a[i + 1].getKey()) {
                 fail("Array is not sorted at " + i + "-th position: " +
                     a[i].getKey() + " and " + a[i + 1].getKey());
+            }
+        }
+    }
+
+    private void checkSorted(Point[] a) {
+        for (int i = 0; i < a.length - 1; i++) {
+            if (a[i].compareTo(a[i + 1]) > 0) {
+                fail("Point array is not sorted at " + i + "-th position: " + a[i] + " and " + a[i + 1]);
+            }
+        }
+    }
+
+    private void checkSorted(Point[] a, Comparator<Point> c) {
+        for (int i = 0; i < a.length - 1; i++) {
+            if (c.compare(a[i], a[i + 1]) > 0) {
+                fail("Point array is not sorted at " + i + "-th position: " + a[i] + " and " + a[i + 1]);
             }
         }
     }

--- a/test/jdk/java/util/Arrays/StreamAndSpliterator.java
+++ b/test/jdk/java/util/Arrays/StreamAndSpliterator.java
@@ -28,8 +28,9 @@
  * @run junit StreamAndSpliterator
  */
 
-
+import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Spliterators;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,6 +44,11 @@ public class StreamAndSpliterator {
         assertThrowsNPE(() -> Arrays.stream((long[]) null, 0, 0));
         assertThrowsNPE(() -> Arrays.stream((double[]) null, 0, 0));
         assertThrowsNPE(() -> Arrays.stream((String[]) null, 0, 0));
+
+        assertThrowsNPE(() -> Arrays.stream((Integer[]) null, 0, 0));
+        assertThrowsNPE(() -> Arrays.stream((Long[]) null, 0, 0));
+        assertThrowsNPE(() -> Arrays.stream((Optional[]) null, 0, 0));
+        assertThrowsNPE(() -> Arrays.stream((LocalDate[]) null, 0, 0));
     }
 
     @Test
@@ -53,17 +59,32 @@ public class StreamAndSpliterator {
         assertThrowsAIOOB(() -> Arrays.stream(new double[]{}, 1, 0));
         assertThrowsAIOOB(() -> Arrays.stream(new String[]{}, 1, 0));
 
+        assertThrowsAIOOB(() -> Arrays.stream(new Integer[]{}, 1, 0));
+        assertThrowsAIOOB(() -> Arrays.stream(new Long[]{}, 1, 0));
+        assertThrowsAIOOB(() -> Arrays.stream(new Optional[]{}, 1, 0));
+        assertThrowsAIOOB(() -> Arrays.stream(new LocalDate[]{}, 1, 0));
+
         // bad origin
         assertThrowsAIOOB(() -> Arrays.stream(new int[]{}, -1, 0));
         assertThrowsAIOOB(() -> Arrays.stream(new long[]{}, -1, 0));
         assertThrowsAIOOB(() -> Arrays.stream(new double[]{}, -1, 0));
         assertThrowsAIOOB(() -> Arrays.stream(new String[]{}, -1, 0));
 
+        assertThrowsAIOOB(() -> Arrays.stream(new Integer[]{}, -1, 0));
+        assertThrowsAIOOB(() -> Arrays.stream(new Long[]{}, -1, 0));
+        assertThrowsAIOOB(() -> Arrays.stream(new Optional[]{}, -1, 0));
+        assertThrowsAIOOB(() -> Arrays.stream(new LocalDate[]{}, -1, 0));
+
         // bad fence
         assertThrowsAIOOB(() -> Arrays.stream(new int[]{}, 0, 1));
         assertThrowsAIOOB(() -> Arrays.stream(new long[]{}, 0, 1));
         assertThrowsAIOOB(() -> Arrays.stream(new double[]{}, 0, 1));
         assertThrowsAIOOB(() -> Arrays.stream(new String[]{}, 0, 1));
+
+        assertThrowsAIOOB(() -> Arrays.stream(new Integer[]{}, 0, 1));
+        assertThrowsAIOOB(() -> Arrays.stream(new Long[]{}, 0, 1));
+        assertThrowsAIOOB(() -> Arrays.stream(new Optional[]{}, 0, 1));
+        assertThrowsAIOOB(() -> Arrays.stream(new LocalDate[]{}, 0, 1));
     }
 
 
@@ -73,6 +94,11 @@ public class StreamAndSpliterator {
         assertThrowsNPE(() -> Arrays.spliterator((long[]) null, 0, 0));
         assertThrowsNPE(() -> Arrays.spliterator((double[]) null, 0, 0));
         assertThrowsNPE(() -> Arrays.spliterator((String[]) null, 0, 0));
+
+        assertThrowsNPE(() -> Arrays.spliterator((Integer[]) null, 0, 0));
+        assertThrowsNPE(() -> Arrays.spliterator((Long[]) null, 0, 0));
+        assertThrowsNPE(() -> Arrays.spliterator((Optional[]) null, 0, 0));
+        assertThrowsNPE(() -> Arrays.spliterator((LocalDate[]) null, 0, 0));
     }
 
     @Test
@@ -103,6 +129,11 @@ public class StreamAndSpliterator {
         assertThrowsNPE(() -> Spliterators.spliterator((long[]) null, 0, 0, 0));
         assertThrowsNPE(() -> Spliterators.spliterator((double[]) null, 0, 0, 0));
         assertThrowsNPE(() -> Spliterators.spliterator((String[]) null, 0, 0, 0));
+
+        assertThrowsNPE(() -> Spliterators.spliterator((Integer[]) null, 0, 0, 0));
+        assertThrowsNPE(() -> Spliterators.spliterator((Long[]) null, 0, 0, 0));
+        assertThrowsNPE(() -> Spliterators.spliterator((Optional[]) null, 0, 0, 0));
+        assertThrowsNPE(() -> Spliterators.spliterator((LocalDate[]) null, 0, 0, 0));
     }
 
     @Test

--- a/test/jdk/java/util/Arrays/largeMemory/ParallelPrefix.java
+++ b/test/jdk/java/util/Arrays/largeMemory/ParallelPrefix.java
@@ -26,6 +26,7 @@
  * @bug 8014076 8025067
  * @summary unit test for Arrays.ParallelPrefix().
  * @modules java.management jdk.management
+ * @library /test/lib
  * @run junit/othervm -Xms256m -Xmx1024m ParallelPrefix
  */
 
@@ -39,6 +40,8 @@ import java.util.function.LongBinaryOperator;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import com.sun.management.OperatingSystemMXBean;
+
+import jdk.test.lib.valueclass.AsValueClass;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,6 +66,9 @@ public class ParallelPrefix {
     private static final int LARGE_ARRAY_SIZE = 1 << 14;
 
     private static int[] arraySizeCollection;
+
+    @AsValueClass
+    record VInt(int value) {}
 
     @BeforeAll
     public static void setup() {
@@ -142,6 +148,15 @@ public class ParallelPrefix {
         return data;
     }
 
+    public static Object[][] valueSet() {
+        Function<Integer, VInt[]> vIntFunc = size ->
+                IntStream.range(0, size).mapToObj(VInt::new).toArray(VInt[]::new);
+        BinaryOperator<VInt> sumOp = (a, b) -> new VInt(a.value() + b.value());
+        BinaryOperator<VInt> minOp = (a, b) -> a.value() <= b.value() ? a : b;
+        return genericData(vIntFunc,
+                (BinaryOperator<VInt>[]) new BinaryOperator[]{sumOp, minOp});
+    }
+
     @ParameterizedTest
     @MethodSource("intSet")
     public void testParallelPrefixForInt(int[] data, int fromIndex, int toIndex, IntBinaryOperator op) {
@@ -210,6 +225,23 @@ public class ParallelPrefix {
         assertArraysEqual(Arrays.copyOfRange(sequentialResult, fromIndex, toIndex), parallelRangeResult);
     }
 
+    @ParameterizedTest
+    @MethodSource("valueSet")
+    public void testParallelPrefixForValue(VInt[] data, int fromIndex, int toIndex, BinaryOperator<VInt> op) {
+        VInt[] sequentialResult = data.clone();
+        for (int index = fromIndex + 1; index < toIndex; index++) {
+            sequentialResult[index] = op.apply(sequentialResult[index - 1], sequentialResult[index]);
+        }
+
+        VInt[] parallelResult = data.clone();
+        Arrays.parallelPrefix(parallelResult, fromIndex, toIndex, op);
+        assertArraysEqual(parallelResult, sequentialResult);
+
+        VInt[] parallelRangeResult = Arrays.copyOfRange(data, fromIndex, toIndex);
+        Arrays.parallelPrefix(parallelRangeResult, op);
+        assertArraysEqual(parallelRangeResult, Arrays.copyOfRange(sequentialResult, fromIndex, toIndex));
+    }
+
     @Test
     public void testNPEs() {
         // null array
@@ -217,24 +249,28 @@ public class ParallelPrefix {
         assertThrowsNPE(() -> Arrays.parallelPrefix((long []) null, Long::max));
         assertThrowsNPE(() -> Arrays.parallelPrefix((double []) null, Double::max));
         assertThrowsNPE(() -> Arrays.parallelPrefix((String []) null, String::concat));
+        assertThrowsNPE(() -> Arrays.parallelPrefix((VInt[]) null, (a, b) -> new VInt(a.value() + b.value())));
 
         // null array w/ range
         assertThrowsNPE(() -> Arrays.parallelPrefix((int[]) null, 0, 0, Integer::max));
         assertThrowsNPE(() -> Arrays.parallelPrefix((long []) null, 0, 0, Long::max));
         assertThrowsNPE(() -> Arrays.parallelPrefix((double []) null, 0, 0, Double::max));
         assertThrowsNPE(() -> Arrays.parallelPrefix((String []) null, 0, 0, String::concat));
+        assertThrowsNPE(() -> Arrays.parallelPrefix((VInt[]) null, 0, 0, (a, b) -> new VInt(a.value() + b.value())));
 
         // null op
         assertThrowsNPE(() -> Arrays.parallelPrefix(new int[] {}, null));
         assertThrowsNPE(() -> Arrays.parallelPrefix(new long[] {}, null));
         assertThrowsNPE(() -> Arrays.parallelPrefix(new double[] {}, null));
         assertThrowsNPE(() -> Arrays.parallelPrefix(new String[] {}, null));
+        assertThrowsNPE(() -> Arrays.parallelPrefix(new VInt[] {}, (BinaryOperator<VInt>) null));
 
         // null op w/ range
         assertThrowsNPE(() -> Arrays.parallelPrefix(new int[] {}, 0, 0, null));
         assertThrowsNPE(() -> Arrays.parallelPrefix(new long[] {}, 0, 0, null));
         assertThrowsNPE(() -> Arrays.parallelPrefix(new double[] {}, 0, 0, null));
         assertThrowsNPE(() -> Arrays.parallelPrefix(new String[] {}, 0, 0, null));
+        assertThrowsNPE(() -> Arrays.parallelPrefix(new VInt[] {}, 0, 0, (BinaryOperator<VInt>) null));
     }
 
     @Test
@@ -243,6 +279,7 @@ public class ParallelPrefix {
         assertThrowsIAE(() -> Arrays.parallelPrefix(new long[] {}, 1, 0, Long::max));
         assertThrowsIAE(() -> Arrays.parallelPrefix(new double[] {}, 1, 0, Double::max));
         assertThrowsIAE(() -> Arrays.parallelPrefix(new String[] {}, 1, 0, String::concat));
+        assertThrowsIAE(() -> Arrays.parallelPrefix(new VInt[] {}, 1, 0, (a, b) -> new VInt(a.value() + b.value())));
     }
 
     @Test
@@ -252,12 +289,14 @@ public class ParallelPrefix {
         assertThrowsAIOOB(() -> Arrays.parallelPrefix(new long[] {}, -1, 0, Long::max));
         assertThrowsAIOOB(() -> Arrays.parallelPrefix(new double[] {}, -1, 0, Double::max));
         assertThrowsAIOOB(() -> Arrays.parallelPrefix(new String[] {}, -1, 0, String::concat));
+        assertThrowsAIOOB(() -> Arrays.parallelPrefix(new VInt[] {}, -1, 0, (a, b) -> new VInt(a.value() + b.value())));
 
         // bad "toIndex"
         assertThrowsAIOOB(() -> Arrays.parallelPrefix(new int[] {}, 0, 1, Integer::max));
         assertThrowsAIOOB(() -> Arrays.parallelPrefix(new long[] {}, 0, 1, Long::max));
         assertThrowsAIOOB(() -> Arrays.parallelPrefix(new double[] {}, 0, 1, Double::max));
         assertThrowsAIOOB(() -> Arrays.parallelPrefix(new String[] {}, 0, 1, String::concat));
+        assertThrowsAIOOB(() -> Arrays.parallelPrefix(new VInt[] {}, 0, 1, (a, b) -> new VInt(a.value() + b.value())));
     }
 
     // "library" code
@@ -304,6 +343,15 @@ public class ParallelPrefix {
     static void assertArraysEqual(String[] expected, String[] actual) {
         try {
             assertArrayEquals(expected, actual, "");
+        } catch (AssertionError x) {
+            throw new AssertionError(String.format("Expected:%s, actual:%s",
+                    Arrays.toString(expected), Arrays.toString(actual)), x);
+        }
+    }
+
+    static void assertArraysEqual(VInt[] actual, VInt[] expected) {
+        try {
+            assertArrayEquals(actual, expected, "");
         } catch (AssertionError x) {
             throw new AssertionError(String.format("Expected:%s, actual:%s",
                     Arrays.toString(expected), Arrays.toString(actual)), x);


### PR DESCRIPTION
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

**Tests Updated**

**TEST.groups**
Add java/util/Arrays to valhalla_adopted, bringing the Arrays test directory into the Valhalla-adopted test group.

**AsList.java**
Add value-oriented object-array datasets: an @AsValueClass record, boxed Integer, LocalDate, and Optional. This extends the existing iterator contract test to ensure Arrays.asList() behaves the same for value-capable elements, including assertSame on iteration.

**ArrayObjectMethods.java**
Add an @AsValueClass record and extend the random object/nested-object generators so value objects and value-object arrays participate in the existing toString, deepToString, hashCode, deepHashCode, and deepEquals coverage. This broadens mixed-content object-array coverage rather than adding a separate value-only test path.

**ArraysEqCmpTest.java**
Add an @AsValueClass Point type and a corresponding ArrayType<ValuePoints> so the existing Arrays.equals, Arrays.compare, and Arrays.mismatch matrix now runs on value-object arrays too. The object-array same-element tests were also generalized to use the ArrayType abstraction instead of assuming Integer[].

**Big.java**
Add a large-array Point[] path using an @AsValueClass record. This extends the existing huge-array binarySearch and range-sort coverage to value-object arrays.

**CopyMethods.java**
Add Point, LocalDate, and Optional to the reflective copy/copyOfRange test matrix, plus the coercion and cloner wiring needed for those types. This extends the existing generic copy-method framework to value-capable reference types.

**Correct.java**
Add an @AsValueClass Point type plus default-sort and comparator-sort subrange tests for Point[], using the existing “compare against reference sort” approach.

**Fill.java**
Add an @AsValueClass array target and verify existing exception behavior when filling it with the wrong type or with an out-of-bounds range.

**HashCode.java**
Add an @AsValueClass Point test that checks Arrays.hashCode(Point[]) is equal for equal value-object arrays and stable across repeated calls.

**SetAllTest.java**
Add Point[] coverage for Arrays.setAll and Arrays.parallelSetAll, including normal generation cases and the existing null-argument exception checks.

**Sorting.java**
Add an @AsValueClass Point sort path to the main sorting test suite. This extends the existing object-sort coverage to value objects for both natural ordering and comparator ordering.

**StreamAndSpliterator.java**
Extend the existing null-array and bad-range exception tests to additional reference-array types: Integer[], Long[], Optional[], and LocalDate[]. This broadens object-array coverage for Arrays.stream, Arrays.spliterator, and Spliterators.spliterator.

**largeMemory/ParallelPrefix.java**
Add an @AsValueClass VInt type and extend the existing parallelPrefix framework to cover value-object arrays, including normal prefix computation plus NPE/IAE/AIOOBE checks.

**Tests With No Change**

**FloatDoubleOrder.java**
No change -- primitive-only float/double ordering test.

**SortingIntBenchmarkTestJMH.java, SortingLongBenchmarkTestJMH.java**
No change -- primitive-array JMH benchmarks.

**SortingNearlySortedPrimitive.java**
No change -- primitive-only nearly-sorted coverage.

**TimSortStackSize.java, TimSortStackSize2.java**
No change -- TimSort stack-shape regression tests over existing Integer[] inputs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8379694](https://bugs.openjdk.org/browse/JDK-8379694): [lworld] Add value class test coverage to java.util.Arrays (**Task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer) ⚠️ Review applies to [2795a743](https://git.openjdk.org/valhalla/pull/2314/files/2795a743e406fb2470ad03000b5ac3797b963656)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2314/head:pull/2314` \
`$ git checkout pull/2314`

Update a local copy of the PR: \
`$ git checkout pull/2314` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2314`

View PR using the GUI difftool: \
`$ git pr show -t 2314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2314.diff">https://git.openjdk.org/valhalla/pull/2314.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2314#issuecomment-4226993188)
</details>
