### PR TITLE
8382583: [lworld] ProblemList serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation on linux-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -210,6 +210,8 @@ compiler/valhalla/inlinetypes/TestIntrinsics.java#id4       8382504 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id5       8382504 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id6       8382504 generic-all
 
+serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8382548 linux-aarch64
+
 vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java 8375062 windows-x64
 vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java 8375076 windows-x64
 


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation on linux-aarch64.




---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382583](https://bugs.openjdk.org/browse/JDK-8382583): [lworld] ProblemList serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation on linux-aarch64 (**Sub-task** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2345/head:pull/2345` \
`$ git checkout pull/2345`

Update a local copy of the PR: \
`$ git checkout pull/2345` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2345`

View PR using the GUI difftool: \
`$ git pr show -t 2345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2345.diff">https://git.openjdk.org/valhalla/pull/2345.diff</a>

</details>
