### PR TITLE
8381653: [lworld] tools/javac/processing/model/element/TestValueClasses.java fails post jdk-27+16

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -89,4 +89,3 @@ tools/javap/output/RepeatingTypeAnnotations.java                                
 #############################################################################
 
 # Valhalla failures start here:
-tools/javac/processing/model/element/TestValueClasses.java 8381653 generic-all


### PR DESCRIPTION
Unproblemlist TestValueClasses because its fix has been merged into lworld in a recent sync of jdk-27+18.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8381653](https://bugs.openjdk.org/browse/JDK-8381653): [lworld] tools/javac/processing/model/element/TestValueClasses.java fails post jdk-27+16 (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2342/head:pull/2342` \
`$ git checkout pull/2342`

Update a local copy of the PR: \
`$ git checkout pull/2342` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2342`

View PR using the GUI difftool: \
`$ git pr show -t 2342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2342.diff">https://git.openjdk.org/valhalla/pull/2342.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2342#issuecomment-4282498940)
</details>
