### PR TITLE
8382603: [lworld] [jittester] Add Value Classes support in generated tests

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,7 @@ public class ProductionParams {
     public static Option<Boolean> enableFinalizers = null;
     // workaraound: to reduce chance throwing ArrayIndexOutOfBoundsException
     public static Option<Integer> chanceExpressionIndex = null;
+    public static Option<Integer> identityValueClassBalance = null;
     public static Option<String> testbaseDir = null;
     public static Option<String> tempDir = null;
     public static Option<Integer> numberOfTests = null;
@@ -129,6 +130,7 @@ public class ProductionParams {
         disableArrays = optionResolver.addBooleanOption("disable-arrays", "Disable generation of arrays");
         enableFinalizers = optionResolver.addBooleanOption("enable-finalizers", "Enable finalizers (for stress testing)");
         chanceExpressionIndex = optionResolver.addIntegerOption("chance-expression-index", 0, "A non negative decimal integer used to restrict chane of generating expression in array index while creating or accessing by index");
+        identityValueClassBalance = optionResolver.addIntegerOption("identity-value-class-balance", 80, "Balance (0..100) between identity and value class generation: 0=identity only, 50=equal, 100=value only");
         testbaseDir = optionResolver.addStringOption("testbase-dir", ".", "Testbase dir");
         tempDir = optionResolver.addStringOption("temp-dir", ".", "Temp dir path");
         numberOfTests = optionResolver.addIntegerOption('n', "number-of-tests", 0, "Number of test classes to generate");

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TestsGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TestsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,6 +174,7 @@ public abstract class TestsGenerator implements Consumer<IRTreeGenerator.Test> {
         String parents = type.getParentsNames().stream().collect(Collectors.joining(","));
         result.append(type.isAbstract() ? "abstract " : "")
               .append(type.isFinal() ? "final " : "")
+              .append(type.isValueKlass() ? "value " : "")
               .append(type.isInterface() ? "interface " : "class ")
               .append(type.getName())
               .append(parents.isEmpty() ? "" : ": " + parents);

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/classes/ValueKlass.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/classes/ValueKlass.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester.classes;
+
+import java.util.ArrayList;
+
+import jdk.test.lib.jittester.IRNode;
+import jdk.test.lib.jittester.types.TypeKlass;
+import jdk.test.lib.jittester.visitors.Visitor;
+
+
+/**
+ * A simple POJO representing Value Class in the AST.
+ */
+public class ValueKlass extends Klass {
+
+    /** Creates a ValueKlass AST node.
+     *
+     * @param thisKlass this class' TypeClass
+     * @param parent parent class TypeClass
+     * @param interfaces a list of interfaces the value class implements
+     * @param name name for the create type
+     * @param level depth level
+     * @param variableDeclarations variables of the class
+     * @param constructorDefinitions constructors
+     * @param functionDefinitions method definitions
+     * @param abstractFunctionRedefinitions redefinitions of abstract methods
+     * @param overridenFunctionRedefitions overriden methods
+     * @param functionDeclarations methods declarations
+     * @param printVariablesBlock print variables block
+     */
+    public ValueKlass(TypeKlass thisKlass, TypeKlass parent,
+            ArrayList<TypeKlass> interfaces, String name, int level,
+            IRNode variableDeclarations, IRNode constructorDefinitions,
+            IRNode functionDefinitions, IRNode abstractFunctionRedefinitions,
+            IRNode overridenFunctionRedefitions, IRNode functionDeclarations,
+            IRNode printVariablesBlock) {
+        super(thisKlass, parent, interfaces, name, level,
+                variableDeclarations, constructorDefinitions, functionDefinitions,
+                abstractFunctionRedefinitions, overridenFunctionRedefitions,
+                functionDeclarations, printVariablesBlock);
+    }
+
+    /** Forwards this node to a visitor.
+     *
+     * @param v visitor to forward to
+     */
+    @Override
+    public<T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+}
+

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/AbstractKlassFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/AbstractKlassFactory.java
@@ -66,7 +66,7 @@ abstract class AbstractKlassFactory<T extends Klass> extends Factory<T> {
         this.operatorLimit = operatorLimit;
         this.level = level;
         interfaces = new ArrayList<>();
-        abstractProbabilityAdjustment = 0.2; // Probability to consider making class an abstract
+        abstractProbabilityAdjustment = 0.2; // Probability to consider making class abstract
     }
 
     @Override

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/AbstractKlassFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/AbstractKlassFactory.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester.factories;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import jdk.test.lib.jittester.IRNode;
+import jdk.test.lib.jittester.ProductionFailedException;
+import jdk.test.lib.jittester.ProductionParams;
+import jdk.test.lib.jittester.Symbol;
+import jdk.test.lib.jittester.SymbolTable;
+import jdk.test.lib.jittester.Type;
+import jdk.test.lib.jittester.TypeList;
+import jdk.test.lib.jittester.VariableInfo;
+import jdk.test.lib.jittester.classes.Klass;
+import jdk.test.lib.jittester.functions.FunctionDeclarationBlock;
+import jdk.test.lib.jittester.functions.FunctionDefinition;
+import jdk.test.lib.jittester.functions.FunctionInfo;
+import jdk.test.lib.jittester.types.TypeKlass;
+import jdk.test.lib.jittester.utils.PseudoRandom;
+
+abstract class AbstractKlassFactory<T extends Klass> extends Factory<T> {
+    private final String name;
+    private final long complexityLimit;
+    private final int statementsInFunctionLimit;
+    private final int operatorLimit;
+    private final int memberFunctionsArgLimit;
+    private final int level;
+    private final ArrayList<TypeKlass> interfaces;
+    private TypeKlass thisKlass;
+    private TypeKlass parent;
+    private int memberFunctionsLimit;
+    protected double abstractProbabilityAdjustment;
+
+    AbstractKlassFactory(String name, long complexityLimit,
+            int memberFunctionsLimit, int memberFunctionsArgLimit, int statementsInFunctionLimit,
+            int operatorLimit, int level) {
+        this.name = name;
+        this.complexityLimit = complexityLimit;
+        this.memberFunctionsLimit = memberFunctionsLimit;
+        this.memberFunctionsArgLimit = memberFunctionsArgLimit;
+        this.statementsInFunctionLimit = statementsInFunctionLimit;
+        this.operatorLimit = operatorLimit;
+        this.level = level;
+        interfaces = new ArrayList<>();
+        abstractProbabilityAdjustment = 0.2; // Probability to consider making class an abstract
+    }
+
+    @Override
+    public final T produce() throws ProductionFailedException {
+        HashSet<Symbol> abstractSet = new HashSet<>();
+        HashSet<Symbol> overrideSet = new HashSet<>();
+        thisKlass = createThisKlass(name);
+
+        // Do we want to inherit something?
+        if (!ProductionParams.disableInheritance.value()) {
+            inheritClass();
+            inheritInterfaces();
+            // Now, we should carefully construct a set of all methods with are still abstract.
+            // In order to do that, we will make two sets of methods: abstract and non-abstract.
+            // Then by substracting non-abstract from abstract we'll get what we want.
+            HashSet<Symbol> nonAbstractSet = new HashSet<>();
+            for (Symbol symbol : SymbolTable.getAllCombined(thisKlass, FunctionInfo.class)) {
+                FunctionInfo functionInfo = (FunctionInfo) symbol;
+                // There could be multiple definitions or declarations encountered,
+                // but all we interested in are signatures.
+                if ((functionInfo.flags & FunctionInfo.ABSTRACT) > 0) {
+                    abstractSet.add(functionInfo);
+                } else {
+                    nonAbstractSet.add(functionInfo);
+                }
+            }
+            abstractSet.removeAll(nonAbstractSet);
+
+            if (PseudoRandom.randomBoolean(abstractProbabilityAdjustment)
+               && (abstractSet.removeIf((_unused) -> PseudoRandom.randomBoolean(0.2)))) {
+                    thisKlass.setAbstract();
+            }
+
+            if (PseudoRandom.randomBoolean(0.2)) {
+                int redefineLimit = (int) (memberFunctionsLimit * PseudoRandom.random());
+                if (redefineLimit > 0) {
+                    // We may also select some functions from the hierarchy that we want
+                    // to redefine..
+                    int i = 0;
+                    for (Symbol symbol : getShuffledOverrideCandidates(nonAbstractSet)) {
+                        if (++i > redefineLimit) {
+                            break;
+                        }
+                        FunctionInfo functionInfo = (FunctionInfo) symbol;
+                        if ((functionInfo.flags & FunctionInfo.FINAL) > 0) {
+                            continue;
+                        }
+                        overrideSet.add(functionInfo);
+                    }
+                }
+            }
+            memberFunctionsLimit -= abstractSet.size() + overrideSet.size();
+            // Ok, remove the symbols from the table which are going to be overrided.
+            // Because the redefiner would probably modify them and put them back into table.
+            for (Symbol symbol : abstractSet) {
+                SymbolTable.remove(symbol);
+            }
+            for (Symbol symbol : overrideSet) {
+                SymbolTable.remove(symbol);
+            }
+        } else {
+            parent = TypeList.OBJECT;
+            thisKlass.addParent(parent.getName());
+            thisKlass.setParent(parent);
+            parent.addChild(name);
+        }
+        VariableInfo thizzVariable = new VariableInfo("this", thisKlass, thisKlass,
+                VariableInfo.FINAL | VariableInfo.LOCAL | VariableInfo.INITIALIZED);
+        SymbolTable.add(thizzVariable);
+
+        IRNode variableDeclarations = null;
+        IRNode constructorDefinitions = null;
+        IRNode functionDefinitions = null;
+        IRNode functionDeclarations = null;
+        IRNode abstractFunctionsRedefinitions = null;
+        IRNode overridenFunctionsRedefinitions = null;
+        IRNodeBuilder builder = new IRNodeBuilder().setOwnerKlass(thisKlass)
+                .setExceptionSafe(true);
+        try {
+            builder.setLevel(level + 1)
+                    .setOperatorLimit(operatorLimit)
+                    .setStatementLimit(statementsInFunctionLimit)
+                    .setMemberFunctionsArgLimit(memberFunctionsArgLimit);
+            variableDeclarations = produceVariableDeclarations(builder,
+                    (long) (complexityLimit * 0.001 * PseudoRandom.random()));
+            if (!ProductionParams.disableFunctions.value()) {
+                // Try to implement all methods.
+                abstractFunctionsRedefinitions = builder.setComplexityLimit((long) (complexityLimit * 0.3 * PseudoRandom.random()))
+                        .setLevel(level + 1)
+                        .getFunctionRedefinitionBlockFactory(abstractSet)
+                        .produce();
+                overridenFunctionsRedefinitions = builder.setComplexityLimit((long) (complexityLimit * 0.3 * PseudoRandom.random()))
+                        .getFunctionRedefinitionBlockFactory(overrideSet)
+                        .produce();
+                if (PseudoRandom.randomBoolean(0.2)) { // wanna be abstract ?
+                    functionDeclarations = builder.setMemberFunctionsLimit((int) (memberFunctionsLimit * 0.2
+                                    * PseudoRandom.random()))
+                            .getFunctionDeclarationBlockFactory()
+                            .produce();
+                    if (((FunctionDeclarationBlock) functionDeclarations).size() > 0) {
+                        thisKlass.setAbstract();
+                    }
+                }
+                functionDefinitions = produceFunctionDefinitions(builder,
+                        (long) (complexityLimit * 0.5 * PseudoRandom.random()),
+                        (int) (memberFunctionsLimit * 0.6 * PseudoRandom.random()));
+
+                constructorDefinitions = builder
+                        .setComplexityLimit((long) (complexityLimit * 0.2 * PseudoRandom.random()))
+                        .setMemberFunctionsLimit((int) (memberFunctionsLimit * 0.2 * PseudoRandom.random()))
+                        .setStatementLimit(statementsInFunctionLimit)
+                        .setOperatorLimit(operatorLimit)
+                        .setLevel(level + 1)
+                        .getConstructorDefinitionBlockFactory()
+                        .produce();
+            }
+        } catch (ProductionFailedException e) {
+            System.out.println("Exception during klass production process:");
+            e.printStackTrace(System.out);
+            throw e;
+        } finally {
+            SymbolTable.remove(new Symbol("this", thisKlass, thisKlass, VariableInfo.NONE));
+        }
+
+        finalizeClassFlags(thisKlass);
+        TypeList.add(thisKlass);
+        IRNode printVariables = builder.setLevel(2).getPrintVariablesFactory().produce();
+        return createKlassNode(thisKlass, parent, interfaces, name, level,
+                variableDeclarations, constructorDefinitions, functionDefinitions,
+                abstractFunctionsRedefinitions, overridenFunctionsRedefinitions,
+                functionDeclarations, printVariables);
+    }
+
+    protected abstract TypeKlass createThisKlass(String name);
+
+    protected abstract boolean canInheritFrom(Type type);
+
+    protected abstract IRNode produceVariableDeclarations(IRNodeBuilder builder, long complexity)
+            throws ProductionFailedException;
+
+    protected IRNode produceFunctionDefinitions(IRNodeBuilder builder, long complexity, int memberLimit)
+            throws ProductionFailedException {
+        return builder.setComplexityLimit(complexity)
+                .setMemberFunctionsLimit(memberLimit)
+                .setFlags(FunctionInfo.NONE)
+                .getFunctionDefinitionBlockFactory()
+                .produce();
+    }
+
+    protected ArrayList<Symbol> getShuffledOverrideCandidates(HashSet<Symbol> nonAbstractSet) {
+        ArrayList<Symbol> candidates = new ArrayList<>(nonAbstractSet);
+        PseudoRandom.shuffle(candidates);
+        return candidates;
+    }
+
+    protected abstract void finalizeClassFlags(TypeKlass thisKlass);
+
+    protected abstract T createKlassNode(TypeKlass thisKlass, TypeKlass parent,
+            ArrayList<TypeKlass> interfaces, String name, int level,
+            IRNode variableDeclarations, IRNode constructorDefinitions,
+            IRNode functionDefinitions, IRNode abstractFunctionRedefinitions,
+            IRNode overridenFunctionRedefinitions, IRNode functionDeclarations,
+            IRNode printVariables);
+
+    private void inheritClass() {
+        // Grab all Klasses from the TypeList and select one to be a parent
+        LinkedList<Type> probableParents = new LinkedList<>(TypeList.getAll());
+        for (Iterator<Type> i = probableParents.iterator(); i.hasNext();) {
+            if (!canInheritFrom(i.next())) {
+                i.remove();
+            }
+        }
+        if (probableParents.isEmpty()) {
+            parent = TypeList.OBJECT;
+        } else {
+            parent = (TypeKlass) PseudoRandom.randomElement(probableParents);
+        }
+        thisKlass.addParent(parent.getName());
+        thisKlass.setParent(parent);
+        parent.addChild(thisKlass.getName());
+        for (Symbol symbol : SymbolTable.getAllCombined(parent)) {
+            if ((symbol.flags & Symbol.PRIVATE) == 0) {
+                Symbol symbolCopy = symbol.deepCopy();
+                if (symbolCopy instanceof FunctionInfo) {
+                    FunctionInfo functionInfo = (FunctionInfo) symbolCopy;
+                    if (functionInfo.isConstructor()) {
+                        continue;
+                    }
+                    if ((functionInfo.flags & FunctionInfo.STATIC) == 0) {
+                        functionInfo.argTypes.get(0).type = thisKlass;
+                    }
+                }
+                symbolCopy.owner = thisKlass;
+                SymbolTable.add(symbolCopy);
+            }
+        }
+    }
+
+    private void inheritInterfaces() {
+        // Select interfaces that we'll implement.
+        LinkedList<Type> probableInterfaces = new LinkedList<>(TypeList.getAll());
+        for (Iterator<Type> i = probableInterfaces.iterator(); i.hasNext();) {
+            Type klass = i.next();
+            if (!(klass instanceof TypeKlass) || !((TypeKlass) klass).isInterface()) {
+                i.remove();
+            }
+        }
+        PseudoRandom.shuffle(probableInterfaces);
+        int implLimit = (int) (ProductionParams.implementationLimit.value() * PseudoRandom.random());
+        // Mulitiple inheritance compatibility check
+        compatibility_check:
+        for (Iterator<Type> i = probableInterfaces.iterator(); i.hasNext() && implLimit > 0; implLimit--) {
+            TypeKlass iface = (TypeKlass) i.next();
+            ArrayList<Symbol> ifaceFuncSet = SymbolTable.getAllCombined(iface, FunctionInfo.class);
+            for (Symbol symbol : SymbolTable.getAllCombined(thisKlass, FunctionInfo.class)) {
+                if (FunctionDefinition.isInvalidOverride((FunctionInfo) symbol, ifaceFuncSet)) {
+                    continue compatibility_check;
+                }
+            }
+            interfaces.add(iface);
+            iface.addChild(thisKlass.getName());
+            thisKlass.addParent(iface.getName());
+            for (Symbol symbol : SymbolTable.getAllCombined(iface, FunctionInfo.class)) {
+                FunctionInfo functionInfo = (FunctionInfo) symbol.deepCopy();
+                functionInfo.owner = thisKlass;
+                functionInfo.argTypes.get(0).type = thisKlass;
+                SymbolTable.add(functionInfo);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/ClassDefinitionBlockFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/ClassDefinitionBlockFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,8 @@ class ClassDefinitionBlockFactory extends Factory<ClassDefinitionBlock> {
     @Override
     public ClassDefinitionBlock produce() throws ProductionFailedException {
         ArrayList<IRNode> content = new ArrayList<>();
+        int identityValueClassBalance = Math.max(0, Math.min(100,
+                ProductionParams.identityValueClassBalance.value()));
         int limit = (int) Math.ceil(PseudoRandom.random() * classesLimit);
         if (limit > 0) {
             long classCompl = complexityLimit / limit;
@@ -75,9 +77,17 @@ class ClassDefinitionBlockFactory extends Factory<ClassDefinitionBlock> {
             for (int i = 0; i < limit; i++) {
                 try {
                     Rule<IRNode> rule = new Rule<>("class");
-                    rule.add("basic_class", builder.setName(prefix + "_Class_" + i)
-                            .setMemberFunctionsLimit(memberFunctionsLimit)
-                            .getKlassFactory());
+                    int identityClassWeight = 100 - identityValueClassBalance;
+                    if (identityClassWeight > 0) {
+                        rule.add("identity_class", builder.setName(prefix + "_Class_" + i)
+                                .setMemberFunctionsLimit(memberFunctionsLimit)
+                                .getKlassFactory(), identityClassWeight);
+                    }
+                    if (identityValueClassBalance > 0) {
+                        rule.add("value_class", builder.setName(prefix + "_Value_Class_" + i)
+                                .setMemberFunctionsLimit(memberFunctionsLimit)
+                                .getValueKlassFactory(), identityValueClassBalance);
+                    }
                     if (!ProductionParams.disableInterfaces.value()) {
                         rule.add("interface", builder.setName(prefix + "_Interface_" + i)
                                 .setMemberFunctionsLimit((int) (memberFunctionsLimit * 0.2))

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/DeclarationFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/DeclarationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,14 +37,21 @@ class DeclarationFactory extends Factory<Declaration> {
     private final boolean isLocal;
     private final boolean exceptionSafe;
     private final TypeKlass ownerClass;
+    private final boolean isConstant;
 
     DeclarationFactory(TypeKlass ownerClass, long complexityLimit,
             int operatorLimit, boolean isLocal, boolean safe) {
+        this(ownerClass, complexityLimit, operatorLimit, isLocal, safe, /* isConstant */ false);
+    }
+
+    DeclarationFactory(TypeKlass ownerClass, long complexityLimit,
+            int operatorLimit, boolean isLocal, boolean safe, boolean isConstant) {
         this.ownerClass = ownerClass;
         this.isLocal = isLocal;
         this.exceptionSafe = safe;
         this.complexityLimit = complexityLimit;
         this.operatorLimit = operatorLimit;
+        this.isConstant = isConstant;
     }
 
     @Override
@@ -57,13 +64,15 @@ class DeclarationFactory extends Factory<Declaration> {
                 .setOperatorLimit(operatorLimit)
                 .setIsLocal(isLocal)
                 .setExceptionSafe(exceptionSafe);
-        rule.add("decl", builder
-                .setIsStatic(false)
-                .getVariableDeclarationFactory());
-        rule.add("decl_and_init", builder
-                .setIsConstant(false)
-                .setIsStatic(false)
-                .getVariableInitializationFactory());
+        if (!isConstant) {
+            rule.add("decl", builder
+                    .setIsStatic(false)
+                    .getVariableDeclarationFactory());
+            rule.add("decl_and_init", builder
+                    .setIsConstant(false)
+                    .setIsStatic(false)
+                    .getVariableInitializationFactory());
+        }
         if (!ProductionParams.disableFinalVariables.value()) {
             rule.add("const_decl_and_init", builder
                     .setIsConstant(true)

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/FunctionDefinitionBlockFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/FunctionDefinitionBlockFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,12 +42,13 @@ class FunctionDefinitionBlockFactory extends Factory<FunctionDefinitionBlock> {
     private final int memberFunctionsLimit;
     private final int memberFunctionsArgLimit;
     private final int initialFlags;
+    private final boolean isSynchronizedAllowed;
     private final int level;
     private final TypeKlass ownerClass;
 
     FunctionDefinitionBlockFactory(TypeKlass ownerClass, int memberFunctionsLimit,
             int memberFunctionsArgLimit, long complexityLimit, int statementLimit,
-            int operatorLimit, int level, int initialFlags) {
+            int operatorLimit, int level, int initialFlags, boolean isSynchronizedAllowed) {
         this.ownerClass = ownerClass;
         this.memberFunctionsLimit = memberFunctionsLimit;
         this.memberFunctionsArgLimit = memberFunctionsArgLimit;
@@ -56,6 +57,7 @@ class FunctionDefinitionBlockFactory extends Factory<FunctionDefinitionBlock> {
         this.operatorLimit = operatorLimit;
         this.level = level;
         this.initialFlags = initialFlags;
+        this.isSynchronizedAllowed = isSynchronizedAllowed;
     }
 
     @Override
@@ -81,7 +83,7 @@ class FunctionDefinitionBlockFactory extends Factory<FunctionDefinitionBlock> {
                 if (PseudoRandom.randomBoolean()) {
                     flags |= FunctionInfo.NONRECURSIVE;
                 }
-                if (PseudoRandom.randomBoolean()) {
+                if (isSynchronizedAllowed && PseudoRandom.randomBoolean()) {
                     flags |= FunctionInfo.SYNCHRONIZED;
                 }
                 switch ((int) (PseudoRandom.random() * 4)) {

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/IRNodeBuilder.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/IRNodeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,7 @@ import jdk.test.lib.jittester.classes.ClassDefinitionBlock;
 import jdk.test.lib.jittester.classes.Interface;
 import jdk.test.lib.jittester.classes.Klass;
 import jdk.test.lib.jittester.classes.MainKlass;
+import jdk.test.lib.jittester.classes.ValueKlass;
 import jdk.test.lib.jittester.functions.ArgumentDeclaration;
 import jdk.test.lib.jittester.functions.ConstructorDefinition;
 import jdk.test.lib.jittester.functions.ConstructorDefinitionBlock;
@@ -110,6 +111,7 @@ public class IRNodeBuilder {
     private Optional<LocalVariable> localVariable = Optional.empty();
     private Optional<Boolean> isLocal = Optional.empty();
     private Optional<Boolean> isStatic = Optional.empty();
+    private boolean isSynchronizedAllowed = false;
     private Optional<Boolean> isConstant = Optional.empty();
     private Optional<Boolean> isInitialized = Optional.empty();
     private Optional<String> name = Optional.empty();
@@ -308,6 +310,11 @@ public class IRNodeBuilder {
                 getIsLocal(), getExceptionSafe());
     }
 
+    public Factory<Declaration> getConstantDeclarationFactory() {
+        return new DeclarationFactory(getOwnerClass(), getComplexityLimit(), getOperatorLimit(),
+                getIsLocal(), getExceptionSafe(), true);
+    }
+
     public Factory<DoWhile> getDoWhileFactory() {
         return new DoWhileFactory(getOwnerClass(), getResultType(), getComplexityLimit(),
                 getStatementLimit(), getOperatorLimit(), getLevel(), getCanHaveReturn());
@@ -350,9 +357,12 @@ public class IRNodeBuilder {
     }
 
     public Factory<FunctionDefinitionBlock> getFunctionDefinitionBlockFactory() {
-        return new FunctionDefinitionBlockFactory(getOwnerClass(), getMemberFunctionsLimit(),
+        Factory<FunctionDefinitionBlock> result =
+            new FunctionDefinitionBlockFactory(getOwnerClass(), getMemberFunctionsLimit(),
                 getMemberFunctionsArgLimit(), getComplexityLimit(), getStatementLimit(),
-                getOperatorLimit(), getLevel(), getFlags());
+                getOperatorLimit(), getLevel(), getFlags(), isSynchronizedAllowed);
+        isSynchronizedAllowed = true;
+        return result;
     }
 
     public Factory<FunctionDefinition> getFunctionDefinitionFactory() {
@@ -385,6 +395,12 @@ public class IRNodeBuilder {
 
     public Factory<Klass> getKlassFactory() {
         return new KlassFactory(getName(), getComplexityLimit(),
+                getMemberFunctionsLimit(), getMemberFunctionsArgLimit(), getStatementLimit(),
+                getOperatorLimit(), getLevel());
+    }
+
+    public Factory<ValueKlass> getValueKlassFactory() {
+        return new ValueKlassFactory(getName(), getComplexityLimit(),
                 getMemberFunctionsLimit(), getMemberFunctionsArgLimit(), getStatementLimit(),
                 getOperatorLimit(), getLevel());
     }
@@ -454,6 +470,16 @@ public class IRNodeBuilder {
     }
 
     public Factory<VariableDeclarationBlock> getVariableDeclarationBlockFactory() {
+        return new VariableDeclarationBlockFactory(getOwnerClass(), getComplexityLimit(),
+                getOperatorLimit(), getLevel(), getExceptionSafe());
+    }
+
+    /**
+     * Creates a variable declaration block factory constrained to constants.
+     *
+     * @return constant-only declaration block factory
+     */
+    public Factory<VariableDeclarationBlock> getConstantVariableDeclarationBlockFactory() {
         return new VariableDeclarationBlockFactory(getOwnerClass(), getComplexityLimit(),
                 getOperatorLimit(), getLevel(), getExceptionSafe());
     }
@@ -594,6 +620,11 @@ public class IRNodeBuilder {
         return this;
     }
 
+    public IRNodeBuilder setIsSynchronizedAllowed(boolean value) {
+        isSynchronizedAllowed = value;
+        return this;
+    }
+
     public IRNodeBuilder setIsInitialized(boolean value) {
         isInitialized = Optional.of(value);
         return this;
@@ -704,6 +735,10 @@ public class IRNodeBuilder {
 
     private boolean getIsStatic() {
         return isStatic.orElseThrow(() -> new IllegalArgumentException("isStatic wasn't set"));
+    }
+
+    private boolean getIsSynchronizedAllowed() {
+        return isSynchronizedAllowed;
     }
 
     private boolean getIsInitialized() {

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/ValueKlassFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/ValueKlassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,28 +24,32 @@
 package jdk.test.lib.jittester.factories;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 
 import jdk.test.lib.jittester.IRNode;
 import jdk.test.lib.jittester.ProductionFailedException;
-import jdk.test.lib.jittester.ProductionParams;
+import jdk.test.lib.jittester.Symbol;
 import jdk.test.lib.jittester.Type;
-import jdk.test.lib.jittester.classes.Klass;
+import jdk.test.lib.jittester.classes.ValueKlass;
 import jdk.test.lib.jittester.functions.FunctionInfo;
 import jdk.test.lib.jittester.types.TypeKlass;
 import jdk.test.lib.jittester.utils.PseudoRandom;
 
-class KlassFactory extends AbstractKlassFactory<Klass> {
+class ValueKlassFactory extends AbstractKlassFactory<ValueKlass> {
 
-    KlassFactory(String name, long complexityLimit,
+    ValueKlassFactory(String name, long complexityLimit,
             int memberFunctionsLimit, int memberFunctionsArgLimit, int statementsInFunctionLimit,
             int operatorLimit, int level) {
         super(name, complexityLimit, memberFunctionsLimit, memberFunctionsArgLimit,
                 statementsInFunctionLimit, operatorLimit, level);
+        abstractProbabilityAdjustment = 1.0; // We want more abstract value classes
     }
 
     @Override
     protected TypeKlass createThisKlass(String name) {
-        return new TypeKlass(name);
+        TypeKlass thisKlass = new TypeKlass(name);
+        thisKlass.setValueKlass();
+        return thisKlass;
     }
 
     @Override
@@ -54,13 +58,13 @@ class KlassFactory extends AbstractKlassFactory<Klass> {
             return false;
         }
         TypeKlass klass = (TypeKlass) type;
-        return !klass.isFinal() && !klass.isInterface();
+        return klass.isAbstract() && klass.isValueKlass();
     }
 
     @Override
     protected IRNode produceVariableDeclarations(IRNodeBuilder builder, long complexity)
             throws ProductionFailedException {
-        return builder.setComplexityLimit(complexity).getVariableDeclarationBlockFactory().produce();
+        return builder.setComplexityLimit(complexity).getConstantVariableDeclarationBlockFactory().produce();
     }
 
     @Override
@@ -69,27 +73,32 @@ class KlassFactory extends AbstractKlassFactory<Klass> {
         return builder.setComplexityLimit(complexity)
                 .setMemberFunctionsLimit(memberLimit)
                 .setFlags(FunctionInfo.NONE)
+                .setIsSynchronizedAllowed(false)
                 .getFunctionDefinitionBlockFactory()
                 .produce();
     }
 
     @Override
+    protected ArrayList<Symbol> getShuffledOverrideCandidates(HashSet<Symbol> nonAbstractSet) {
+        nonAbstractSet.removeIf(symbol -> (((FunctionInfo) symbol).flags & FunctionInfo.FINAL) > 0);
+        return super.getShuffledOverrideCandidates(nonAbstractSet);
+    }
+
+    @Override
     protected void finalizeClassFlags(TypeKlass thisKlass) {
-        if (!ProductionParams.disableFinalClasses.value()
-                && !thisKlass.isAbstract()
-                && PseudoRandom.randomBoolean()) {
+        if (!thisKlass.isAbstract()) {
             thisKlass.setFinal();
         }
     }
 
     @Override
-    protected Klass createKlassNode(TypeKlass thisKlass, TypeKlass parent,
+    protected ValueKlass createKlassNode(TypeKlass thisKlass, TypeKlass parent,
             ArrayList<TypeKlass> interfaces, String name, int level,
             IRNode variableDeclarations, IRNode constructorDefinitions,
             IRNode functionDefinitions, IRNode abstractFunctionRedefinitions,
             IRNode overridenFunctionRedefinitions, IRNode functionDeclarations,
             IRNode printVariables) {
-        return new Klass(thisKlass, parent, interfaces, name, level,
+        return new ValueKlass(thisKlass, parent, interfaces, name, level,
                 variableDeclarations, constructorDefinitions, functionDefinitions,
                 abstractFunctionRedefinitions, overridenFunctionRedefinitions,
                 functionDeclarations, printVariables);

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/VariableDeclarationBlockFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/VariableDeclarationBlockFactory.java
@@ -58,7 +58,7 @@ class VariableDeclarationBlockFactory extends Factory<VariableDeclarationBlock> 
                 .setOperatorLimit(operatorLimit)
                 .setIsLocal(false)
                 .setExceptionSafe(exceptionSafe)
-                .getDeclarationFactory();
+                .getConstantDeclarationFactory();
         for (int i = 0; i < limit; i++) {
             try {
                 content.add(declFactory.produce());

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/types/TypeKlass.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/types/TypeKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class TypeKlass extends Type {
     public static final int FINAL = 0x01;
     public static final int INTERFACE = 0x02;
     public static final int ABSTRACT = 0x04;
-
+    public static final int VALUE_KLASS = 0x08;
 
     public TypeKlass(String name) {
         this(name, NONE);
@@ -187,6 +187,22 @@ public class TypeKlass extends Type {
 
     public void setAbstract() {
         flags |= ABSTRACT;
+    }
+
+    /**
+     * Checks whether this type represents a value class.
+     *
+     * @return true when the value-class flag is set
+     */
+    public boolean isValueKlass() {
+        return (flags & VALUE_KLASS) > 0;
+    }
+
+    /**
+     * Marks this type as a value class.
+     */
+    public void setValueKlass() {
+        flags |= VALUE_KLASS;
     }
 
     public boolean isInterface() {

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/ByteCodeVisitor.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/ByteCodeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,7 @@ import jdk.test.lib.jittester.classes.ClassDefinitionBlock;
 import jdk.test.lib.jittester.classes.Interface;
 import jdk.test.lib.jittester.classes.Klass;
 import jdk.test.lib.jittester.classes.MainKlass;
+import jdk.test.lib.jittester.classes.ValueKlass;
 import jdk.test.lib.jittester.functions.ArgumentDeclaration;
 import jdk.test.lib.jittester.functions.ConstructorDefinition;
 import jdk.test.lib.jittester.functions.ConstructorDefinitionBlock;
@@ -1090,6 +1091,11 @@ public class ByteCodeVisitor implements Visitor<byte[]> {
         context.register(name, byteCode);
         currentClass = prevClass;
         return byteCode;
+    }
+
+    @Override
+    public byte[] visit(ValueKlass node) {
+        throw new UnsupportedOperationException("ByteCodeVisitor doesn't support Value classes");
     }
 
     private void visitLiteral(boolean value) {

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/JavaCodeVisitor.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/JavaCodeVisitor.java
@@ -660,7 +660,6 @@ public class JavaCodeVisitor implements Visitor<String> {
     public String visit(ValueKlass node) {
         TypeKlass thisKlass = node.getThisKlass();
         String r = (ProductionParams.enableStrictFP.value() ? "strictfp " : "")
-                + (thisKlass.isFinal() ? "final " : "")
                 + (thisKlass.isAbstract() ? "abstract " : "")
                 + "value class " + node.getName()
                 + (node.getParentKlass() != null && !node.getParentKlass().equals(TypeList.OBJECT)

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/JavaCodeVisitor.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/JavaCodeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package jdk.test.lib.jittester.visitors;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -66,6 +67,7 @@ import jdk.test.lib.jittester.classes.ClassDefinitionBlock;
 import jdk.test.lib.jittester.classes.Interface;
 import jdk.test.lib.jittester.classes.Klass;
 import jdk.test.lib.jittester.classes.MainKlass;
+import jdk.test.lib.jittester.classes.ValueKlass;
 import jdk.test.lib.jittester.functions.ArgumentDeclaration;
 import jdk.test.lib.jittester.functions.ConstructorDefinition;
 import jdk.test.lib.jittester.functions.ConstructorDefinitionBlock;
@@ -629,6 +631,38 @@ public class JavaCodeVisitor implements Visitor<String> {
                 + (thisKlass.isFinal() ? "final " : "")
                 + (thisKlass.isAbstract() ? "abstract " : "")
                 + "class " + node.getName()
+                + (node.getParentKlass() != null && !node.getParentKlass().equals(TypeList.OBJECT)
+                ? " extends " + node.getParentKlass().getName() : "");
+        List<TypeKlass> interfaces = node.getInterfaces();
+        r += interfaces.stream()
+                .map(Type::getName)
+                .collect(Collectors.joining(", ", (interfaces.isEmpty() ? "" : " implements "), ""));
+        IRNode dataMembers = node.getChild(Klass.KlassPart.DATA_MEMBERS.ordinal());
+        IRNode constructors = node.getChild(Klass.KlassPart.CONSTRUCTORS.ordinal());
+        IRNode redefinedFunctions = node.getChild(Klass.KlassPart.REDEFINED_FUNCTIONS.ordinal());
+        IRNode overridenFunctions = node.getChild(Klass.KlassPart.OVERRIDEN_FUNCTIONS.ordinal());
+        IRNode memberFunctions = node.getChild(Klass.KlassPart.MEMBER_FUNCTIONS.ordinal());
+        IRNode memberFunctionDecls = node.getChild(Klass.KlassPart.MEMBER_FUNCTIONS_DECLARATIONS.ordinal());
+        IRNode printVariables = node.getChild(Klass.KlassPart.PRINT_VARIABLES.ordinal());
+        r += " {\n"
+             + (dataMembers != null ? (dataMembers.accept(this)+ "\n") : "")
+             + (constructors != null ? (constructors.accept(this)+ "\n") : "")
+             + (redefinedFunctions != null ? (redefinedFunctions.accept(this)+ "\n") : "")
+             + (overridenFunctions != null ? (overridenFunctions.accept(this)+ "\n") : "")
+             + (memberFunctionDecls != null ? (memberFunctionDecls.accept(this)+ "\n") : "")
+             + (memberFunctions != null ? (memberFunctions.accept(this)+ "\n") : "")
+             + printVariables.accept(this)
+             + "}\n";
+        return r;
+    }
+
+    @Override
+    public String visit(ValueKlass node) {
+        TypeKlass thisKlass = node.getThisKlass();
+        String r = (ProductionParams.enableStrictFP.value() ? "strictfp " : "")
+                + (thisKlass.isFinal() ? "final " : "")
+                + (thisKlass.isAbstract() ? "abstract " : "")
+                + "value class " + node.getName()
                 + (node.getParentKlass() != null && !node.getParentKlass().equals(TypeList.OBJECT)
                 ? " extends " + node.getParentKlass().getName() : "");
         List<TypeKlass> interfaces = node.getInterfaces();

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/Visitor.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/visitors/Visitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ import jdk.test.lib.jittester.classes.ClassDefinitionBlock;
 import jdk.test.lib.jittester.classes.Interface;
 import jdk.test.lib.jittester.classes.Klass;
 import jdk.test.lib.jittester.classes.MainKlass;
+import jdk.test.lib.jittester.classes.ValueKlass;
 import jdk.test.lib.jittester.functions.ArgumentDeclaration;
 import jdk.test.lib.jittester.functions.ConstructorDefinition;
 import jdk.test.lib.jittester.functions.ConstructorDefinitionBlock;
@@ -103,6 +104,7 @@ public interface Visitor<T> {
     T visit(Initialization node);
     T visit(Interface node);
     T visit(Klass node);
+    T visit(ValueKlass node);
     T visit(Literal node);
     T visit(LocalVariable node);
     T visit(LoopingCondition node);


### PR DESCRIPTION
Currently JITTester only generates common, instance classes. This PR suggests a value classes support for the tool.

Specifically, it:
- adds a ValueKlass as an AST node carrier for the new type
- moves most of KlassFactory internals  into generic AbstractKlassFactory
- adds smaller concrete KlassFactory and ValueKlassFactory.
- makes sure that we don't generate mutable fields in the value classes
- blocks synchronized usage on value-class methods
- raises probability to be abstract for the value classes - to check deeper hierarchies.
- adds a parameter governing the balance between instance and value classes. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382603](https://bugs.openjdk.org/browse/JDK-8382603): [lworld] [jittester] Add Value Classes support in generated tests (**Enhancement** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2346/head:pull/2346` \
`$ git checkout pull/2346`

Update a local copy of the PR: \
`$ git checkout pull/2346` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2346`

View PR using the GUI difftool: \
`$ git pr show -t 2346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2346.diff">https://git.openjdk.org/valhalla/pull/2346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2346#issuecomment-4287710762)
</details>
