### PR TITLE
8382560: [lworld] Unsafe access to klass name in SystemDictionary::try_preload_from_loadable_descriptors

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1164,7 +1164,7 @@ void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, 
                                   "(cause: field type in LoadableDescriptors attribute) failed : "
                                   "app substituted a different version of %s",
                                   name->as_C_string(), ik->name()->as_C_string(),
-                                  k->name()->as_C_string());
+                                  name->as_C_string());
       return;
     } else if (real_k != nullptr) {
       log_info(class, preload)("Preloading of class %s during loading of shared class %s "

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1128,9 +1128,8 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
     // oops, the app has substituted a different version of k! Does not fail fatally
     log_info(class, preload)("Preloading of class %s during loading of shared class %s "
                                 "(cause: null-free non-static field) failed : "
-                                "app substituted a different version of %s",
-                                name->as_C_string(), ik->name()->as_C_string(),
-                                name->as_C_string());
+                                "app substituted a different version",
+                                name->as_C_string(), ik->name()->as_C_string());
     return false;
   }
   log_info(class, preload)("Preloading of class %s during loading of shared class %s "
@@ -1162,9 +1161,8 @@ void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, 
       // oops, the app has substituted a different version of k!
       log_info(class, preload)("Preloading of class %s during loading of shared class %s "
                                   "(cause: field type in LoadableDescriptors attribute) failed : "
-                                  "app substituted a different version of %s",
-                                  name->as_C_string(), ik->name()->as_C_string(),
-                                  name->as_C_string());
+                                  "app substituted a different version",
+                                  name->as_C_string(), ik->name()->as_C_string());
       return;
     } else if (real_k != nullptr) {
       log_info(class, preload)("Preloading of class %s during loading of shared class %s "

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1127,9 +1127,9 @@ bool SystemDictionary::preload_from_null_free_field(InstanceKlass* ik, Handle cl
   if (real_k != k) {
     // oops, the app has substituted a different version of k! Does not fail fatally
     log_info(class, preload)("Preloading of class %s during loading of shared class %s "
-                                "(cause: null-free non-static field) failed : "
-                                "app substituted a different version",
-                                name->as_C_string(), ik->name()->as_C_string());
+                             "(cause: null-free non-static field) failed : "
+                             "app substituted a different version",
+                             name->as_C_string(), ik->name()->as_C_string());
     return false;
   }
   log_info(class, preload)("Preloading of class %s during loading of shared class %s "
@@ -1160,9 +1160,9 @@ void SystemDictionary::try_preload_from_loadable_descriptors(InstanceKlass* ik, 
     if (real_k != k) {
       // oops, the app has substituted a different version of k!
       log_info(class, preload)("Preloading of class %s during loading of shared class %s "
-                                  "(cause: field type in LoadableDescriptors attribute) failed : "
-                                  "app substituted a different version",
-                                  name->as_C_string(), ik->name()->as_C_string());
+                               "(cause: field type in LoadableDescriptors attribute) failed : "
+                               "app substituted a different version",
+                               name->as_C_string(), ik->name()->as_C_string());
       return;
     } else if (real_k != nullptr) {
       log_info(class, preload)("Preloading of class %s during loading of shared class %s "


### PR DESCRIPTION
Hello,

When looking at the usages of `InstanceKlass::get_inline_type_field_klass_or_null` I saw that `SystemDictionary::try_preload_from_loadable_descriptors` uses the returned value even though it may be null, which can result in a SIGSGV. This change aligns well with what is done just above in `SystemDictionary::preload_from_null_free_field`, using the local variable `name` instead of getting the name from the klass.

Given the right conditions this will result in a crash, but it seems rare as it requires "the stars to be aligned just right" for it to happen.

I'm not sure how much testing testing there is for classes which have inlined and non-inlined fields in them in connection to the code being changed. Such classes would result in an inline_layout_info_array having null-entires, since it is a sparse array.

Testing:
* Oracle's tier1-3
* Testing with a local reproducer that this does not crash with the changes

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382560](https://bugs.openjdk.org/browse/JDK-8382560): [lworld] Unsafe access to klass name in SystemDictionary::try_preload_from_loadable_descriptors (**Bug** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [22f68cb2](https://git.openjdk.org/valhalla/pull/2344/files/22f68cb2d24ae2aab057093e9223a4cc98a4adfc)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2344/head:pull/2344` \
`$ git checkout pull/2344`

Update a local copy of the PR: \
`$ git checkout pull/2344` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2344`

View PR using the GUI difftool: \
`$ git pr show -t 2344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2344.diff">https://git.openjdk.org/valhalla/pull/2344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2344#issuecomment-4287824004)
</details>
