### PR TITLE
8382421: [lworld] g1StoreLSpecialOneOopOff4 pass wrong new_value to post barrier

### DIFF
--- a/src/hotspot/cpu/x86/gc/g1/g1_x86_64.ad
+++ b/src/hotspot/cpu/x86/gc/g1/g1_x86_64.ad
@@ -157,7 +157,7 @@ instruct g1StoreLSpecialOneOopOff4(memory mem, rRegL src, immI_4 off, rRegP tmp1
     __ decode_heap_oop($tmp2$$Register);
     write_barrier_post(masm, this,
                        $tmp1$$Register /* store_addr */,
-                       $src$$Register /* new_val */,
+                       $tmp2$$Register /* new_val */,
                        $tmp3$$Register /* tmp1 */);
   %}
   ins_pipe(ialu_mem_reg);


### PR DESCRIPTION
This PR addresses a wrong register being passed to the G1 post barrier in `g1StoreLSpecialOneOopOff4`.

This is a typo, as the current code extracts the 4 bytes that contain a narrowOop, decodes them into a full oop in `tmp2`, and then does not use them. Instead, the 8 byte value payload is passed as the `new_value` oop.

**Testing:** tiers 1-3, compiler stress tests

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382421](https://bugs.openjdk.org/browse/JDK-8382421): [lworld] g1StoreLSpecialOneOopOff4 pass wrong new_value to post barrier (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2337/head:pull/2337` \
`$ git checkout pull/2337`

Update a local copy of the PR: \
`$ git checkout pull/2337` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2337`

View PR using the GUI difftool: \
`$ git pr show -t 2337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2337.diff">https://git.openjdk.org/valhalla/pull/2337.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2337#issuecomment-4279239715)
</details>
