### PR TITLE
8382071: [lworld] Print more information at "must constrain OSR typestate" assert

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -192,7 +192,7 @@ Node* Parse::check_interpreter_type(Node* l, const Type* type, const TypeKlassPt
   // TODO 8374475 Remove once this is fixed
 #ifdef ASSERT
   if (!_gvn.type(l)->higher_equal(type)) {
-    l->dump(0);
+    l->dump(10);
     _gvn.type(l)->dump_on(tty);
     tty->cr();
     type->dump_on(tty);

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -189,7 +189,20 @@ Node* Parse::check_interpreter_type(Node* l, const Type* type, const TypeKlassPt
     l = gen_checkcast(l, makecon(klass_type), &bad_type_ctrl, nullptr, false, is_early_larval);
     bad_type_exit->control()->add_req(bad_type_ctrl);
   }
-
+  // TODO 8374475 Remove once this is fixed
+#ifdef ASSERT
+  if (!_gvn.type(l)->higher_equal(type)) {
+    l->dump(0);
+    _gvn.type(l)->dump_on(tty);
+    tty->cr();
+    type->dump_on(tty);
+    tty->cr();
+    if (klass_type != nullptr) {
+      klass_type->dump_on(tty);
+      tty->cr();
+    }
+  }
+#endif
   assert(_gvn.type(l)->higher_equal(type), "must constrain OSR typestate");
   return l;
 }


### PR DESCRIPTION
[JDK-8374475](https://bugs.openjdk.org/browse/JDK-8374475) is extremely intermittent and we were never able to reproduce it. Let's add some more debugging output which will help us diagnose this issue once it shows up again in the CI.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382071](https://bugs.openjdk.org/browse/JDK-8382071): [lworld] Print more information at "must constrain OSR typestate" assert (**Sub-task** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2321/head:pull/2321` \
`$ git checkout pull/2321`

Update a local copy of the PR: \
`$ git checkout pull/2321` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2321`

View PR using the GUI difftool: \
`$ git pr show -t 2321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2321.diff">https://git.openjdk.org/valhalla/pull/2321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2321#issuecomment-4235302600)
</details>
