### PR TITLE
8381866: [lworld] C2: SIGSEGV in SafePointNode::disconnect_from_root

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3239,6 +3239,9 @@ void Compile::Optimize() {
     // More opportunities to optimize virtual and MH calls.
     // Though it's maybe too late to perform inlining, strength-reducing them to direct calls is still an option.
     process_late_inline_calls_no_inline(igvn);
+    if (failing()) {
+      return;
+    }
     process_inline_types(igvn);
   }
 


### PR DESCRIPTION
This PR prevents a segmentation fault during `Compile::process_inline_types` caused by a missing check for failure.

This was originally spotted on our CI when running `applications/ctw/modules/java_desktop.java` with `StressBailout`, and is reproducible with replay compilation.

Near the end of `Compile::Optimize`, we have:
https://github.com/openjdk/valhalla/blob/f29dba868499db3b1369efee8ea22365efa36849/src/hotspot/share/opto/compile.cpp#L3238-L3243

In `Compile::process_late_inline_calls_no_inline`, we have a `if (failing())  return;` check. When using `StressBailout`, this might trigger a compilation bailout.

Before valhalla this was fine because there is a failure check a few lines after the call to `process_late_inline_calls_no_inline`. Now we also have `process_inline_types(igvn)`, and this can go very wrong if `C->root()` is `nullptr`. Therefore we need a new `if failing()` check before processing the inline types.

I have checked other usages of `process_inline_types` and it seems there is no cause for concern there.

I don't think it's worth it to try to produce a regression test here as it would rely on setting a stress seed and would therefore be very sensitive.

### Testing
- [ ] tier1-3, plus some internal testing

Thank you for reviewing!

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8381866](https://bugs.openjdk.org/browse/JDK-8381866): [lworld] C2: SIGSEGV in SafePointNode::disconnect_from_root (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2332/head:pull/2332` \
`$ git checkout pull/2332`

Update a local copy of the PR: \
`$ git checkout pull/2332` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2332`

View PR using the GUI difftool: \
`$ git pr show -t 2332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2332.diff">https://git.openjdk.org/valhalla/pull/2332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2332#issuecomment-4269077143)
</details>
