### PR TITLE
8382189: [lworld] move two ProblemList entries for tests impacted by JDK-8381268

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -61,7 +61,4 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 
 # Valhalla failures start here:
 
-compiler/valhalla/inlinetypes/TestArrays.java#id1 8381268 generic-all
-compiler/valhalla/inlinetypes/TestArrays.java#id5 8381268 generic-all
-
 runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8378071 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -202,6 +202,8 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 compiler/c2/irTests/TestFloat16ScalarOperations.java 8377808 linux-aarch64
 compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
 compiler/c2/TestGVNCrash.java 8381268 generic-all
+compiler/valhalla/inlinetypes/TestArrays.java#id1 8381268 generic-all
+compiler/valhalla/inlinetypes/TestArrays.java#id5 8381268 generic-all
 
 vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java 8375062 windows-x64
 vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java 8375076 windows-x64


### PR DESCRIPTION
A trivial fix to move two ProblemList entries for tests impacted by JDK-8381268.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382189](https://bugs.openjdk.org/browse/JDK-8382189): [lworld] move two ProblemList entries for tests impacted by JDK-8381268 (**Sub-task** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2322/head:pull/2322` \
`$ git checkout pull/2322`

Update a local copy of the PR: \
`$ git checkout pull/2322` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2322`

View PR using the GUI difftool: \
`$ git pr show -t 2322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2322.diff">https://git.openjdk.org/valhalla/pull/2322.diff</a>

</details>
