### PR TITLE
8374475: [lworld] C2: assert(_gvn.type(l)->higher_equal(type)) failed: must constrain OSR typestate

### DIFF
--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -443,7 +443,7 @@ class Parse : public GraphKit {
 
   // OSR helpers
   Node* fetch_interpreter_state(int index, const Type* type, Node* local_addrs);
-  Node* check_interpreter_type(Node* l, const Type* type, const TypeKlassPtr* klass_type, SafePointNode* &bad_type_exit, bool is_larval);
+  Node* check_interpreter_type(Node* l, ciType* ci_type, SafePointNode* &bad_type_exit);
   void  load_interpreter_state(Node* osr_buf);
 
   // Functions for managing basic blocks:

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -24,6 +24,7 @@
 
 #include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciSignature.hpp"
+#include "ci/ciTypeFlow.hpp"
 #include "compiler/compileLog.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "memory/resourceArea.hpp"
@@ -154,19 +155,18 @@ Node* Parse::fetch_interpreter_state(int index,
 // The type is the type predicted by ciTypeFlow.  Note that it is
 // not a general type, but can only come from Type::get_typeflow_type.
 // The safepoint is a map which will feed an uncommon trap.
-Node* Parse::check_interpreter_type(Node* l, const Type* type, const TypeKlassPtr* klass_type,
-                                    SafePointNode* &bad_type_exit, bool is_early_larval) {
-  const TypeOopPtr* tp = type->isa_oopptr();
+Node* Parse::check_interpreter_type(Node* l, ciType* ci_type, SafePointNode* &bad_type_exit) {
+  ciType* unwrapped_ci_type = ci_type->unwrap();
 
   // TypeFlow may assert null-ness if a type appears unloaded.
-  if (type == TypePtr::NULL_PTR ||
-      (tp != nullptr && !tp->is_loaded())) {
+  if (int(unwrapped_ci_type->basic_type()) == int(ciTypeFlow::StateVector::T_NULL) ||
+      !unwrapped_ci_type->is_loaded()) {
     // Value must be null, not a real oop.
-    Node* chk = _gvn.transform( new CmpPNode(l, null()) );
-    Node* tst = _gvn.transform( new BoolNode(chk, BoolTest::eq) );
+    Node* chk = _gvn.transform(new CmpPNode(l, null()));
+    Node* tst = _gvn.transform(new BoolNode(chk, BoolTest::eq));
     IfNode* iff = create_and_map_if(control(), tst, PROB_MAX, COUNT_UNKNOWN);
-    set_control(_gvn.transform( new IfTrueNode(iff) ));
-    Node* bad_type = _gvn.transform( new IfFalseNode(iff) );
+    set_control(_gvn.transform(new IfTrueNode(iff)));
+    Node* bad_type = _gvn.transform(new IfFalseNode(iff));
     bad_type_exit->control()->add_req(bad_type);
     l = null();
   }
@@ -176,34 +176,27 @@ Node* Parse::check_interpreter_type(Node* l, const Type* type, const TypeKlassPt
   // When paths are cut off, values at later merge points can rise
   // toward more specific classes.  Make sure these specific classes
   // are still in effect.
-  if (tp != nullptr && !tp->is_same_java_type_as(TypeInstPtr::BOTTOM)) {
-    // TypeFlow asserted a specific object type.  Value must have that type.
-    Node* bad_type_ctrl = nullptr;
-    if (tp->is_inlinetypeptr() && !tp->maybe_null()) {
+  if (unwrapped_ci_type->is_klass()) {
+    // TypeFlow asserted a specific object type. Value must have that type.
+    assert(_gvn.type(l) == TypePtr::NULL_PTR || _gvn.type(l)->isa_oopptr(), "must be an oop");
+    if (ci_type->is_null_free()) {
       // Check inline types for null here to prevent checkcast from adding an
       // exception state before the bytecode entry (use 'bad_type_ctrl' instead).
+      Node* bad_type_ctrl = nullptr;
       l = null_check_oop(l, &bad_type_ctrl);
       bad_type_exit->control()->add_req(bad_type_ctrl);
     }
 
+    const TypeKlassPtr* klass_type = TypeKlassPtr::make(unwrapped_ci_type->as_klass(), Type::ignore_interfaces);
+    bool is_early_larval = ci_type->is_early_larval();
+    Node* bad_type_ctrl = nullptr;
     l = gen_checkcast(l, makecon(klass_type), &bad_type_ctrl, nullptr, false, is_early_larval);
     bad_type_exit->control()->add_req(bad_type_ctrl);
+  } else {
+    const Type* type = Type::get_typeflow_type(ci_type);
+    assert(_gvn.type(l)->higher_equal(type), "must match");
   }
-  // TODO 8374475 Remove once this is fixed
-#ifdef ASSERT
-  if (!_gvn.type(l)->higher_equal(type)) {
-    l->dump(10);
-    _gvn.type(l)->dump_on(tty);
-    tty->cr();
-    type->dump_on(tty);
-    tty->cr();
-    if (klass_type != nullptr) {
-      klass_type->dump_on(tty);
-      tty->cr();
-    }
-  }
-#endif
-  assert(_gvn.type(l)->higher_equal(type), "must constrain OSR typestate");
+
   return l;
 }
 
@@ -366,17 +359,22 @@ void Parse::load_interpreter_state(Node* osr_buf) {
 
   assert(osr_block->flow()->jsrs()->size() == 0, "should be no jsrs live at osr point");
   for (index = 0; index < max_locals; index++) {
-    if (stopped())  break;
-    Node* l = local(index);
-    if (l->is_top())  continue;  // nothing here
-    const Type *type = osr_block->local_type_at(index);
-    if (type->isa_oopptr() != nullptr) {
-      if (!live_oops.at(index)) {
-        // skip type check for dead oops
-        continue;
-      }
+    if (stopped()) {
+      break;
     }
-    if (osr_block->flow()->local_type_at(index)->is_return_address()) {
+
+    Node* l = local(index);
+    if (l->is_top()) {
+      continue;
+    }
+
+    ciType* ci_type = osr_block->flow()->local_type_at(index);
+    if (ci_type->unwrap()->is_klass() && !live_oops.at(index)) {
+      // skip type check for dead oops
+      continue;
+    }
+
+    if (ci_type->is_return_address()) {
       // In our current system it's illegal for jsr addresses to be
       // live into an OSR entry point because the compiler performs
       // inlining of jsrs.  ciTypeFlow has a bailout that detect this
@@ -390,27 +388,21 @@ void Parse::load_interpreter_state(Node* osr_buf) {
       // value and the expected type is a constant.
       continue;
     }
-    const TypeKlassPtr* klass_type = nullptr;
-    if (type->isa_oopptr()) {
-      klass_type = TypeKlassPtr::make(osr_block->flow()->local_type_at(index)->unwrap()->as_klass(), Type::ignore_interfaces);
-      klass_type = klass_type->try_improve();
-    }
-    bool is_early_larval = osr_block->flow()->local_type_at(index)->is_early_larval();
-    set_local(index, check_interpreter_type(l, type, klass_type, bad_type_exit, is_early_larval));
+    set_local(index, check_interpreter_type(l, ci_type, bad_type_exit));
   }
 
   for (index = 0; index < sp(); index++) {
-    if (stopped())  break;
-    Node* l = stack(index);
-    if (l->is_top())  continue;  // nothing here
-    const Type* type = osr_block->stack_type_at(index);
-    const TypeKlassPtr* klass_type = nullptr;
-    if (type->isa_oopptr()) {
-      klass_type = TypeKlassPtr::make(osr_block->flow()->stack_type_at(index)->unwrap()->as_klass(), Type::ignore_interfaces);
-      klass_type = klass_type->try_improve();
+    if (stopped()) {
+      break;
     }
-    bool is_early_larval = osr_block->flow()->stack_type_at(index)->is_early_larval();
-    set_stack(index, check_interpreter_type(l, type, klass_type, bad_type_exit, is_early_larval));
+
+    Node* l = stack(index);
+    if (l->is_top()) {
+      continue;
+    }
+
+    ciType* ci_type = osr_block->flow()->stack_type_at(index);
+    set_stack(index, check_interpreter_type(l, ci_type, bad_type_exit));
   }
 
   if (bad_type_exit->control()->req() > 1) {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -188,6 +188,7 @@ Node* Parse::check_interpreter_type(Node* l, ciType* ci_type, SafePointNode* &ba
     }
 
     const TypeKlassPtr* klass_type = TypeKlassPtr::make(unwrapped_ci_type->as_klass(), Type::ignore_interfaces);
+    klass_type = klass_type->try_improve();
     bool is_early_larval = ci_type->is_early_larval();
     Node* bad_type_ctrl = nullptr;
     l = gen_checkcast(l, makecon(klass_type), &bad_type_ctrl, nullptr, false, is_early_larval);


### PR DESCRIPTION
Hi,

The reason for the failure is that, we separately compute the instance type `type`, which is used in the assert, and the klass type `klass_type`, which is used for the check cast, so there is a chance during the computation of `type`, the class has only 1 single concrete subclass, and before the computation of `klass_type`, another subtype is loaded, leading to `klass_type` being the supertype of `type`, which triggers the assert. Computing these 2 in the opposite order likely does not work, either, because we can have concurrent class unloading.

As a result, in this PR, I reworked `check_interpreter_type` to receive a `ciType`, this also helps simplify the implementation, as previously, we needed to obtain the null restriction and larval-ness of the value indirectly, while they are readily available in the `ciType` obtained from `ciTypeFlow`. Trying to keep the assert for every case is cumbersome, and verifying the type right after the check cast seems unnecessary, so I relaxed the assert to only verify the correct kind of value.

Testing:

- [x] tier1-4,valhalla-comp-stress

Please take a look and leave your review, thanks a lot.

---------

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8374475](https://bugs.openjdk.org/browse/JDK-8374475): [lworld] C2: assert(_gvn.type(l)-&gt;higher_equal(type)) failed: must constrain OSR typestate (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2333/head:pull/2333` \
`$ git checkout pull/2333`

Update a local copy of the PR: \
`$ git checkout pull/2333` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2333`

View PR using the GUI difftool: \
`$ git pr show -t 2333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2333.diff">https://git.openjdk.org/valhalla/pull/2333.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2333#issuecomment-4269809406)
</details>
