### PR TITLE
8381996: [lworld] JNIHandles::is_same_object makes an unsafe Java upcall

### DIFF
--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -291,14 +291,17 @@ bool JNIHandles::is_same_object(jobject handle1, jobject handle2) {
 
   bool ret = obj1 == obj2;
 
-  if (Arguments::is_valhalla_enabled()) {
-    if (!ret && obj1 != nullptr && obj2 != nullptr && obj1->klass() == obj2->klass() && obj1->klass()->is_inline_klass()) {
+  if (!ret && Arguments::is_valhalla_enabled()) {
+    if (obj1 != nullptr && obj2 != nullptr &&
+        obj1->klass() == obj2->klass() && obj1->klass()->is_inline_klass()) {
       // The two references are different, they are not null and they are both inline types,
       // a full substitutability test is required, calling ValueObjectMethods.isSubstitutable()
-      // (similarly to InterpreterRuntime::is_substitutable)
+      // (similarly to InterpreterRuntime::is_substitutable).
+      // The jobjects must be re-resolved as the no-keepalive variants are not safe to use
+      // with the Java upcall.
       JavaThread* THREAD = JavaThread::current();
-      Handle ha(THREAD, obj1);
-      Handle hb(THREAD, obj2);
+      Handle ha(THREAD, resolve_non_null(handle1));
+      Handle hb(THREAD, resolve_non_null(handle2));
       JavaValue result(T_BOOLEAN);
       JavaCallArguments args;
       args.push_oop(ha);


### PR DESCRIPTION
The no-keepalive oops are not safe to use when making the Java upcall for the substitutability test, so we need to re-resolve them.

Minor optimising tweak to the logic to check `!ret` first.

Testing:
  - IsSameObject valhalla tests
  - tiers 1-3 sanity

Thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8381996](https://bugs.openjdk.org/browse/JDK-8381996): [lworld] JNIHandles::is_same_object makes an unsafe Java upcall (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2317/head:pull/2317` \
`$ git checkout pull/2317`

Update a local copy of the PR: \
`$ git checkout pull/2317` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2317`

View PR using the GUI difftool: \
`$ git pr show -t 2317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2317.diff">https://git.openjdk.org/valhalla/pull/2317.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2317#issuecomment-4232965899)
</details>
