### PR TITLE
8382398: [lworld] AOTCodeFlags.java fails with  -XX:+AOTAdapterCaching -XX:-AOTStubCaching

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -217,6 +217,11 @@ void AOTCodeCache::initialize() {
     }
   }
 
+  if (AOTAdapterCaching && !AOTStubCaching) {
+    // In Valhalla, adapters can call Stub:forward_exception_stub, so we must enable stub caching
+    FLAG_SET_ERGO(AOTStubCaching, true);
+  }
+
   bool is_dumping = false;
   bool is_using   = false;
   if (CDSConfig::is_dumping_final_static_archive() && CDSConfig::is_dumping_aot_linked_classes()) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -112,6 +112,11 @@ public class AOTCodeFlags {
         // Run only 2 modes (0 - no AOT code, 1 - AOT adapters) until JDK-8357398 is fixed
         for (int mode = 0; mode < 4; mode++) {
             t.setTestMode(mode);
+            if (t.isAdapterCachingOn() && !t.isStubCachingOn()) {
+                // In Valhalla, -XX:+AOTAdapterCaching will ergonomically turn on -XX:+AOTStubCaching, so
+                // no need to test this combination.
+                continue;
+            }
             t.run(new String[] {"AOT", "--two-step-training"});
         }
     }


### PR DESCRIPTION
In Valhalla `--enable-preview` mode, adapters will call `Stub:forward_exception`, so we cannot cache adapters without caching stubs.

Going forward, I think having two options for `AOTAdapterCaching` and `AOTStubCaching` might be too complex. Maybe we should remove these two options altogether have a single options for enabling/disabling the code cache (adapters, stubs and methods).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Errors
&nbsp;⚠️ 8382398 is used in problem lists: [test/hotspot/jtreg/ProblemList-enable-preview.txt]
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8382398](https://bugs.openjdk.org/browse/JDK-8382398): [lworld] AOTCodeFlags.java fails with  -XX:+AOTAdapterCaching -XX:-AOTStubCaching (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2334/head:pull/2334` \
`$ git checkout pull/2334`

Update a local copy of the PR: \
`$ git checkout pull/2334` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2334`

View PR using the GUI difftool: \
`$ git pr show -t 2334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2334.diff">https://git.openjdk.org/valhalla/pull/2334.diff</a>

</details>
