### PR TITLE
8369166: [lworld] Avoid final field barriers at the end of constructors for strict fields

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1648,7 +1648,7 @@ void GraphBuilder::method_return(Value x, bool ignore_return) {
   // The conditions for a memory barrier are described in Parse::do_exits().
   bool need_mem_bar = false;
   if (method()->is_object_constructor() &&
-       (scope()->wrote_final() || scope()->wrote_stable() ||
+       (scope()->wrote_non_strict_final() || scope()->wrote_stable() ||
          (AlwaysSafeConstructors && scope()->wrote_fields()) ||
          (support_IRIW_for_not_multiple_copy_atomic_cpu && scope()->wrote_volatile()))) {
     need_mem_bar = true;
@@ -1855,8 +1855,8 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
     if (field->is_volatile()) {
       scope()->set_wrote_volatile();
     }
-    if (field->is_final()) {
-      scope()->set_wrote_final();
+    if (field->is_final() && !field->is_strict()) {
+      scope()->set_wrote_non_strict_final();
     }
     if (field->is_stable()) {
       scope()->set_wrote_stable();
@@ -2018,7 +2018,9 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                 set_pending_field_access(dfa);
               }
             } else {
-              scope()->set_wrote_final();
+              if (!field->is_strict()) {
+                scope()->set_wrote_non_strict_final();
+              }
               scope()->set_wrote_fields();
               if (has_pending_load_indexed()) {
                 assert(field->is_null_free(), "nullable fields do not support delayed accesses yet");

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -142,7 +142,7 @@ IRScope::IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMe
   _xhandlers          = new XHandlers(method);
   _number_of_locks    = 0;
   _monitor_pairing_ok = method->has_balanced_monitors();
-  _wrote_final        = false;
+  _wrote_non_strict_final = false;
   _wrote_fields       = false;
   _wrote_volatile     = false;
   _wrote_stable       = false;

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -145,7 +145,7 @@ class IRScope: public CompilationResourceObj {
   XHandlers*    _xhandlers;                      // the exception handlers
   int           _number_of_locks;                // the number of monitor lock slots needed
   bool          _monitor_pairing_ok;             // the monitor pairing info
-  bool          _wrote_final;                    // has written final field
+  bool          _wrote_non_strict_final;         // has written non-strict final field
   bool          _wrote_fields;                   // has written fields
   bool          _wrote_volatile;                 // has written volatile field
   bool          _wrote_stable;                   // has written @Stable field
@@ -181,8 +181,8 @@ class IRScope: public CompilationResourceObj {
   void          set_min_number_of_locks(int n)   { if (n > _number_of_locks) _number_of_locks = n; }
   bool          monitor_pairing_ok() const       { return _monitor_pairing_ok; }
   BlockBegin*   start() const                    { return _start; }
-  void          set_wrote_final()                { _wrote_final = true; }
-  bool          wrote_final    () const          { return _wrote_final; }
+  void          set_wrote_non_strict_final()     { _wrote_non_strict_final = true; }
+  bool          wrote_non_strict_final() const   { return _wrote_non_strict_final; }
   void          set_wrote_fields()               { _wrote_fields = true; }
   bool          wrote_fields    () const         { return _wrote_fields; }
   void          set_wrote_volatile()             { _wrote_volatile = true; }

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -351,7 +351,7 @@ class Parse : public GraphKit {
   int           _block_count;   // Number of elements in _blocks.
 
   GraphKit      _exits;         // Record all normal returns and throws here.
-  bool          _wrote_final;   // Did we write a final field?
+  bool          _wrote_non_strict_final; // Did we write a non-strict final field?
   bool          _wrote_volatile;     // Did we write a volatile field?
   bool          _wrote_stable;       // Did we write a @Stable field?
   bool          _wrote_fields;       // Did we write any field?
@@ -392,8 +392,8 @@ class Parse : public GraphKit {
   int           block_count()   const { return _block_count; }
 
   GraphKit&     exits()               { return _exits; }
-  bool          wrote_final() const   { return _wrote_final; }
-  void      set_wrote_final(bool z)   { _wrote_final = z; }
+  bool          wrote_non_strict_final() const { return _wrote_non_strict_final; }
+  void      set_wrote_non_strict_final(bool z) { _wrote_non_strict_final = z; }
   bool          wrote_volatile() const { return _wrote_volatile; }
   void      set_wrote_volatile(bool z) { _wrote_volatile = z; }
   bool          wrote_stable() const  { return _wrote_stable; }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -427,7 +427,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   _method = parse_method;
   _expected_uses = expected_uses;
   _depth = 1 + (caller->has_method() ? caller->depth() : 0);
-  _wrote_final = false;
+  _wrote_non_strict_final = false;
   _wrote_volatile = false;
   _wrote_stable = false;
   _wrote_fields = false;
@@ -1076,7 +1076,7 @@ void Parse::do_exits() {
   // exceptional returns, since they cannot publish normally.
   //
   if ((method()->is_object_constructor() || method()->is_class_initializer()) &&
-       (wrote_final() || wrote_stable() ||
+       (wrote_non_strict_final() || wrote_stable() ||
          (AlwaysSafeConstructors && wrote_fields()) ||
          (support_IRIW_for_not_multiple_copy_atomic_cpu && wrote_volatile()))) {
     Node* recorded_alloc = alloc_with_final_or_stable();

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -329,7 +329,9 @@ void Parse::do_put_xxx(Node* obj, ciField* field, bool is_field) {
     // out of the constructor.
     if (field->is_final() || field->is_stable()) {
       if (field->is_final()) {
-        set_wrote_final(true);
+        if (!field->is_strict()) {
+          set_wrote_non_strict_final(true);
+        }
       }
       if (field->is_stable()) {
         set_wrote_stable(true);

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -328,10 +328,8 @@ void Parse::do_put_xxx(Node* obj, ciField* field, bool is_field) {
     // can insert a memory barrier later on to keep the writes from floating
     // out of the constructor.
     if (field->is_final() || field->is_stable()) {
-      if (field->is_final()) {
-        if (!field->is_strict()) {
-          set_wrote_non_strict_final(true);
-        }
+      if (field->is_final() && !field->is_strict()) {
+        set_wrote_non_strict_final(true);
       }
       if (field->is_stable()) {
         set_wrote_stable(true);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFieldBarriers.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFieldBarriers.java
@@ -38,6 +38,8 @@
  * @run main/othervm compiler.valhalla.inlinetypes.TestStrictFieldBarriers
  * @run main/othervm -Xbatch
  *                   compiler.valhalla.inlinetypes.TestStrictFieldBarriers
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1
+ *                   compiler.valhalla.inlinetypes.TestStrictFieldBarriers
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,java.lang.Object::*init*
  *                   compiler.valhalla.inlinetypes.TestStrictFieldBarriers
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,StrictInitTest$A::*init*

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
@@ -131,15 +131,15 @@ public class TestStrictFinalExitMemBar {
     @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "0",
                   "MemBar(StoreStore|Release).*NonStrictNonFinalHolder::<init>\\s+@ bci:-1", "0"},
         phase = CompilePhase.BEFORE_MATCHING)
-    public static int testNonStrictNonFinalMemBar() {
+    public static int testNonStrictNonFinalNoMemBar() {
         NonStrictNonFinalHolder holder = new NonStrictNonFinalHolder(42);
         sink = holder;
         return holder.x;
     }
 
-    @Run(test = "testNonStrictNonFinalMemBar")
-    public static void testNonStrictNonFinalMemBarRunner() {
-        Asserts.assertEquals(testNonStrictNonFinalMemBar(), 42);
+    @Run(test = "testNonStrictNonFinalNoMemBar")
+    public static void testNonStrictNonFinalNoMemBarRunner() {
+        Asserts.assertEquals(testNonStrictNonFinalNoMemBar(), 42);
     }
 
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
@@ -83,8 +83,8 @@ public class TestStrictFinalExitMemBar {
     }
 
     @Test
-    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "1",
-                  "MemBar(StoreStore|Release).*StrictFinalHolder::<init>\\s+@ bci:-1", "0"},
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "1"},
+        failOn = {"MemBar(StoreStore|Release).*StrictFinalHolder::<init>\\s+@ bci:-1"},
         phase = CompilePhase.BEFORE_MATCHING)
     public static int testStrictFinalNoExitMemBar() {
         StrictFinalHolder holder = new StrictFinalHolder(42);
@@ -98,8 +98,8 @@ public class TestStrictFinalExitMemBar {
     }
 
     @Test
-    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "0",
-                  "MemBar(StoreStore|Release).*NonStrictFinalHolder::<init>\\s+@ bci:-1", "1"},
+    @IR(counts = {"MemBar(StoreStore|Release).*NonStrictFinalHolder::<init>\\s+@ bci:-1", "1"},
+        failOn = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1"},
         phase = CompilePhase.BEFORE_MATCHING)
     public static int testNonStrictFinalHasExitMemBar() {
         NonStrictFinalHolder holder = new NonStrictFinalHolder(42);
@@ -113,8 +113,8 @@ public class TestStrictFinalExitMemBar {
     }
 
     @Test
-    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "1",
-                  "MemBar(StoreStore|Release).*StrictNonFinalHolder::<init>\\s+@ bci:-1", "0"},
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "1"},
+        failOn = {"MemBar(StoreStore|Release).*StrictNonFinalHolder::<init>\\s+@ bci:-1"},
         phase = CompilePhase.BEFORE_MATCHING)
     public static int testStrictNonFinalNoExitMemBar() {
         StrictNonFinalHolder holder = new StrictNonFinalHolder(42);
@@ -128,8 +128,8 @@ public class TestStrictFinalExitMemBar {
     }
 
     @Test
-    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "0",
-                  "MemBar(StoreStore|Release).*NonStrictNonFinalHolder::<init>\\s+@ bci:-1", "0"},
+    @IR(failOn = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1",
+                  "MemBar(StoreStore|Release).*NonStrictNonFinalHolder::<init>\\s+@ bci:-1"},
         phase = CompilePhase.BEFORE_MATCHING)
     public static int testNonStrictNonFinalNoMemBar() {
         NonStrictNonFinalHolder holder = new NonStrictNonFinalHolder(42);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
@@ -63,8 +63,8 @@ public class TestStrictFinalExitMemBar {
     }
 
     @Test
-    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>", "1",
-                  "MemBar(StoreStore|Release).*StrictFinalHolder::<init>", "0"},
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "1",
+                  "MemBar(StoreStore|Release).*StrictFinalHolder::<init>\\s+@ bci:-1", "0"},
         phase = CompilePhase.BEFORE_MATCHING)
     public static int testStrictFinalNoExitMemBar() {
         StrictFinalHolder holder = new StrictFinalHolder(42);
@@ -78,8 +78,8 @@ public class TestStrictFinalExitMemBar {
     }
 
     @Test
-    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>", "1",
-                  "MemBar(StoreStore|Release).*NonStrictFinalHolder::<init>", "2"},
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "0",
+                  "MemBar(StoreStore|Release).*NonStrictFinalHolder::<init>\\s+@ bci:-1", "1"},
         phase = CompilePhase.BEFORE_MATCHING)
     public static int testNonStrictFinalHasExitMemBar() {
         NonStrictFinalHolder holder = new NonStrictFinalHolder(42);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
@@ -28,9 +28,9 @@
  * @library /test/lib /
  * @requires vm.compiler2.enabled
  * @enablePreview
- * @compile TestStrictFinalExitMemBarIR.java
+ * @compile TestStrictFinalExitMemBar.java
  * @run driver jdk.test.lib.helpers.StrictProcessor
- *             compiler.valhalla.inlinetypes.TestStrictFinalExitMemBarIR$StrictFinalHolder
+ *             compiler.valhalla.inlinetypes.TestStrictFinalExitMemBar$StrictFinalHolder
  * @run main ${test.main.class}
  */
 
@@ -40,7 +40,7 @@ import compiler.lib.ir_framework.*;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.helpers.StrictInit;
 
-public class TestStrictFinalExitMemBarIR {
+public class TestStrictFinalExitMemBar {
     static Object sink;
 
     static class StrictFinalHolder {
@@ -93,6 +93,6 @@ public class TestStrictFinalExitMemBarIR {
     }
 
     public static void main(String[] args) {
-        TestFramework.run();
+        TestFramework.runWithFlags("--enable-preview");
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBar.java
@@ -31,6 +31,7 @@
  * @compile TestStrictFinalExitMemBar.java
  * @run driver jdk.test.lib.helpers.StrictProcessor
  *             compiler.valhalla.inlinetypes.TestStrictFinalExitMemBar$StrictFinalHolder
+ *             compiler.valhalla.inlinetypes.TestStrictFinalExitMemBar$StrictNonFinalHolder
  * @run main ${test.main.class}
  */
 
@@ -57,6 +58,25 @@ public class TestStrictFinalExitMemBar {
         final int x;
 
         NonStrictFinalHolder(int x) {
+            this.x = x;
+            super();
+        }
+    }
+
+    static class StrictNonFinalHolder {
+        @StrictInit
+        int x;
+
+        StrictNonFinalHolder(int x) {
+            this.x = x;
+            super();
+        }
+    }
+
+    static class NonStrictNonFinalHolder {
+        int x;
+
+        NonStrictNonFinalHolder(int x) {
             this.x = x;
             super();
         }
@@ -90,6 +110,36 @@ public class TestStrictFinalExitMemBar {
     @Run(test = "testNonStrictFinalHasExitMemBar")
     public static void testNonStrictFinalHasExitMemBarRunner() {
         Asserts.assertEquals(testNonStrictFinalHasExitMemBar(), 42);
+    }
+
+    @Test
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "1",
+                  "MemBar(StoreStore|Release).*StrictNonFinalHolder::<init>\\s+@ bci:-1", "0"},
+        phase = CompilePhase.BEFORE_MATCHING)
+    public static int testStrictNonFinalNoExitMemBar() {
+        StrictNonFinalHolder holder = new StrictNonFinalHolder(42);
+        sink = holder;
+        return holder.x;
+    }
+
+    @Run(test = "testStrictNonFinalNoExitMemBar")
+    public static void testStrictNonFinalNoExitMemBarRunner() {
+        Asserts.assertEquals(testStrictNonFinalNoExitMemBar(), 42);
+    }
+
+    @Test
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>\\s+@ bci:-1", "0",
+                  "MemBar(StoreStore|Release).*NonStrictNonFinalHolder::<init>\\s+@ bci:-1", "0"},
+        phase = CompilePhase.BEFORE_MATCHING)
+    public static int testNonStrictNonFinalMemBar() {
+        NonStrictNonFinalHolder holder = new NonStrictNonFinalHolder(42);
+        sink = holder;
+        return holder.x;
+    }
+
+    @Run(test = "testNonStrictNonFinalMemBar")
+    public static void testNonStrictNonFinalMemBarRunner() {
+        Asserts.assertEquals(testNonStrictNonFinalMemBar(), 42);
     }
 
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBarIR.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStrictFinalExitMemBarIR.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8369166
+ * @summary Verify constructor exit barriers are emitted for non-strict finals but not for strict finals.
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @enablePreview
+ * @compile TestStrictFinalExitMemBarIR.java
+ * @run driver jdk.test.lib.helpers.StrictProcessor
+ *             compiler.valhalla.inlinetypes.TestStrictFinalExitMemBarIR$StrictFinalHolder
+ * @run main ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.helpers.StrictInit;
+
+public class TestStrictFinalExitMemBarIR {
+    static Object sink;
+
+    static class StrictFinalHolder {
+        @StrictInit
+        final int x;
+
+        StrictFinalHolder(int x) {
+            this.x = x;
+            super();
+        }
+    }
+
+    static class NonStrictFinalHolder {
+        final int x;
+
+        NonStrictFinalHolder(int x) {
+            this.x = x;
+            super();
+        }
+    }
+
+    @Test
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>", "1",
+                  "MemBar(StoreStore|Release).*StrictFinalHolder::<init>", "0"},
+        phase = CompilePhase.BEFORE_MATCHING)
+    public static int testStrictFinalNoExitMemBar() {
+        StrictFinalHolder holder = new StrictFinalHolder(42);
+        sink = holder;
+        return holder.x;
+    }
+
+    @Run(test = "testStrictFinalNoExitMemBar")
+    public static void testStrictFinalNoExitMemBarRunner() {
+        Asserts.assertEquals(testStrictFinalNoExitMemBar(), 42);
+    }
+
+    @Test
+    @IR(counts = {"MemBar(StoreStore|Release).*Object::<init>", "1",
+                  "MemBar(StoreStore|Release).*NonStrictFinalHolder::<init>", "2"},
+        phase = CompilePhase.BEFORE_MATCHING)
+    public static int testNonStrictFinalHasExitMemBar() {
+        NonStrictFinalHolder holder = new NonStrictFinalHolder(42);
+        sink = holder;
+        return holder.x;
+    }
+
+    @Run(test = "testNonStrictFinalHasExitMemBar")
+    public static void testNonStrictFinalHasExitMemBarRunner() {
+        Asserts.assertEquals(testNonStrictFinalHasExitMemBar(), 42);
+    }
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+}


### PR DESCRIPTION
[JDK-8367785](https://bugs.openjdk.org/browse/JDK-8367785) added a barrier to the beginning of `java.lang.Object::<init>` for _strict_ fields.

If the field is _strict_ **and** _final_, we will also add barriers to the end of the constructors.
C1:
https://github.com/openjdk/valhalla/blob/274d56076260a490ed52df29373216617ddf73ef/src/hotspot/share/c1/c1_GraphBuilder.cpp#L1645-L1652
C2:
https://github.com/openjdk/valhalla/blob/274d56076260a490ed52df29373216617ddf73ef/src/hotspot/share/opto/parse1.cpp#L1092-L1099

In that specific case the _final_ barrier can be omitted because the object can only escape after `java.lang.Object::<init>` for strict fields.

So, this change narrows the constructor exit barrier condition to non-strict instance final writes only. In C2, the `do_exits()` decision now uses `wrote_non_strict_final`, and that flag is set only for final stores where `!field->is_strict()`. The same condition is mirrored in C1 by tracking `wrote_non_strict_final` in IRScope and using it in `GraphBuilder::method_return`.

## Testing
* added C2 IR test that checks that strict-final constructors do not get a constructor exit barrier, while non-strict final constructors still do
* added C1 test run (to `TestStrictFinalBarriers.java`) to exercise constructor strict-field barrier behaviour
* Tier 1-3+

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8369166](https://bugs.openjdk.org/browse/JDK-8369166): [lworld] Avoid final field barriers at the end of constructors for strict fields (**Enhancement** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer) ⚠️ Review applies to [63552279](https://git.openjdk.org/valhalla/pull/2336/files/635522795445509dba6742ba95f4e3a390d5adf9)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2336/head:pull/2336` \
`$ git checkout pull/2336`

Update a local copy of the PR: \
`$ git checkout pull/2336` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2336`

View PR using the GUI difftool: \
`$ git pr show -t 2336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2336.diff">https://git.openjdk.org/valhalla/pull/2336.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2336#issuecomment-4282236421)
</details>
