### PR TITLE
8382622: [lworld] Cleanup new_flatArray

### DIFF
--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -133,18 +133,12 @@ refArrayOop oopFactory::new_refArray(Klass* klass, int length, TRAPS) {
   return new_refArray(klass, length, ArrayProperties::Default(), THREAD);
 }
 
-flatArrayOop oopFactory::new_flatArray(FlatArrayKlass* klass, int length, TRAPS) {
-  return klass->allocate_instance(length, THREAD);
-}
-
-flatArrayOop oopFactory::new_flatArray(Klass* k, int length, ArrayProperties props, LayoutKind lk, TRAPS) {
-  InlineKlass* klass = InlineKlass::cast(k);
-
-  ArrayKlass* ak = klass->array_klass(CHECK_NULL);
+flatArrayOop oopFactory::new_flatArray(InlineKlass* ik, int length, ArrayProperties props, TRAPS) {
+  ArrayKlass* ak = ik->array_klass(CHECK_NULL);
   ObjArrayKlass* oak = ObjArrayKlass::cast(ak)->klass_with_properties(props, CHECK_NULL);
-
   FlatArrayKlass* fak = FlatArrayKlass::cast(oak);
-  return fak->allocate_instance(length, CHECK_NULL);
+
+  return fak->allocate_instance(length, THREAD);
 }
 
 refArrayHandle oopFactory::new_refArray_handle(Klass* klass, int length, TRAPS) {

--- a/src/hotspot/share/memory/oopFactory.hpp
+++ b/src/hotspot/share/memory/oopFactory.hpp
@@ -31,6 +31,8 @@
 #include "runtime/handles.hpp"
 #include "utilities/exceptions.hpp"
 
+class InlineKlass;
+
 // oopFactory is a class used for creating new objects.
 
 class oopFactory: AllStatic {
@@ -63,8 +65,7 @@ class oopFactory: AllStatic {
   static refArrayOop     new_refArray(Klass* klass, int length, ArrayProperties properties, TRAPS);
 
   // Factory to create flat arrays.
-  static flatArrayOop    new_flatArray(FlatArrayKlass* klass, int length, TRAPS);
-  static flatArrayOop    new_flatArray(Klass* klass, int length, ArrayProperties props, LayoutKind lk, TRAPS);
+  static flatArrayOop    new_flatArray(InlineKlass* klass, int length, ArrayProperties props, TRAPS);
 
   // Helper that returns a Handle
   static refArrayHandle  new_refArray_handle(Klass* klass, int length, TRAPS);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -461,7 +461,7 @@ JVM_ENTRY(jarray, JVM_CopyOfSpecialArray(JNIEnv *env, jarray orig, jint from, ji
     int org_length = org->length();
     int copy_len = MIN2(to, org_length) - MIN2(from, org_length);
     FlatArrayKlass* const fak = FlatArrayKlass::cast(org->klass());
-    flatArrayOop dst = oopFactory::new_flatArray(fak, len, CHECK_NULL);
+    flatArrayOop dst = fak->allocate_instance(len, CHECK_NULL);
     assert(!ak->is_null_free_array_klass() || copy_len == len,
            "Failed to throw the IllegalArgumentException");
     if (copy_len != 0) {

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -400,7 +400,7 @@ UNSAFE_ENTRY(jarray, Unsafe_NewSpecialArray(JNIEnv *env, jobject unsafe, jclass 
     THROW_MSG_NULL(vmSymbols::java_lang_UnsupportedOperationException(), "Layout not supported");
   }
   ArrayProperties props = ArrayKlass::array_properties_from_layout(lk);
-  oop array = oopFactory::new_flatArray(vk, len, props, lk, CHECK_NULL);
+  oop array = oopFactory::new_flatArray(vk, len, props, CHECK_NULL);
   return (jarray) JNIHandles::make_local(THREAD, array);
 } UNSAFE_END
 


### PR DESCRIPTION
[JDK-8379514](https://bugs.openjdk.org/browse/JDK-8379514) Restructured the code and left the LayoutKind parameter unused in new_flatArray.

While removing that parameter I realized that the other overload of new_flatArray is inconsistent with the other new_*Array functions. It's first element is the klass that is going to be used to allocate an instance, whereas all the other functions take the element klass as the first parameter. I propose that we remove overload and inline its single line into the single call site.

I've also updated new_flatArray to take an InlineKlass* instead of a Klass*.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382622](https://bugs.openjdk.org/browse/JDK-8382622): [lworld] Cleanup new_flatArray (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2347/head:pull/2347` \
`$ git checkout pull/2347`

Update a local copy of the PR: \
`$ git checkout pull/2347` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2347`

View PR using the GUI difftool: \
`$ git pr show -t 2347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2347.diff">https://git.openjdk.org/valhalla/pull/2347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2347#issuecomment-4288961928)
</details>
