### PR TITLE
8382810: [lworld] ImageReader mishandles preview resource paths

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -89,6 +89,10 @@ import static jdk.internal.jimage.ImageLocation.PREVIEW_INFIX;
  * to the jimage file provided by the shipped JDK by tools running on JDK 8.
  */
 public final class ImageReader implements AutoCloseable {
+
+    // For resource paths, there's no leading '/'.
+    private static final String PREVIEW_RESOURCE_PREFIX = PREVIEW_INFIX.substring(1);
+
     private final SharedImageReader reader;
 
     private volatile boolean closed;
@@ -470,12 +474,22 @@ public final class ImageReader implements AutoCloseable {
             if (moduleName.indexOf('/') >= 0) {
                 throw new IllegalArgumentException("invalid module name: " + moduleName);
             }
+            if (resourcePath.startsWith(PREVIEW_RESOURCE_PREFIX)) {
+                return null;
+            }
             String nodeName = MODULES_PREFIX + "/" + moduleName + "/" + resourcePath;
             // Synchronize as tightly as possible to reduce locking contention.
             synchronized (this) {
                 Node node = nodes.get(nodeName);
                 if (node == null) {
-                    ImageLocation loc = findLocation(moduleName, resourcePath);
+                    ImageLocation loc = null;
+                    if (previewMode) {
+                        // We must test preview location first (if in preview mode).
+                        loc = findLocation(moduleName, PREVIEW_RESOURCE_PREFIX + resourcePath);
+                    }
+                    if (loc == null) {
+                        loc = findLocation(moduleName, resourcePath);
+                    }
                     if (loc != null && loc.getType() == RESOURCE) {
                         node = newResource(nodeName, loc);
                         nodes.put(node.getName(), node);
@@ -501,8 +515,12 @@ public final class ImageReader implements AutoCloseable {
             if (moduleName.indexOf('/') >= 0) {
                 throw new IllegalArgumentException("invalid module name: " + moduleName);
             }
+            if (resourcePath.startsWith(PREVIEW_RESOURCE_PREFIX)) {
+                return false;
+            }
             // In preview mode, preview-only resources are eagerly added to the
             // cache, so we must check that first.
+            ImageLocation loc = null;
             if (previewMode) {
                 String nodeName = MODULES_PREFIX + "/" + moduleName + "/" + resourcePath;
                 // Synchronize as tightly as possible to reduce locking contention.
@@ -512,8 +530,11 @@ public final class ImageReader implements AutoCloseable {
                         return node.isResource();
                     }
                 }
+                loc = findLocation(moduleName, PREVIEW_RESOURCE_PREFIX + resourcePath);
             }
-            ImageLocation loc = findLocation(moduleName, resourcePath);
+            if (loc == null) {
+                loc = findLocation(moduleName, resourcePath);
+            }
             return loc != null && loc.getType() == RESOURCE;
         }
 

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -102,7 +102,8 @@ public class ImageReaderTest {
             "/modules/modbar",
             "/modules/modfoo/com",
             "/modules/modfoo/com/foo",
-            "/modules/modfoo/com/foo/bar"})
+            "/modules/modfoo/com/foo/bar",
+    })
     public void testModuleDirectories_expected(String name) throws IOException {
         try (ImageReader reader = ImageReader.open(image, PreviewMode.DISABLED)) {
             assertDir(reader, name);
@@ -117,7 +118,8 @@ public class ImageReaderTest {
             "/modules/unknown",
             "/modules/modbar/",
             "/modules/modfoo//com",
-            "/modules/modfoo/com/"})
+            "/modules/modfoo/com/",
+    })
     public void testModuleNodes_absent(String name) throws IOException {
         try (ImageReader reader = ImageReader.open(image, PreviewMode.DISABLED)) {
             assertAbsent(reader, name);
@@ -144,13 +146,15 @@ public class ImageReaderTest {
             "modbar:com/bar/One.class",
     })
     public void testResource_present(String modName, String resPath) throws IOException {
-        try (ImageReader reader = ImageReader.open(image, PreviewMode.DISABLED)) {
-            assertNotNull(reader.findResourceNode(modName, resPath));
-            assertTrue(reader.containsResource(modName, resPath));
+        for (PreviewMode mode : List.of(PreviewMode.ENABLED, PreviewMode.DISABLED)) {
+            try (ImageReader reader = ImageReader.open(image, mode)) {
+                assertNotNull(reader.findResourceNode(modName, resPath));
+                assertTrue(reader.containsResource(modName, resPath));
 
-            String canonicalNodeName = "/modules/" + modName + "/" + resPath;
-            Node node = reader.findNode(canonicalNodeName);
-            assertTrue(node != null && node.isResource());
+                String canonicalNodeName = "/modules/" + modName + "/" + resPath;
+                Node node = reader.findNode(canonicalNodeName);
+                assertTrue(node != null && node.isResource());
+            }
         }
     }
 
@@ -169,17 +173,22 @@ public class ImageReaderTest {
             "packages:com.foo/modfoo",
             // Empty module names/paths do not find resources.
             "'':modfoo/com/foo/HasPreviewVersion.class",
-            "modfoo:''"})
+            "modfoo:''",
+            // Make sure preview paths are excluded.
+            "modfoo:META-INF/preview/com/foo/HasPreviewVersion.class",
+    })
     public void testResource_absent(String modName, String resPath) throws IOException {
-        try (ImageReader reader = ImageReader.open(image, PreviewMode.DISABLED)) {
-            assertNull(reader.findResourceNode(modName, resPath));
-            assertFalse(reader.containsResource(modName, resPath));
+        for (PreviewMode mode : List.of(PreviewMode.ENABLED, PreviewMode.DISABLED)) {
+            try (ImageReader reader = ImageReader.open(image, mode)) {
+                assertNull(reader.findResourceNode(modName, resPath));
+                assertFalse(reader.containsResource(modName, resPath));
 
-            // Non-existent resources names should either not be found,
-            // or (in the case of directory nodes) not be resources.
-            String canonicalNodeName = "/modules/" + modName + "/" + resPath;
-            Node node = reader.findNode(canonicalNodeName);
-            assertTrue(node == null || !node.isResource());
+                // Non-existent resources names should either not be found,
+                // or (in the case of directory nodes) not be resources.
+                String canonicalNodeName = "/modules/" + modName + "/" + resPath;
+                Node node = reader.findNode(canonicalNodeName);
+                assertTrue(node == null || !node.isResource());
+            }
         }
     }
 
@@ -191,9 +200,11 @@ public class ImageReaderTest {
             "modules/modfoo/com:foo/HasPreviewVersion.class",
     })
     public void testResource_invalid(String modName, String resPath) throws IOException {
-        try (ImageReader reader = ImageReader.open(image, PreviewMode.DISABLED)) {
-            assertThrows(IllegalArgumentException.class, () -> reader.containsResource(modName, resPath));
-            assertThrows(IllegalArgumentException.class, () -> reader.findResourceNode(modName, resPath));
+        for (PreviewMode mode : List.of(PreviewMode.ENABLED, PreviewMode.DISABLED)) {
+            try (ImageReader reader = ImageReader.open(image, mode)) {
+                assertThrows(IllegalArgumentException.class, () -> reader.containsResource(modName, resPath));
+                assertThrows(IllegalArgumentException.class, () -> reader.findResourceNode(modName, resPath));
+            }
         }
     }
 


### PR DESCRIPTION
Added correct checks to "fast path" read methods in ImageReader to avoid module readers being able to see preview resources.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382810](https://bugs.openjdk.org/browse/JDK-8382810): [lworld] ImageReader mishandles preview resource paths (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - no project role)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2354/head:pull/2354` \
`$ git checkout pull/2354`

Update a local copy of the PR: \
`$ git checkout pull/2354` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2354`

View PR using the GUI difftool: \
`$ git pr show -t 2354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2354.diff">https://git.openjdk.org/valhalla/pull/2354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2354#issuecomment-4296685304)
</details>
