### PR TITLE
8380525: [lworld] C2: Various issues with abstract value classes leading to bad casts with is_inlinetype()

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1899,7 +1899,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         null_check(val);
 
         ciType* field_type = field->type();
-        if (field_type->is_loaded() && field_type->is_inlinetype() && field->type()->as_inline_klass()->is_empty() &&
+        if (field_type->is_loaded() && field_type->is_inlinetype() && field_type->as_inline_klass()->is_empty() &&
             (!method()->is_class_initializer() || field->is_flat())) {
           // Storing to a field of an empty, null-free inline type that is already initialized. Ignore.
           break;
@@ -2095,7 +2095,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
 
       ciType* field_type = field->type();
       if (field->is_null_free() && field_type->is_loaded() && field_type->is_inlinetype() &&
-          field->type()->as_inline_klass()->is_empty() && (!method()->is_object_constructor() || field->is_flat())) {
+          field_type->as_inline_klass()->is_empty() && (!method()->is_object_constructor() || field->is_flat())) {
         // Storing to a field of an empty, null-free inline type that is already initialized. Ignore.
         null_check(obj);
         null_check(val);
@@ -2111,7 +2111,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       } else {
         // Flat field
         assert(!needs_patching, "Can't patch flat inline type field access");
-        ciInlineKlass* inline_klass = field->type()->as_inline_klass();
+        ciInlineKlass* inline_klass = field_type->as_inline_klass();
         if (field->is_atomic()) {
           if (field->is_null_free()) {
             null_check(val);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1825,8 +1825,8 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
   bool will_link;
   ciField* field = stream()->get_field(will_link);
   ciInstanceKlass* holder = field->holder();
-  BasicType field_type = field->type()->basic_type();
-  ValueType* type = as_ValueType(field_type);
+  BasicType field_basic_type = field->type()->basic_type();
+  ValueType* type = as_ValueType(field_basic_type);
 
   // call will_link again to determine if the field is valid.
   const bool needs_patching = !holder->is_loaded() ||
@@ -1891,16 +1891,19 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       if (state_before == nullptr) {
         state_before = copy_state_for_exception();
       }
-      if (field_type == T_BOOLEAN) {
+      if (field_basic_type == T_BOOLEAN) {
         Value mask = append(new Constant(new IntConstant(1)));
         val = append(new LogicOp(Bytecodes::_iand, val, mask));
       }
       if (field->is_null_free()) {
         null_check(val);
-      }
-      if (field->is_null_free() && field->type()->is_loaded() && field->type()->as_inline_klass()->is_empty() && (!method()->is_class_initializer() || field->is_flat())) {
-        // Storing to a field of an empty, null-free inline type that is already initialized. Ignore.
-        break;
+
+        ciType* field_type = field->type();
+        if (field_type->is_loaded() && field_type->is_inlinetype() && field->type()->as_inline_klass()->is_empty() &&
+            (!method()->is_class_initializer() || field->is_flat())) {
+          // Storing to a field of an empty, null-free inline type that is already initialized. Ignore.
+          break;
+        }
       }
       append(new StoreField(append(obj), offset, field, val, true, state_before, needs_patching));
       break;
@@ -1963,7 +1966,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             assert(replacement->is_linked() || !replacement->can_be_linked(), "should already by linked");
             // Writing an (integer) value to a boolean, byte, char or short field includes an implicit narrowing
             // conversion. Emit an explicit conversion here to get the correct field value after the write.
-            switch (field_type) {
+            switch (field_basic_type) {
             case T_BOOLEAN:
             case T_BYTE:
               replacement = append(new Convert(Bytecodes::_i2b, replacement, type));
@@ -2085,12 +2088,14 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       if (state_before == nullptr) {
         state_before = copy_state_for_exception();
       }
-      if (field_type == T_BOOLEAN) {
+      if (field_basic_type == T_BOOLEAN) {
         Value mask = append(new Constant(new IntConstant(1)));
         val = append(new LogicOp(Bytecodes::_iand, val, mask));
       }
 
-      if (field->is_null_free() && field->type()->is_loaded() && field->type()->as_inline_klass()->is_empty() && (!method()->is_object_constructor() || field->is_flat())) {
+      ciType* field_type = field->type();
+      if (field->is_null_free() && field_type->is_loaded() && field_type->is_inlinetype() &&
+          field->type()->as_inline_klass()->is_empty() && (!method()->is_object_constructor() || field->is_flat())) {
         // Storing to a field of an empty, null-free inline type that is already initialized. Ignore.
         null_check(obj);
         null_check(val);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4218,7 +4218,7 @@ Node* GraphKit::get_layout_helper(Node* klass_node, jint& constant_value) {
     bool xklass = klass_t->klass_is_exact();
     bool can_be_flat = false;
     const TypeAryPtr* ary_type = klass_t->as_instance_type()->isa_aryptr();
-    if (UseArrayFlattening && !xklass && ary_type != nullptr && !ary_type->is_null_free()) {
+    if (UseArrayFlattening && !xklass && ary_type != nullptr) {
       // Don't constant fold if the runtime type might be a flat array but the static type is not.
       const TypeOopPtr* elem = ary_type->elem()->make_oopptr();
       can_be_flat = ary_type->can_be_inline_array() && (!elem->is_inlinetypeptr() || elem->inline_klass()->maybe_flat_in_array());

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -595,9 +595,7 @@ void InlineTypeNode::store(GraphKit* kit, Node* base, Node* ptr, bool immutable_
     Node* field_ptr = kit->basic_plus_adr(base, ptr, field_off);
     if (field->is_flat()) {
       // Recursively store the flat inline type field
-      ciInlineKlass* fvk = ft->as_inline_klass();
       bool atomic = field->is_atomic();
-
       field_val->as_InlineType()->store_flat(kit, base, field_ptr, atomic, immutable_memory, field_null_free, decorators);
     } else {
       // Store field value to memory

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5018,6 +5018,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
     // write barrier. Conservatively, go to slow path.
     // TODO 8251971: Optimize for the case when flat src/dst are later found
     // to not contain oops (i.e., move this check to the macro expansion phase).
+    // TODO 8382226: Revisit for flat abstract value class arrays
     BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
     const TypeAryPtr* orig_t = _gvn.type(original)->isa_aryptr();
     const TypeKlassPtr* tklass = _gvn.type(klass_node)->is_klassptr();

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1550,8 +1550,6 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
 
   RegionNode* slow_region = new RegionNode(1);
   transform_later(slow_region);
-  const bool both_flat = top_src->is_flat() && top_dest->is_flat();
-  const bool both_exact = top_src->klass_is_exact() && top_dest->klass_is_exact();
   const bool same_nullness = top_src->is_null_free() == top_dest->is_null_free();
 
   if (!ac->is_arraycopy_validated()) {
@@ -1593,10 +1591,10 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
 
     // TODO 8350865 This is too strong
     // We need to be careful here because 'adjust_for_flat_array' will adjust offsets/length etc. which then does not work anymore for the slow call to SharedRuntime::slow_arraycopy_C.
-    if (!both_flat || !same_nullness || !both_exact) {
+    assert(top_src->is_flat() == top_dest->is_flat(), "must have bailed out before");
+    if (!(top_src->is_flat() && same_nullness)) {
       // Go to slow path. This could be improved by directly going to the slow_region instead of letting it handle by
       // generate_array_copy(). But we might want to improve the situation in the future.
-      // Note that we also need to make sure to exclude flat abstract value class arrays (i.e. !both_exact).
       generate_flat_array_guard(&ctrl, src, merge_mem, slow_region);
       generate_flat_array_guard(&ctrl, dest, merge_mem, slow_region);
       generate_null_free_array_guard(&ctrl, dest, merge_mem, slow_region);
@@ -1606,7 +1604,8 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // This is where the memory effects are placed:
   const TypePtr* adr_type = nullptr;
   Node* dest_length = (alloc != nullptr) ? alloc->in(AllocateNode::ALength) : nullptr;
-  if (both_flat && same_nullness && both_exact) {
+  assert(top_src->is_flat() == top_dest->is_flat(), "must have bailed out before");
+  if (top_src->is_flat() && same_nullness) {
     adr_type = adjust_for_flat_array(top_dest, src_offset, dest_offset, length, dest_elem, dest_length);
   } else if (ac->_dest_type != TypeOopPtr::BOTTOM) {
     adr_type = ac->_dest_type->add_offset(Type::OffsetBot)->is_ptr();

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1321,7 +1321,7 @@ const TypePtr* PhaseMacroExpand::adjust_for_flat_array(const TypeAryPtr* top_des
                                                        Node*& dest_offset, Node*& length, BasicType& dest_elem,
                                                        Node*& dest_length) {
 #ifdef ASSERT
-  assert(top_dest->elem()->make_ptr()->is_instptr()->is_inlinetypeptr(), "must be value klass");
+  assert(top_dest->elem()->make_ptr()->is_instptr()->is_inlinetypeptr(), "must be concrete value klass");
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bool needs_barriers = top_dest->elem()->inline_klass()->contains_oops() &&
     bs->array_copy_requires_gc_barriers(dest_length != nullptr, T_OBJECT, false, false, BarrierSetC2::Optimization);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1492,22 +1492,27 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // (2) src and dest arrays must have elements of the same BasicType
   // Figure out the size and type of the elements we will be copying.
   //
-  // We have no stub to copy flat value class arrays with oop fields
-  // if we need to emit write barriers. We also cannot use the stub
-  // if we deal with a flat abstract value class array because we
-  // don't know the exact layout. Go to slow path in both cases.
+  //
+  // Go to the slow path but avoid the native method wrapper to JVM_ArrayCopy when:
+  // 1) The component types are not the same or void.
+  // 2) src and dest do not have the same flatness.
+  // 3) src or dest is a flat abstract value class array (we don't know the exact layout and cannot use the stub).
+  // 4) dest is a flat value class array with oop fields and requires to emit write barriers (we don't have such a stub).
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  if (src_elem != dest_elem || top_src->is_flat() != top_dest->is_flat() || dest_elem == T_VOID ||
-      (top_src->is_flat() &&
-       bs->array_copy_requires_gc_barriers(alloc != nullptr, T_OBJECT, false, false, BarrierSetC2::Optimization) &&
-       (!top_dest->elem()->make_ptr()->is_inlinetypeptr() || // Abstract value class
-        top_dest->elem()->inline_klass()->contains_oops()))) {
-    // The component types are not the same or are not recognized.  Punt.
-    // (But, avoid the native method wrapper to JVM_ArrayCopy.)
-    {
-      Node* mem = ac->in(TypeFunc::Memory);
-      merge_mem = generate_slow_arraycopy(ac, &ctrl, mem, &io, TypePtr::BOTTOM, src, src_offset, dest, dest_offset, length, false);
-    }
+  bool go_to_slow_path = src_elem != dest_elem || top_src->is_flat() != top_dest->is_flat() || dest_elem == T_VOID;
+  if ((top_src->is_flat() && !top_src->elem()->is_inlinetypeptr()) ||
+      (top_dest->is_flat() && !top_dest->elem()->is_inlinetypeptr())) {
+    go_to_slow_path = true;
+  } else if (top_dest->is_flat() &&
+             bs->array_copy_requires_gc_barriers(alloc != nullptr, T_OBJECT, false, false, BarrierSetC2::Optimization) &&
+             top_dest->elem()->inline_klass()->contains_oops()) {
+    go_to_slow_path = true;
+  }
+
+  if (go_to_slow_path) {
+    // Avoid the native method wrapper to JVM_ArrayCopy.
+    Node* mem = ac->in(TypeFunc::Memory);
+    merge_mem = generate_slow_arraycopy(ac, &ctrl, mem, &io, TypePtr::BOTTOM, src, src_offset, dest, dest_offset, length, false);
 
     _igvn.replace_node(_callprojs->fallthrough_memproj, merge_mem);
     if (_callprojs->fallthrough_ioproj != nullptr) {

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1559,6 +1559,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   RegionNode* slow_region = new RegionNode(1);
   transform_later(slow_region);
   const bool same_nullness = top_src->is_null_free() == top_dest->is_null_free();
+  const bool flat_and_same_nullness = top_src->is_flat() && same_nullness;
 
   if (!ac->is_arraycopy_validated()) {
     // (3) operands must not be null
@@ -1600,7 +1601,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     // TODO 8350865 This is too strong
     // We need to be careful here because 'adjust_for_flat_array' will adjust offsets/length etc. which then does not work anymore for the slow call to SharedRuntime::slow_arraycopy_C.
     assert(top_src->is_flat() == top_dest->is_flat(), "must have bailed out before");
-    if (!top_src->is_flat() || !same_nullness) {
+    if (!flat_and_same_nullness) {
       generate_flat_array_guard(&ctrl, src, merge_mem, slow_region);
       generate_flat_array_guard(&ctrl, dest, merge_mem, slow_region);
       generate_null_free_array_guard(&ctrl, dest, merge_mem, slow_region);
@@ -1611,7 +1612,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   const TypePtr* adr_type = nullptr;
   Node* dest_length = (alloc != nullptr) ? alloc->in(AllocateNode::ALength) : nullptr;
   assert(top_src->is_flat() == top_dest->is_flat(), "must have bailed out before");
-  if (top_src->is_flat() && same_nullness) {
+  if (flat_and_same_nullness) {
     adr_type = adjust_for_flat_array(top_dest, src_offset, dest_offset, length, dest_elem, dest_length);
   } else if (ac->_dest_type != TypeOopPtr::BOTTOM) {
     adr_type = ac->_dest_type->add_offset(Type::OffsetBot)->is_ptr();

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1592,9 +1592,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     // TODO 8350865 This is too strong
     // We need to be careful here because 'adjust_for_flat_array' will adjust offsets/length etc. which then does not work anymore for the slow call to SharedRuntime::slow_arraycopy_C.
     assert(top_src->is_flat() == top_dest->is_flat(), "must have bailed out before");
-    if (!(top_src->is_flat() && same_nullness)) {
-      // Go to slow path. This could be improved by directly going to the slow_region instead of letting it handle by
-      // generate_array_copy(). But we might want to improve the situation in the future.
+    if (!top_src->is_flat() || !same_nullness) {
       generate_flat_array_guard(&ctrl, src, merge_mem, slow_region);
       generate_flat_array_guard(&ctrl, dest, merge_mem, slow_region);
       generate_null_free_array_guard(&ctrl, dest, merge_mem, slow_region);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1321,10 +1321,11 @@ const TypePtr* PhaseMacroExpand::adjust_for_flat_array(const TypeAryPtr* top_des
                                                        Node*& dest_offset, Node*& length, BasicType& dest_elem,
                                                        Node*& dest_length) {
 #ifdef ASSERT
+  assert(top_dest->elem()->make_ptr()->is_instptr()->is_inlinetypeptr(), "must be value klass");
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bool needs_barriers = top_dest->elem()->inline_klass()->contains_oops() &&
     bs->array_copy_requires_gc_barriers(dest_length != nullptr, T_OBJECT, false, false, BarrierSetC2::Optimization);
-  assert(!needs_barriers || StressReflectiveCode, "Flat arracopy would require GC barriers");
+  assert(!needs_barriers || StressReflectiveCode, "Flat arraycopy would require GC barriers");
 #endif
   int elem_size = top_dest->flat_elem_size();
   if (elem_size >= 8) {
@@ -1491,13 +1492,16 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // (2) src and dest arrays must have elements of the same BasicType
   // Figure out the size and type of the elements we will be copying.
   //
-  // We have no stub to copy flat inline type arrays with oop
-  // fields if we need to emit write barriers.
-  //
+  // We have no stub to copy flat value class arrays with oop fields
+  // if we need to emit write barriers. We also cannot use the stub
+  // if we deal with a flat abstract value class array because we
+  // don't know the exact layout. Go to slow path in both cases.
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   if (src_elem != dest_elem || top_src->is_flat() != top_dest->is_flat() || dest_elem == T_VOID ||
-      (top_src->is_flat() && top_dest->elem()->inline_klass()->contains_oops() &&
-       bs->array_copy_requires_gc_barriers(alloc != nullptr, T_OBJECT, false, false, BarrierSetC2::Optimization))) {
+      (top_src->is_flat() &&
+       bs->array_copy_requires_gc_barriers(alloc != nullptr, T_OBJECT, false, false, BarrierSetC2::Optimization) &&
+       (!top_dest->elem()->make_ptr()->is_inlinetypeptr() || // Abstract value class
+        top_dest->elem()->inline_klass()->contains_oops()))) {
     // The component types are not the same or are not recognized.  Punt.
     // (But, avoid the native method wrapper to JVM_ArrayCopy.)
     {
@@ -1541,6 +1545,9 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
 
   RegionNode* slow_region = new RegionNode(1);
   transform_later(slow_region);
+  const bool both_flat = top_src->is_flat() && top_dest->is_flat();
+  const bool both_exact = top_src->klass_is_exact() && top_dest->klass_is_exact();
+  const bool same_nullness = top_src->is_null_free() == top_dest->is_null_free();
 
   if (!ac->is_arraycopy_validated()) {
     // (3) operands must not be null
@@ -1581,7 +1588,10 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
 
     // TODO 8350865 This is too strong
     // We need to be careful here because 'adjust_for_flat_array' will adjust offsets/length etc. which then does not work anymore for the slow call to SharedRuntime::slow_arraycopy_C.
-    if (!(top_src->is_flat() && top_dest->is_flat() && top_src->is_null_free() == top_dest->is_null_free())) {
+    if (!both_flat || !same_nullness || !both_exact) {
+      // Go to slow path. This could be improved by directly going to the slow_region instead of letting it handle by
+      // generate_array_copy(). But we might want to improve the situation in the future.
+      // Note that we also need to make sure to exclude flat abstract value class arrays (i.e. !both_exact).
       generate_flat_array_guard(&ctrl, src, merge_mem, slow_region);
       generate_flat_array_guard(&ctrl, dest, merge_mem, slow_region);
       generate_null_free_array_guard(&ctrl, dest, merge_mem, slow_region);
@@ -1591,8 +1601,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // This is where the memory effects are placed:
   const TypePtr* adr_type = nullptr;
   Node* dest_length = (alloc != nullptr) ? alloc->in(AllocateNode::ALength) : nullptr;
-  if (top_src->is_flat() && top_dest->is_flat() &&
-      top_src->is_null_free() == top_dest->is_null_free()) {
+  if (both_flat && same_nullness && both_exact) {
     adr_type = adjust_for_flat_array(top_dest, src_offset, dest_offset, length, dest_elem, dest_length);
   } else if (ac->_dest_type != TypeOopPtr::BOTTOM) {
     adr_type = ac->_dest_type->add_offset(Type::OffsetBot)->is_ptr();

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1497,15 +1497,23 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // 1) The component types are not the same or void.
   // 2) src and dest do not have the same flatness.
   // 3) src or dest is a flat abstract value class array (we don't know the exact layout and cannot use the stub).
-  // 4) dest is a flat value class array with oop fields and requires to emit write barriers (we don't have such a stub).
+  // 4) src or dest is a flat value class array with oop fields and requires to emit barriers (we don't have such a stub).
+  // TODO 8251971: This does not handle atomicity. We should probably match on layouts which makes this code easier
+  //               and handles all cases.
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  bool go_to_slow_path = src_elem != dest_elem || top_src->is_flat() != top_dest->is_flat() || dest_elem == T_VOID;
-  if ((top_src->is_flat() && !top_src->elem()->is_inlinetypeptr()) ||
-      (top_dest->is_flat() && !top_dest->elem()->is_inlinetypeptr())) {
+  bool go_to_slow_path = false;
+  if (src_elem != dest_elem || top_src->is_flat() != top_dest->is_flat() || dest_elem == T_VOID) {
+    // 1) and 2)
+    go_to_slow_path = true;
+  } else if ((top_src->is_flat() && !top_src->elem()->is_inlinetypeptr()) ||
+             (top_dest->is_flat() && !top_dest->elem()->is_inlinetypeptr())) {
+    // 3)
     go_to_slow_path = true;
   } else if (top_dest->is_flat() &&
              bs->array_copy_requires_gc_barriers(alloc != nullptr, T_OBJECT, false, false, BarrierSetC2::Optimization) &&
              top_dest->elem()->inline_klass()->contains_oops()) {
+    // 4)
+    assert(top_src->is_flat() && top_src->elem()->inline_klass()->contains_oops(), "must match");
     go_to_slow_path = true;
   }
 

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -168,6 +168,7 @@ void Parse::do_get_xxx(Node* obj, ciField* field) {
   }
   if (ld == nullptr) {
     // Build the resultant type of the load
+    assert(!field->is_flat(), "cannot be flat");
     const Type* type;
     if (is_reference_type(bt)) {
       if (!field_klass->is_loaded()) {
@@ -300,6 +301,7 @@ void Parse::do_put_xxx(Node* obj, ciField* field, bool is_field) {
   }
   if (do_store) {
     // Store the value.
+    assert(!field->is_flat(), "cannot be flat");
     const Type* field_type;
     if (!field->type()->is_loaded()) {
       field_type = TypeInstPtr::BOTTOM;

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -154,16 +154,19 @@ void Parse::do_get_xxx(Node* obj, ciField* field) {
          "slice of address and input slice don't match");
 
   Node* ld = nullptr;
-  if (field->is_null_free() && field_klass->as_inline_klass()->is_empty()) {
-    // Loading from a field of an empty inline type. Just return the default instance.
-    ld = InlineTypeNode::make_all_zero(_gvn, field_klass->as_inline_klass());
-  } else if (field->is_flat()) {
-    // Loading from a flat inline type field.
-    ciInlineKlass* vk = field->type()->as_inline_klass();
-    bool is_immutable = field->is_final() && field->is_strict();
-    bool atomic = field->is_atomic();
-    ld = InlineTypeNode::make_from_flat(this, field_klass->as_inline_klass(), obj, adr, atomic, is_immutable, field->is_null_free(), IN_HEAP | MO_UNORDERED);
-  } else {
+  if (field_klass->is_inlinetype()) { // could also have an abstract value class
+    ciInlineKlass* vk = field_klass->as_inline_klass();
+    if (field->is_null_free() && vk->is_empty()) {
+      // Loading from a field of an empty inline type. Just return the default instance.
+      ld = InlineTypeNode::make_all_zero(_gvn, vk);
+    } else if (field->is_flat()) {
+      // Loading from a flat inline type field.
+      bool is_immutable = field->is_final() && field->is_strict();
+      bool atomic = field->is_atomic();
+      ld = InlineTypeNode::make_from_flat(this, vk, obj, adr, atomic, is_immutable, field->is_null_free(), IN_HEAP | MO_UNORDERED);
+    }
+  }
+  if (ld == nullptr) {
     // Build the resultant type of the load
     const Type* type;
     if (is_reference_type(bt)) {
@@ -273,22 +276,29 @@ void Parse::do_put_xxx(Node* obj, ciField* field, bool is_field) {
 
   // We cannot store into a non-larval object, so obj must not be an InlineTypeNode
   assert(!obj->is_InlineType(), "InlineTypeNodes are non-larval value objects");
-  if (field->is_null_free() && field->type()->as_inline_klass()->is_empty() && (!method()->is_object_constructor() || field->is_flat())) {
-    // Storing to a field of an empty, null-free inline type that is already initialized. Ignore.
-    return;
-  } else if (field->is_flat()) {
-    // Storing to a flat inline type field.
-    ciInlineKlass* vk = field->type()->as_inline_klass();
-    if (!val->is_InlineType()) {
-      assert(gvn().type(val) == TypePtr::NULL_PTR, "Unexpected value");
-      val = InlineTypeNode::make_null(gvn(), vk);
+  ciType* field_klass = field->type();
+  bool do_store = true;
+  if (field_klass->is_inlinetype()) { // could also have an abstract value class
+    ciInlineKlass* vk = field_klass->as_inline_klass();
+    if (field->is_null_free() && vk->is_empty() && (!method()->is_object_constructor() || field->is_flat())) {
+      // Storing to a field of an empty, null-free inline type that is already initialized. Ignore.
+      return;
     }
-    inc_sp(1);
-    bool is_immutable = field->is_final() && field->is_strict();
-    bool atomic = field->is_atomic();
-    val->as_InlineType()->store_flat(this, obj, adr, atomic, is_immutable, field->is_null_free(), IN_HEAP | MO_UNORDERED);
-    dec_sp(1);
-  } else {
+    if (field->is_flat()) {
+      // Storing to a flat inline type field.
+      if (!val->is_InlineType()) {
+        assert(gvn().type(val) == TypePtr::NULL_PTR, "Unexpected value");
+        val = InlineTypeNode::make_null(gvn(), vk);
+      }
+      inc_sp(1);
+      bool is_immutable = field->is_final() && field->is_strict();
+      bool atomic = field->is_atomic();
+      val->as_InlineType()->store_flat(this, obj, adr, atomic, is_immutable, field->is_null_free(), IN_HEAP | MO_UNORDERED);
+      dec_sp(1);
+      do_store = false;
+    }
+  }
+  if (do_store) {
     // Store the value.
     const Type* field_type;
     if (!field->type()->is_loaded()) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -3853,4 +3853,160 @@ public class TestArrays {
     public void test155_verifier() {
         test155((Test151Value[])ValueClass.newNullRestrictedNonAtomicArray(Test151Value.class, 1, Test151Value.DEFAULT));
     }
+
+    @LooselyConsistentValue
+    static abstract value class BadCastA {}
+
+    @LooselyConsistentValue
+    static value class BadCastV1 extends BadCastA {
+        byte a;
+        byte b;
+        byte c;
+        byte d;
+
+        BadCastV1(int i) {
+            a = (byte)i;
+            b = (byte)(i + 1);
+            c = (byte)(i + 2);
+            d = (byte)(i + 3);
+        }
+
+        BadCastV1() {
+            this(1);
+        }
+    }
+
+    @LooselyConsistentValue
+    static value class BadCastV2 extends BadCastA {
+        byte a;
+        byte b;
+        byte c;
+        byte d;
+
+        BadCastV2(int i) {
+            a = (byte)i;
+            b = (byte)(i + 1);
+            c = (byte)(i + 2);
+            d = (byte)(i + 3);
+        }
+
+        BadCastV2() {
+            this(1);
+        }
+    }
+
+    static BadCastV1 badCastv1 = new BadCastV1(11);
+    static BadCastV1 badCastv11 =  new BadCastV1(21);
+    static BadCastV2 badCastv2 =  new BadCastV2(31);
+    static BadCastV2 badCastv22 =  new BadCastV2(41);
+    static int badCastLen = Math.abs(rI) % 10;
+
+    @Test
+    static void testBadCastAbstractArray1(BadCastA[] src, BadCastA[] dst) {
+        System.arraycopy(src, 0, dst, 0, badCastLen);
+    }
+
+    @Test
+    static BadCastA[] testBadCastAbstractArray2(boolean flag, BadCastA[] dst) {
+        BadCastA[] aArr;
+        if (flag) {
+            aArr = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV1.class, badCastLen, badCastv1);
+        } else {
+            aArr = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV2.class, badCastLen, badCastv2);
+        }
+        // aArr is flat and null-free. This wrongly skips a check to set "can_be_flat" in GraphKit::get_layout_helper()
+        // because it relies on the old the assumption that a nullable array is never flat.
+        System.arraycopy(aArr, 0, dst, 0, badCastLen);
+        return aArr;
+    }
+
+    @Test
+    static BadCastA[] testBadCastAbstractArray3(boolean flag,  BadCastA[] src) {
+        BadCastA[] aArr;
+        if (flag) {
+            aArr = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV1.class, badCastLen, badCastv1);
+        } else {
+            aArr = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV2.class, badCastLen, badCastv2);
+        }
+
+        System.arraycopy(src, 0, aArr, 0, badCastLen);
+        return aArr;
+    }
+
+    @Test
+    static BadCastA[] testBadCastAbstractArray4(boolean flag) {
+        BadCastA[] aArr;
+        if (flag) {
+            aArr = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV1.class, badCastLen, badCastv1);
+        } else {
+            aArr = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV2.class, badCastLen, badCastv2);
+        }
+
+        BadCastA[] aArr2;
+        if (flag) {
+            aArr2 = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV1.class, badCastLen, badCastv11);
+        } else {
+            aArr2 = (BadCastA[]) ValueClass.newNullRestrictedNonAtomicArray(BadCastV2.class, badCastLen, badCastv22);
+        }
+
+        System.arraycopy(aArr, 0, aArr2, 0, badCastLen);
+        return aArr2;
+    }
+
+    @Run(test = {"testBadCastAbstractArray1",
+                 "testBadCastAbstractArray2",
+                 "testBadCastAbstractArray3",
+                 "testBadCastAbstractArray4"})
+    @Warmup(0)
+    static void testBadCastAbstractArray_verifier() {
+        boolean flag = true;
+
+        for (int i = 0; i < 10_000; i++) {
+            BadCastA[] arrV1 = resetBadCastV1();
+            BadCastA[] arrV11 = resetBadCastV11();
+            BadCastA[] arrV2 = resetBadCastV2();
+            BadCastA[] arrV22 = resetBadCastV22();
+            testBadCastAbstractArray1(arrV1, arrV11);
+            testBadCastAbstractArray1(arrV2, arrV22);
+            for (int j = 0; j < badCastLen; ++j) {
+                Asserts.assertEQ(arrV1[j], arrV11[j]);
+                Asserts.assertEQ(arrV2[j], arrV22[j]);
+            }
+
+            BadCastA[] dst = flag ? resetBadCastV11() : resetBadCastV22();
+            BadCastA[] src = testBadCastAbstractArray2(flag, dst);
+            dst = flag ? arrV1 : arrV2;
+            for (int j = 0; j < badCastLen; ++j) {
+                Asserts.assertEQ(src[j], dst[j]);
+            }
+
+            src = flag ? resetBadCastV1() : resetBadCastV2();
+            dst = testBadCastAbstractArray3(flag, src);
+            for (int j = 0; j < badCastLen; ++j) {
+                Asserts.assertEQ(src[j], dst[j]);
+            }
+
+            dst = testBadCastAbstractArray4(flag);
+            for (int j = 0; j < badCastLen; ++j) {
+                Asserts.assertEQ(src[j], dst[j]);
+            }
+            flag = !flag;
+        }
+    }
+
+    static BadCastA[] resetBadCastV1() {
+        return (BadCastA[])ValueClass.newNullRestrictedNonAtomicArray(BadCastV1.class, badCastLen, badCastv1);
+    }
+
+    static BadCastA[] resetBadCastV11() {
+        return (BadCastA[])ValueClass.newNullRestrictedNonAtomicArray(BadCastV1.class, badCastLen, badCastv11);
+    }
+
+    static BadCastA[] resetBadCastV2() {
+        return (BadCastA[])ValueClass.newNullRestrictedNonAtomicArray(BadCastV2.class, badCastLen, badCastv2);
+    }
+
+    static BadCastA[] resetBadCastV22() {
+        return (BadCastA[])ValueClass.newNullRestrictedNonAtomicArray(BadCastV2.class, badCastLen, badCastv22);
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -5335,5 +5335,78 @@ public class TestLWorld {
         int v2 = (int) rL;
         Asserts.assertEQ(v1, testScalarReplaceArray(v1, v2));
     }
+
+    static class BadCastWrapperA {
+        static BadCastA a;
+        static BadCastA2 a2 = new BadCastV4();
+    }
+
+    @ForceCompileClassInitializer
+    static value class BadCastV {
+        static int i;
+        @NullRestricted
+        BadCastA a;
+
+        // C1: trigger in access_field() for ByteCodes::_putstatic in <clinit>
+        @NullRestricted
+        static BadCastA2 a2Static = BadCastWrapperA.a2;
+
+        @ForceInline
+        BadCastV() {
+            this.a = BadCastWrapperA.a;
+        }
+    }
+
+    static abstract value class BadCastA {
+        @NullRestricted
+        BadCastA2 a2 = BadCastWrapperA.a2;
+
+        @NullRestricted
+        static BadCastA2 a2Static = BadCastWrapperA.a2;
+    }
+
+    static value class BadCastV1 extends BadCastA {}
+    static value class BadCastV2 extends BadCastA {}
+
+
+    static abstract value class BadCastA2 {}
+
+    static value class BadCastV3 extends BadCastA2 {}
+    static value class BadCastV4 extends BadCastA2 {}
+
+
+    static int loadBadCastV = BadCastV.i; // Load BadCastV
+    static BadCastA aBadCast;
+    static BadCastA2 a2BadCast;
+
+    // Load these classes
+    static BadCastV1 v1BadCast = new BadCastV1();
+    static BadCastV2 v2BadCast = new BadCastV2();
+    static BadCastV3 v3BadCast = new BadCastV3();
+    static BadCastV4 v4BadCast = new BadCastV4();
+
+    @Test
+    static void testBadCastToInlineKlass() {
+        // triggers in do_get_xxx()
+        // 'a2' is null-free and an abstract value class and thus an InstanceKlass -> cannot cast to InlineKlass
+        a2BadCast = aBadCast.a2;
+
+        // C1: trigger in access_field() for ByteCodes::_putfield
+        // C2: triggers in do_set_xxx()
+        // in BadCastV(), we assign 'a' which is null-free and an abstract value class and thus an InstanceKlass
+        // -> cannot cast to InlineKlass
+        new BadCastV();
+    }
+
+    @Run(test = "testBadCastToInlineKlass")
+    @Warmup(0)
+    public static void testBadCastToInlineKlass_verifier() {
+        try {
+            testBadCastToInlineKlass();
+            Asserts.fail("should not reach");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
 }
 


### PR DESCRIPTION
This patch fixes various issues found with abstract value classes where the assumption was that we have a concrete value class but we actually could have an abstract value class as well.

The main issue found is that a concrete value class is represented with an `InlineKlass` while an abstract value class is represented with an `InstanceKlass`. Therefore, we cannot cast the latter to `InlineKlass`. While working on this, I checked all `is_inlinetype()` uses and found more issues. I also found issues around the `Arrays.copyOf/copyOfRange` intrinsic but left it as follow-up work and filed [JDK-8382226](https://bugs.openjdk.org/browse/JDK-8382226) for it. 

Here is a list of fixes included in this patch, together with corresponding tests:
1. `GraphKit::get_layout_helper()`: Wrong old assumption that nullable implies not-flat.
2. Checking whether we have a load/store from/to a field of an empty value class:
a. C1: `GraphBuilder::access_field()`, for static and instance field.
b. C2: `Parse::do_get_xxx()`, for loading
c. C2: `Parse::do_set_xxx()`, for storing
3. `arraycopy` instrinsic: Not bailing out when src or dest is a flat abstract value class array - in this case we don't know the layout. We currently hit an assert due to an invalid cast, assuming concrete value classes when an array is flat.

Additional changes:
- Added some more asserts
- Some small code cleanups

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8380525](https://bugs.openjdk.org/browse/JDK-8380525): [lworld] C2: Various issues with abstract value classes leading to bad casts with is_inlinetype() (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2325/head:pull/2325` \
`$ git checkout pull/2325`

Update a local copy of the PR: \
`$ git checkout pull/2325` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2325`

View PR using the GUI difftool: \
`$ git pr show -t 2325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2325.diff">https://git.openjdk.org/valhalla/pull/2325.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2325#issuecomment-4259550821)
</details>
