### PR TITLE
8382814: [lworld] C2: crash with late inlining of call with circular value argument

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -701,6 +701,8 @@ void CallGenerator::do_late_inline_helper() {
         // field of the inline type. Build InlineTypeNodes from the inline type arguments.
         GraphKit arg_kit(jvms, &gvn);
         Node* vt = InlineTypeNode::make_from_multi(&arg_kit, call, t->inline_klass(), j, /* in= */ true, /* null_free= */ !t->maybe_null());
+        // GraphKit::access_load_at() may be called from InlineTypeNode::make_from_multi() and it may change the map
+        // that arg_kit uses.
         map = arg_kit.map();
         map->set_control(arg_kit.control());
         map->set_argument(jvms, i1, vt);

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -701,6 +701,7 @@ void CallGenerator::do_late_inline_helper() {
         // field of the inline type. Build InlineTypeNodes from the inline type arguments.
         GraphKit arg_kit(jvms, &gvn);
         Node* vt = InlineTypeNode::make_from_multi(&arg_kit, call, t->inline_klass(), j, /* in= */ true, /* null_free= */ !t->maybe_null());
+        map = arg_kit.map();
         map->set_control(arg_kit.control());
         map->set_argument(jvms, i1, vt);
       } else {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -887,6 +887,7 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
       // Use immutable memory for inline type loads and restore it below
       kit.set_all_memory(C->immutable_memory());
       parm = InlineTypeNode::make_from_multi(&kit, start, t->inline_klass(), j, /* in= */ true, /* null_free= */ !t->maybe_null());
+      assert(map == kit.map(), "broken if map changes");
       map->set_control(kit.control());
       map->set_memory(old_mem);
     } else {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInliningIncorrectArgs.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInliningIncorrectArgs.java
@@ -25,7 +25,7 @@
  * @test
  * @enablePreview
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @run main/othervm -XX:-BackgroundCompilation -XX:+AlwaysIncrementalInline ${test.main.class}
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline ${test.main.class}
  */
 
 package compiler.valhalla.inlinetypes;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInliningIncorrectArgs.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInliningIncorrectArgs.java
@@ -35,6 +35,7 @@ public class TestLateInliningIncorrectArgs {
     static public void main(String[] args) {
         for (int i = 0; i < 20_000; i++) {
             test1();
+            test2();
         }
     }
 
@@ -49,6 +50,14 @@ public class TestLateInliningIncorrectArgs {
     }
 
     static int lateInlined1(MyValue1 v1, C c) {
+        return c.field;
+    }
+
+    static void test2() {
+        lateInlined2(v1, v1, c);
+    }
+
+    static int lateInlined2(MyValue1 v1, MyValue1 v2, C c) {
         return c.field;
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInliningIncorrectArgs.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInliningIncorrectArgs.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @enablePreview
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+AlwaysIncrementalInline ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+
+public class TestLateInliningIncorrectArgs {
+    static public void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1();
+        }
+    }
+
+
+    static final MyValue2 v3 = new MyValue2((byte)42, null);
+    static final MyValue2 v2 = new MyValue2((byte)42, v3);
+    static final MyValue1 v1 = new MyValue1((byte)42, v2);
+    static final C c = new C(42);
+
+    static void test1() {
+        lateInlined1(v1, c);
+    }
+
+    static int lateInlined1(MyValue1 v1, C c) {
+        return c.field;
+    }
+
+    static value class MyValue1 {
+        byte byteField;
+        MyValue2 next;
+
+        MyValue1(byte byteField, MyValue2 next) {
+            this.byteField = byteField;
+            this.next = next;
+        }
+    };
+
+    static value class MyValue2 {
+        byte byteField;
+        MyValue2 next;
+
+        MyValue2(byte byteField, MyValue2 next) {
+            this.byteField = byteField;
+            this.next = next;
+        }
+    };
+
+    static class C {
+        int field;
+
+        C(int field) {
+            this.field = field;
+        }
+    }
+}


### PR DESCRIPTION
When doing late inlining, `GraphKit::access_load_at()` may be called
to populate an `InlineTypeNode`. When it executes, it, sometimes,
causes the `map` used by the `GraphKit` instance to change. When that
happens, `CallGenerator::do_late_inline_helper()` continues execution
with an outdated `map` which causes issues during parsing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382814](https://bugs.openjdk.org/browse/JDK-8382814): [lworld] C2: crash with late inlining of call with circular value argument (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2356/head:pull/2356` \
`$ git checkout pull/2356`

Update a local copy of the PR: \
`$ git checkout pull/2356` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2356`

View PR using the GUI difftool: \
`$ git pr show -t 2356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2356.diff">https://git.openjdk.org/valhalla/pull/2356.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2356#issuecomment-4296899287)
</details>
