### PR TITLE
8382541: [lworld] Remove com/sun/jdi/EATests.java#id0 from ProblemList with --enable-preview

### DIFF
--- a/test/jdk/ProblemList-enable-preview.txt
+++ b/test/jdk/ProblemList-enable-preview.txt
@@ -31,4 +31,3 @@
 #############################################################################
 
 # Valhalla failures start here:
-com/sun/jdi/EATests.java#id0                                       8372831 generic-all


### PR DESCRIPTION
[JDK-8381609](https://bugs.openjdk.org/browse/JDK-8381609) in mainline has addressed this issue and has now been merged into valhalla. The test no longer needs to be problem listed.

Tested with tier1 CI, including running with --enable-preview.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382541](https://bugs.openjdk.org/browse/JDK-8382541): [lworld] Remove com/sun/jdi/EATests.java#id0 from ProblemList with --enable-preview (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2343/head:pull/2343` \
`$ git checkout pull/2343`

Update a local copy of the PR: \
`$ git checkout pull/2343` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2343`

View PR using the GUI difftool: \
`$ git pr show -t 2343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2343.diff">https://git.openjdk.org/valhalla/pull/2343.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2343#issuecomment-4282792567)
</details>
