### PR TITLE
8382028: [lworld] gc/stress/gcbasher/TestGCBasherWithParallel.java fails with OOME

### DIFF
--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * @requires vm.gc.Parallel
  * @requires vm.flavor == "server"
  * @summary Stress the Parallel GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -XX:+UseParallelGC -XX:-UseGCOverheadLimit gc.stress.gcbasher.TestGCBasherWithParallel 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx384m -XX:+UseParallelGC -XX:-UseGCOverheadLimit gc.stress.gcbasher.TestGCBasherWithParallel 120000
  */
 public class TestGCBasherWithParallel {
     public static void main(String[] args) throws IOException {


### PR DESCRIPTION
Test starts failing after https://bugs.openjdk.org/browse/JDK-8379695 [lworld] Update GCBasher to use value classes

The problem happened during file reading file and converting byte[] to Byte[] because it requires creation of 2 arrays of file length at the same time. 
Verified that TestGCBasherWithParallel.java test pass with -XX:-UseCompressedOops.
The other tests (G1, Serial, ZGC) don't fail.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382028](https://bugs.openjdk.org/browse/JDK-8382028): [lworld] gc/stress/gcbasher/TestGCBasherWithParallel.java fails with OOME (**Bug** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - Committer)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2320/head:pull/2320` \
`$ git checkout pull/2320`

Update a local copy of the PR: \
`$ git checkout pull/2320` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2320`

View PR using the GUI difftool: \
`$ git pr show -t 2320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2320.diff">https://git.openjdk.org/valhalla/pull/2320.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2320#issuecomment-4241255171)
</details>
