### PR TITLE
8380927: [lworld] C2: Missed Value() optimization for InlineType

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -1617,6 +1617,12 @@ const Type* InlineTypeNode::Value(PhaseGVN* phase) const {
     return Type::TOP;
   }
   const Type* t = toop->filter_speculative(_type);
+  // Because of contradicting type profiling, we can end up with top as speculative type,
+  // which would then get removed by cleanup_speculative. In this case we have to run filter_speculative
+  // again, otherwise we would break the idempotence of Value
+  if (t->speculative() == nullptr && toop->speculative() != nullptr) {
+    t = toop->filter_speculative(t);
+  }
   if (t->singleton()) {
     // Don't replace InlineType by a constant
     t = _type;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -1490,21 +1490,20 @@ public class TestCallingConvention {
     }
 
     // Method handle with a scalarized return that will always throw an exception
-    // TODO JDK-8380927 this should be re-introduced once fixed
-    // @Test
-    // public static MyValue2 test59(MyValue2 val) throws Throwable {
-    //     return (MyValue2)test59_mh.invokeExact(val);
-    // }
+    @Test
+    public static MyValue2 test59(MyValue2 val) throws Throwable {
+        return (MyValue2)test59_mh.invokeExact(val);
+    }
 
-    // @Run(test = "test59")
-    // @Warmup(10000) // Trigger compilation of LambdaForm method
-    // public void test59_verifier() throws Throwable {
-    //     try {
-    //         test59(null);
-    //     } catch (ArithmeticException e) {
-    //         // Expected
-    //     }
-    // }
+    @Run(test = "test59")
+    @Warmup(10000) // Trigger compilation of LambdaForm method
+    public void test59_verifier() throws Throwable {
+        try {
+            test59(null);
+        } catch (ArithmeticException e) {
+            // Expected
+        }
+    }
 
     static interface Interface60 {
         public void m(MyValue2 val);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+/*
+ * @test
+ * @bug 8380927
+ * @summary Polluted call-site profiling must not break the idempotence of InlineTypeNode::Value
+ * @library /test/lib /
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -Xbatch
+ *                   -XX:VerifyIterativeGVN=1110
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::call
+ *                   -XX:+AlwaysIncrementalInline -XX:-InlineTypeReturnedAsFields
+ *                   -XX:TypeProfileLevel=222 ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+public class TestPollutedCallsiteProfileInlineType {
+    static value class MyValue {
+        int i = 0;
+    }
+
+    public static MyValue call(boolean throwRE) {
+        if (throwRE) {
+            // 1) At the outer callsite (in test) we want ProfileNeverNull:
+            // ==> we should never observe a null return value
+            // 2) At the inner callsite (in callWrapper) we want ProfileAlwaysNull:
+            // ==> we should never observe a non-null return value
+            // By conditionally throwing an exception we can guarantee that 1) and 2) hold
+            throw new RuntimeException();
+        } else {
+            return null;
+        }
+    }
+
+    static MyValue callWrapper(boolean throwRE) {
+        return call(throwRE); // profile at callsite: ProfileAlwaysNull
+    }
+    
+    public static MyValue test() {
+        return callWrapper(true); // profile at callsite: ProfileNeverNull
+    }
+
+    public static void main(String[] args) {
+        // pollute the profile in callWrapper
+        for (int i = 0; i < 10_000; i++) {
+            callWrapper(false);
+        }
+
+        // get a compilation based on the polluted profile
+        for (int i = 0; i < 10_000; i++) {
+            try {
+                test();
+            } catch (RuntimeException t) {}
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
@@ -67,12 +67,12 @@ public class TestPollutedCallsiteProfileInlineType {
 
     public static void main(String[] args) {
         // pollute the profile in callWrapper
-        for (int i = 0; i < 10_000; i++) {
+        for (int i = 0; i < 2000; i++) {
             callWrapper(false);
         }
 
         // get a compilation based on the polluted profile
-        for (int i = 0; i < 10_000; i++) {
+        for (int i = 0; i < 7000; i++) {
             try {
                 test();
             } catch (RuntimeException t) {}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
@@ -31,7 +31,8 @@ package compiler.valhalla.inlinetypes;
  * @enablePreview
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions -Xbatch
  *                   -XX:-TieredCompilation -XX:VerifyIterativeGVN=1110
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test
  *                   -XX:CompileCommand=dontinline,${test.main.class}::call
@@ -41,11 +42,9 @@ package compiler.valhalla.inlinetypes;
  */
 
 public class TestPollutedCallsiteProfileInlineType {
-    static value class MyValue {
-        int i = 0;
-    }
+    static value class MyValue {}
 
-    public static MyValue call(boolean throwRE) {
+    static MyValue call(boolean throwRE) {
         if (throwRE) {
             // 1) At the outer callsite (in test) we want ProfileNeverNull:
             // ==> we should never observe a null return value
@@ -59,11 +58,11 @@ public class TestPollutedCallsiteProfileInlineType {
     }
 
     static MyValue callWrapper(boolean throwRE) {
-        return call(throwRE); // profile at callsite: ProfileAlwaysNull
+        return call(throwRE); // profile: ProfileAlwaysNull
     }
 
-    public static MyValue test() {
-        return callWrapper(true); // profile at callsite: ProfileNeverNull
+    static MyValue test() {
+        return callWrapper(true); // profile: ProfileNeverNull
     }
 
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType.java
@@ -26,13 +26,13 @@ package compiler.valhalla.inlinetypes;
 /*
  * @test
  * @bug 8380927
- * @summary Polluted call-site profiling must not break the idempotence of InlineTypeNode::Value
+ * @summary Polluted callsite profiling must not break the idempotence of InlineTypeNode::Value
  * @library /test/lib /
  * @enablePreview
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -Xbatch
- *                   -XX:VerifyIterativeGVN=1110
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch
+ *                   -XX:-TieredCompilation -XX:VerifyIterativeGVN=1110
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test
  *                   -XX:CompileCommand=dontinline,${test.main.class}::call
  *                   -XX:+AlwaysIncrementalInline -XX:-InlineTypeReturnedAsFields
@@ -61,7 +61,7 @@ public class TestPollutedCallsiteProfileInlineType {
     static MyValue callWrapper(boolean throwRE) {
         return call(throwRE); // profile at callsite: ProfileAlwaysNull
     }
-    
+
     public static MyValue test() {
         return callWrapper(true); // profile at callsite: ProfileNeverNull
     }


### PR DESCRIPTION
This PR prevents a missed optimization caused by a breach of idempotence in `InlineTypeNode::Value` when handling contradicting method return profiles.

## Conflicting return profiles

Suppose we have the following java code, and that we have record profile data for both callsites (`call(...)` and `callWrapper(...)`):

```java
static MyValue callWrapper(...) {
    return call(...); // callsite #1
}

static MyValue test() {
    return callWrapper(...); // callsite #2
}
```

It could be that `test` is not the only place where we call `callWrapper(...)`, and that the other call sites result in wildy different executions of callsite `#1` with wildly different return values at that callsite.

Suppose that callsite `#1` always returns `null`, except when `callWrapper` is called from callsite `#2` where it throws an exception. In `ciMethod::return_profiled_type`, we end up with the following `ProfilePtrKind` when compiling `test`:
- For callsite `#1`: `ProfileAlwaysNull`, because we have only observed `null` (the rest of the time an exception was thrown, so we didn't see anything)
- For callsite `#2`: `ProfileNeverNull`, because we have never observed a return value and this is basically the default

Please look at the test from this PR for a more complete example.

These two profiles contradict each other. If we do incremental inlining (probably not limited to it, but easier to reproduce), we can easily end up in a situation where a speculative type derived from the return of the callsite is `NotNull` before inlining the outer callsite, and then moves to `ptr:null` after inlining. This can confuse `Value` implementations that rely on `filter_speculative`. This is handled gracefully for `ConstraintCastNode`, but not for `InlineTypeNode`.

## Missed optimization

In `InlineTypeNode::Value`, we have:
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/share/opto/inlinetypenode.cpp#L1619

Suppose we have the following types (only the speculative part is shown):
```
oop: instptr:compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType$MyValue:NotNull:exact *,iid=bot (flat in array)
_type: instptr:compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType$MyValue:NotNull:exact *,iid=bot (flat in array)
```

After this step we have `t = oop = _type`.

The oop input suddenly changes types because of incremental inlining, as explained in the previous section. It goes from `NotNull` to `ptr:null` because the type from the polluted profile propagates.

Then at the next IGVN pass, we have:
```
oop: ptr:null
_type: instptr:compiler/valhalla/inlinetypes/TestPollutedCallsiteProfileInlineType$MyValue:NotNull:exact *,iid=bot (flat in array)
```

Intuitively, the resulting type should be `TOP`. But `TypePtr::cleanup_speculative` does not like it, and we end up with `t.speculatve() = nullptr`:

https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/share/opto/type.cpp#L2966-L2979

We end up with no speculative type, which means `speculative = non_speculative`. Then in verification we do another `Value` pass:

```
oop: ptr:null
_type: nullptr
```

This gives us `ptr:null` for the resulting speculative type. This breaks the idempotence of `Value`, and is reported as missed optimization.

## Fix

I think ideally we would like to be able to have `TOP` as a valid speculative type (this is the most accurate it could get), but this would clearly break a lot of things (I have tried). I think for now we should have the same behavior as in `ConstraintCastNode::Value`: detect that the speculative type was suppressed by `cleanup_speculative`, and call `filter_speculative` again when it is the case. This is roughly the same as [JDK-8371716](https://bugs.openjdk.org/browse/JDK-8371716).

### Testing

This issue was initially as a failure in `test59` of `TestCallingConvention.java` with `-XX:-TieredCompilation -XX:VerifyIterativeGVN=1110`. I think this specific test exhibits some quite interesting behavior, but is quite hard to debug (it's not the first time it is failing). For this reason I really wanted to reduce this to a less opaque test case, and I think this test pattern (especially the profiling part) could be useful in the future as well.

- [x] tier1-3, plus some internal testing

Thank you for reviewing!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8380927](https://bugs.openjdk.org/browse/JDK-8380927): [lworld] C2: Missed Value() optimization for InlineType (**Bug** - P5)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2351/head:pull/2351` \
`$ git checkout pull/2351`

Update a local copy of the PR: \
`$ git checkout pull/2351` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2351`

View PR using the GUI difftool: \
`$ git pr show -t 2351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2351.diff">https://git.openjdk.org/valhalla/pull/2351.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2351#issuecomment-4296168013)
</details>
