### PR TITLE
8382346: Problemlist compiler/print/CompileCommandMemLimit.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -36,6 +36,8 @@
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java      8372605 generic-all
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java       8372605 generic-all
 compiler/stable/TestStableArrayMembars.java                                                      8380921 generic-all
+compiler/print/CompileCommandMemLimit.java#c1_stop                                               8382344 generic-all
+compiler/print/CompileCommandMemLimit.java#c1_crash                                              8382344 generic-all
 
 # Runtime:
 


### PR DESCRIPTION
Problemlist tests failing with --enable-preview with product bits.
They are start failing after adding --enable-preview with product combination in CI. So it is not a regression of some recent fix.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382346](https://bugs.openjdk.org/browse/JDK-8382346): Problemlist compiler/print/CompileCommandMemLimit.java (**Sub-task** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2327/head:pull/2327` \
`$ git checkout pull/2327`

Update a local copy of the PR: \
`$ git checkout pull/2327` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2327`

View PR using the GUI difftool: \
`$ git pr show -t 2327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2327.diff">https://git.openjdk.org/valhalla/pull/2327.diff</a>

</details>
