### PR TITLE
8382027: [lworld] if_acmp nullchecks can produce false positives

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2029,14 +2029,15 @@ void TemplateTable::if_acmp(Condition cc) {
   __ mov(is_inline_type_mask, markWord::inline_type_pattern);
 
   if (Arguments::is_valhalla_enabled()) {
+    // The substitutability test is only necessary if r1 and r0 are not the same...
     __ cmp(r1, r0);
     __ br(Assembler::EQ, (cc == equal) ? taken : not_taken);
 
-    // might be substitutable, test if either r0 or r1 is null
-    __ andr(r2, r0, r1);
-    __ cbz(r2, (cc == equal) ? not_taken : taken);
+    // ... neither are null...
+    __ cbz(r1, (cc == equal) ? not_taken : taken);
+    __ cbz(r0, (cc == equal) ? not_taken : taken);
 
-    // and both are values ?
+    // ...and both are values...
     __ ldr(r2, Address(r1, oopDesc::mark_offset_in_bytes()));
     __ andr(r2, r2, is_inline_type_mask);
     __ ldr(r4, Address(r0, oopDesc::mark_offset_in_bytes()));
@@ -2045,7 +2046,7 @@ void TemplateTable::if_acmp(Condition cc) {
     __ cmp(r2,  is_inline_type_mask);
     __ br(Assembler::NE, (cc == equal) ? not_taken : taken);
 
-    // same value klass ?
+    // ...with the same value klass
     __ load_metadata(r2, r1);
     __ load_metadata(r4, r0);
     __ cmp(r2, r4);

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1605,7 +1605,9 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   // (1) Null check -- if one of the operands is null, the other must not be null (because
   //     the two references are not equal), so they are not substitutable,
   //     FIXME: do null check only if the operand is nullable
-  __ testptr(left, right);
+  __ testptr(left, left);
+  __ jcc(Assembler::zero, L_oops_not_equal);
+  __ testptr(right, right);
   __ jcc(Assembler::zero, L_oops_not_equal);
 
   ciKlass* left_klass = op->left_klass();


### PR DESCRIPTION
Hi all,

This fixes implementation bugs in the interpreter and C1 for `if_acmp<cc>` bytecodes.

The substitutability check that we perform to determine equality of value objects requires that certain conditions have been checked beforehand. Namely, that it's not the same object, neither is null, and both are value objects with the same klass.

At the point of the null-check, it is already clear that the oops are unequal; hence the nullcheck checks `lhs == 0 xor rhs == 0`. Both the AArch64 interpreter and x86 C1 code falsely ANDs the two operands. This can yield false positives if two oops have no set-bit positions in common (e.g., `1010` and `0101`). The operands need to be compared separately; the interpreter for x86 and C1 for AArch64 already does this.

Note that this fix is covered by the many test cases failing in `compiler/valhalla/inlinetypes/`.

Testing: tiers 1-4 on Linux (x64, AArch64), macOS (x64, AArch64), Windows (x64).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382027](https://bugs.openjdk.org/browse/JDK-8382027): [lworld] if_acmp nullchecks can produce false positives (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`
 * Joel Sikström `<jsikstro@openjdk.org>`
 * Stefan Karlsson `<stefank@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2329/head:pull/2329` \
`$ git checkout pull/2329`

Update a local copy of the PR: \
`$ git checkout pull/2329` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2329`

View PR using the GUI difftool: \
`$ git pr show -t 2329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2329.diff">https://git.openjdk.org/valhalla/pull/2329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2329#issuecomment-4267092314)
</details>
