### PR TITLE
8382639: [lworld] FlatFieldPayload resolves super class field from sub class

### DIFF
--- a/src/hotspot/share/oops/valuePayload.hpp
+++ b/src/hotspot/share/oops/valuePayload.hpp
@@ -224,26 +224,18 @@ private:
                           InlineLayoutInfo* inline_layout_info);
 
   inline void assert_post_construction_invariants(instanceOop container,
-                                                  ResolvedFieldEntry* resolved_field_entry,
-                                                  InstanceKlass* klass) const NOT_DEBUG_RETURN;
+                                                  ResolvedFieldEntry* resolved_field_entry) const NOT_DEBUG_RETURN;
   inline void assert_post_construction_invariants(instanceOop container,
-                                                  fieldDescriptor* field_descriptor,
-                                                  InstanceKlass* klass) const NOT_DEBUG_RETURN;
+                                                  fieldDescriptor* field_descriptor) const NOT_DEBUG_RETURN;
 
 public:
   FlatFieldPayload() = default;
 
   inline FlatFieldPayload(instanceOop container,
                           fieldDescriptor* field_descriptor);
-  inline FlatFieldPayload(instanceOop container,
-                          fieldDescriptor* field_descriptor,
-                          InstanceKlass* klass);
 
   inline FlatFieldPayload(instanceOop container,
                           ResolvedFieldEntry* resolved_field_entry);
-  inline FlatFieldPayload(instanceOop container,
-                          ResolvedFieldEntry* resolved_field_entry,
-                          InstanceKlass* klass);
 
   inline instanceOop container() const;
 

--- a/src/hotspot/share/oops/valuePayload.inline.hpp
+++ b/src/hotspot/share/oops/valuePayload.inline.hpp
@@ -599,8 +599,7 @@ inline FlatFieldPayload::FlatFieldPayload(instanceOop container,
 #ifdef ASSERT
 
 inline void FlatFieldPayload::assert_post_construction_invariants(instanceOop container,
-                                                                  ResolvedFieldEntry* resolved_field_entry,
-                                                                  InstanceKlass* klass) const {
+                                                                  ResolvedFieldEntry* resolved_field_entry) const {
   OnVMError on_assertion_failure([&](outputStream* st) {
     st->print_cr("=== assert_post_construction_invariants failure ===");
     StreamIndentor si(st);
@@ -608,14 +607,12 @@ inline void FlatFieldPayload::assert_post_construction_invariants(instanceOop co
     st->cr();
   });
 
-  postcond(container->klass()->is_subclass_of(klass));
-  postcond(klass == resolved_field_entry->field_holder());
+  postcond(container->klass()->is_subclass_of(resolved_field_entry->field_holder()));
   postcond(resolved_field_entry->is_flat());
 }
 
 inline void FlatFieldPayload::assert_post_construction_invariants(instanceOop container,
-                                                                  fieldDescriptor* field_descriptor,
-                                                                  InstanceKlass* klass) const {
+                                                                  fieldDescriptor* field_descriptor) const {
   OnVMError on_assertion_failure([&](outputStream* st) {
     st->print_cr("=== assert_post_construction_invariants failure ===");
     StreamIndentor si(st);
@@ -623,8 +620,7 @@ inline void FlatFieldPayload::assert_post_construction_invariants(instanceOop co
     st->cr();
   });
 
-  postcond(container->klass()->is_subclass_of(klass));
-  postcond(klass == field_descriptor->field_holder());
+  postcond(container->klass()->is_subclass_of(field_descriptor->field_holder()));
   postcond(field_descriptor->is_flat());
 }
 
@@ -632,31 +628,18 @@ inline void FlatFieldPayload::assert_post_construction_invariants(instanceOop co
 
 inline FlatFieldPayload::FlatFieldPayload(instanceOop container,
                                           fieldDescriptor* field_descriptor)
-    : FlatFieldPayload(container, field_descriptor,
-                       InstanceKlass::cast(container->klass())) {}
-
-inline FlatFieldPayload::FlatFieldPayload(instanceOop container,
-                                          fieldDescriptor* field_descriptor,
-                                          InstanceKlass* klass)
     : FlatFieldPayload(container,
                        field_descriptor->offset(),
-                       klass->inline_layout_info_adr(field_descriptor->index())) {
-  assert_post_construction_invariants(container, field_descriptor, klass);
+                       field_descriptor->field_holder()->inline_layout_info_adr(field_descriptor->index())) {
+  assert_post_construction_invariants(container, field_descriptor);
 }
 
 inline FlatFieldPayload::FlatFieldPayload(instanceOop container,
                                           ResolvedFieldEntry* resolved_field_entry)
     : FlatFieldPayload(container,
-                       resolved_field_entry,
-                       resolved_field_entry->field_holder()) {}
-
-inline FlatFieldPayload::FlatFieldPayload(instanceOop container,
-                                          ResolvedFieldEntry* resolved_field_entry,
-                                          InstanceKlass* klass)
-    : FlatFieldPayload(container,
                        resolved_field_entry->field_offset(),
-                       klass->inline_layout_info_adr(resolved_field_entry->field_index())) {
-  assert_post_construction_invariants(container, resolved_field_entry, klass);
+                       resolved_field_entry->field_holder()->inline_layout_info_adr(resolved_field_entry->field_index())) {
+  assert_post_construction_invariants(container, resolved_field_entry);
 }
 
 inline instanceOop FlatFieldPayload::container() const {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InheritedFlatFieldTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InheritedFlatFieldTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.inlinetypes;
+
+import java.lang.reflect.Field;
+
+import jdk.internal.misc.Unsafe;
+import jdk.internal.vm.annotation.NullRestricted;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @summary Test JNI access to an inherited flat field
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED
+ *                          -XX:+UnlockDiagnosticVMOptions
+ *                          -XX:+UseFieldFlattening
+ *                          runtime.valhalla.inlinetypes.InheritedFlatFieldTest
+ */
+public class InheritedFlatFieldTest {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static {
+        System.loadLibrary("InheritedFlatFieldTest");
+    }
+
+    static value class Value {
+        int x;
+
+        Value(int x) {
+            this.x = x;
+        }
+    }
+
+    static class BaseHolder {
+        @NullRestricted
+        Value baseValue;
+
+        BaseHolder() {
+            baseValue = new Value(11);
+            super();
+        }
+    }
+
+    static class DerivedHolder extends BaseHolder {
+        @NullRestricted
+        Value derivedValue;
+
+        DerivedHolder() {
+            derivedValue = new Value(22);
+            super();
+        }
+    }
+
+    private static native Value readBaseValue(Object obj);
+    private static native Value readDerivedValue(Object obj);
+    private static native void writeBaseValue(Object obj, Value value);
+
+    public static void main(String[] args) throws Exception {
+        Field baseField = BaseHolder.class.getDeclaredField("baseValue");
+        Field derivedField = DerivedHolder.class.getDeclaredField("derivedValue");
+        Asserts.assertTrue(UNSAFE.isFlatField(baseField), "base field should be flattened");
+        Asserts.assertTrue(UNSAFE.isFlatField(derivedField), "derived field should be flattened");
+
+        BaseHolder base = new BaseHolder();
+        Value baseRead = readBaseValue(base);
+        Asserts.assertNotNull(baseRead);
+        Asserts.assertEquals(baseRead.x, 11, "Unexpected base class field JNI read");
+
+        Value baseReplacement = new Value(33);
+        writeBaseValue(base, baseReplacement);
+        Asserts.assertEquals(base.baseValue.x, 33, "Base class JNI write did not update base field");
+        Asserts.assertEquals(readBaseValue(base).x, 33, "Base class JNI read after write returned wrong value");
+
+        DerivedHolder derived = new DerivedHolder();
+        Value derivedRead = readDerivedValue(derived);
+        Asserts.assertNotNull(derivedRead);
+        Asserts.assertEquals(derivedRead.x, 22, "Unexpected subclass field JNI read");
+
+        Value inheritedRead = readBaseValue(derived);
+        Asserts.assertNotNull(inheritedRead);
+        Asserts.assertEquals(inheritedRead.x, 11, "Unexpected inherited base class field JNI read");
+
+        Value derivedReplacement = new Value(44);
+        writeBaseValue(derived, derivedReplacement);
+        Asserts.assertEquals(derived.baseValue.x, 44, "JNI write did not update base field");
+        Asserts.assertEquals(readBaseValue(derived).x, 44, "JNI read after write returned wrong value");
+        Asserts.assertEquals(readDerivedValue(derived).x, 22, "Subclass field should be unchanged");
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InheritedFlatFieldTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InheritedFlatFieldTest.java
@@ -25,7 +25,6 @@ package runtime.valhalla.inlinetypes;
 
 import java.lang.reflect.Field;
 
-import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.NullRestricted;
 import jdk.test.lib.Asserts;
 
@@ -33,17 +32,12 @@ import jdk.test.lib.Asserts;
  * @test
  * @summary Test JNI access to an inherited flat field
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.base/jdk.internal.vm.annotation
+ * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
  * @run main/othervm/native --enable-native-access=ALL-UNNAMED
- *                          -XX:+UnlockDiagnosticVMOptions
- *                          -XX:+UseFieldFlattening
  *                          runtime.valhalla.inlinetypes.InheritedFlatFieldTest
  */
 public class InheritedFlatFieldTest {
-    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
-
     static {
         System.loadLibrary("InheritedFlatFieldTest");
     }
@@ -81,11 +75,6 @@ public class InheritedFlatFieldTest {
     private static native void writeBaseValue(Object obj, Value value);
 
     public static void main(String[] args) throws Exception {
-        Field baseField = BaseHolder.class.getDeclaredField("baseValue");
-        Field derivedField = DerivedHolder.class.getDeclaredField("derivedValue");
-        Asserts.assertTrue(UNSAFE.isFlatField(baseField), "base field should be flattened");
-        Asserts.assertTrue(UNSAFE.isFlatField(derivedField), "derived field should be flattened");
-
         BaseHolder base = new BaseHolder();
         Value baseRead = readBaseValue(base);
         Asserts.assertNotNull(baseRead);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInheritedFlatFieldTest.c
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInheritedFlatFieldTest.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+
+#define VALUE_SIGNATURE "Lruntime/valhalla/inlinetypes/InheritedFlatFieldTest$Value;"
+#define BASE_FIELD_NAME "baseValue"
+#define DERIVED_FIELD_NAME "derivedValue"
+
+static jfieldID get_field_id(JNIEnv* env, jobject obj, const char* field_name) {
+    jclass receiver_class = (*env)->GetObjectClass(env, obj);
+    return (*env)->GetFieldID(env, receiver_class, field_name, VALUE_SIGNATURE);
+}
+
+static jobject read_field(JNIEnv* env, jobject obj, const char* field_name) {
+    jfieldID field_id = get_field_id(env, obj, field_name);
+    return (*env)->GetObjectField(env, obj, field_id);
+}
+
+JNIEXPORT jobject JNICALL
+Java_runtime_valhalla_inlinetypes_InheritedFlatFieldTest_readBaseValue(JNIEnv* env, jclass klass, jobject obj) {
+    return read_field(env, obj, BASE_FIELD_NAME);
+}
+
+JNIEXPORT jobject JNICALL
+Java_runtime_valhalla_inlinetypes_InheritedFlatFieldTest_readDerivedValue(JNIEnv* env, jclass klass, jobject obj) {
+    return read_field(env, obj, DERIVED_FIELD_NAME);
+}
+
+JNIEXPORT void JNICALL
+Java_runtime_valhalla_inlinetypes_InheritedFlatFieldTest_writeBaseValue(JNIEnv* env, jclass klass, jobject obj, jobject value) {
+    jfieldID field_id = get_field_id(env, obj, BASE_FIELD_NAME);
+    (*env)->SetObjectField(env, obj, field_id, value);
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInheritedFlatFieldTest.c
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInheritedFlatFieldTest.c
@@ -52,3 +52,7 @@ Java_runtime_valhalla_inlinetypes_InheritedFlatFieldTest_writeBaseValue(JNIEnv* 
     jfieldID field_id = get_field_id(env, obj, BASE_FIELD_NAME);
     (*env)->SetObjectField(env, obj, field_id, value);
 }
+
+#undef VALUE_SIGNATURE
+#undef BASE_FIELD_NAME
+#undef DERIVED_FIELD_NAME


### PR DESCRIPTION
Hi everyone,

One of the `FlatFieldPayload` constructors uses `container->klass()` when calling `inline_layout_info_adr`, even though the layout should be resolved from `field_holder()`. When JNI `GetObjectField` or `SetObjectField` accesses an inherited flat field on a derived class it ends up looking up inline layout info from the that class instead of the class that actually declares the field. In debug builds this triggers an assert, and in general it is the wrong class to use for the lookup.

This path is only reached through JNI field access. The original fix is from @stefank. I added a regression test that tests JNI reads and writes of inherited flat fields and checks that the inherited base field is resolved correctly. The new test hits the assert before the fix and passes with the patch applied.

Testing:
- Tier 1
- New test testing modifying inherited flat fields through JNI 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382639](https://bugs.openjdk.org/browse/JDK-8382639): [lworld] FlatFieldPayload resolves super class field from sub class (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer) ⚠️ Review applies to [c62454e1](https://git.openjdk.org/valhalla/pull/2355/files/c62454e13084410f87d5f9b5fc6dcccdec2be62b)


### Contributors
 * Stefan Karlsson `<stefank@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2355/head:pull/2355` \
`$ git checkout pull/2355`

Update a local copy of the PR: \
`$ git checkout pull/2355` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2355`

View PR using the GUI difftool: \
`$ git pr show -t 2355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2355.diff">https://git.openjdk.org/valhalla/pull/2355.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2355#issuecomment-4296751058)
</details>
