### PR TITLE
8376514: [lworld] VarHandleTestMethodHandleAccessValue.java fails in fastdebug

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -813,7 +813,6 @@ tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java 83
 
 # Valhalla failures start here:
 
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java 8376514 generic-all # debug only
 java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java 8375778 macosx-aarch64
 
 sun/tools/jhsdb/JStackStressTest.java 8247940 macosx-aarch64


### PR DESCRIPTION
Unproblemlist VarHandleTestMethodHandleAccessValue because it no longer reproduces. Thanks @anton-seoane for confirming.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8376514](https://bugs.openjdk.org/browse/JDK-8376514): [lworld] VarHandleTestMethodHandleAccessValue.java fails in fastdebug (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - no project role)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Contributors
 * Anton Seoane Ampudia `<aseoane@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2341/head:pull/2341` \
`$ git checkout pull/2341`

Update a local copy of the PR: \
`$ git checkout pull/2341` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2341`

View PR using the GUI difftool: \
`$ git pr show -t 2341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2341.diff">https://git.openjdk.org/valhalla/pull/2341.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2341#issuecomment-4282483540)
</details>
