### PR TITLE
8379145: [lworld] Boxing performance regression

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1216,7 +1216,13 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
     }
 
     // Next step is the nullable layouts: they must include a null marker
-    if (UseNullableAtomicValueFlattening || UseNullableNonAtomicValueFlattening) {
+    // Note about the special case of j.l.Double and j.l.Long: the introduction of
+    // the NULLABLE_NON_ATOMIC_FLAT layout caused an increase of the size of their
+    // instances which causes performance regression (see JDK-8379145)
+    // The temporary solution is to simply disable nullable layouts for these classes
+    // until a better fix is implemented (see JDK-8382361).
+    if ((UseNullableAtomicValueFlattening || UseNullableNonAtomicValueFlattening)
+         && _classname != vmSymbols::java_lang_Double() && _classname != vmSymbols::java_lang_Long()) {
       // Looking if there's an empty slot inside the layout that could be used to store a null marker
       LayoutRawBlock* b = _layout->first_field_block();
       assert(b != nullptr, "A concrete value class must have at least one (possible dummy) field");

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1218,7 +1218,7 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
     // Next step is the nullable layouts: they must include a null marker
     // Note about the special case of j.l.Double and j.l.Long: the introduction of
     // the NULLABLE_NON_ATOMIC_FLAT layout caused an increase of the size of their
-    // instances which causes performance regression (see JDK-8379145)
+    // instances which causes performance regression (see JDK-8379145).
     // The temporary solution is to simply disable nullable layouts for these classes
     // until a better fix is implemented (see JDK-8382361).
     if ((UseNullableAtomicValueFlattening || UseNullableNonAtomicValueFlattening)


### PR DESCRIPTION
The addition of the NULLABLE_NON_ATOMIC_FLAT layout forced the addition of a null-marker in all value classes instances, causing a instance size increase for value classes which didn't supported any nullable layout before. This size increase caused some performance regressions which boxing classes Double and Long. This patch temporarily disables the support for the NULLABLE_NON_ATOMIC_FLAT layout in classes Long and Double. A longer term solution will be developed and is tracked by JDK-8382361.

Tested on Mach5: tiers 1-4
Thanks to @dafedafe for measuring the performance with the fix.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8379145](https://bugs.openjdk.org/browse/JDK-8379145): [lworld] Boxing performance regression (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer) ⚠️ Review applies to [70d965da](https://git.openjdk.org/valhalla/pull/2331/files/70d965da2019170f93dd21abf88b418835071f62)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2331/head:pull/2331` \
`$ git checkout pull/2331`

Update a local copy of the PR: \
`$ git checkout pull/2331` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2331`

View PR using the GUI difftool: \
`$ git pr show -t 2331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2331.diff">https://git.openjdk.org/valhalla/pull/2331.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2331#issuecomment-4268303055)
</details>
