### PR TITLE
8382776: [lworld] applications/ctw/modules/java_desktop.java fails with COH

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1633,8 +1633,12 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   } else {
     Register tmp1 = op->tmp1()->as_register();
     Register tmp2 = op->tmp2()->as_register();
-    __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
-    __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
+    if (left == right) { // same operand, so clearly the same klasses, let's save the check
+      __ jmp (*op->stub()->entry());  //  -> do slow check
+    } else {
+      __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
+      __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
+    }
     // fall through to L_oops_not_equal
   }
 


### PR DESCRIPTION
In `javax.swing.JComponent::_paintImmediately`, in `src/java.desktop/share/classes/javax/swing/JComponent.java`, because few classes are loaded during CTW, `isOptimizedDrawingEnabled()` is believed to be always true (because no overload is known), so
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/java.desktop/share/classes/javax/swing/JComponent.java#L5123
seems impossible, which is the only path that allows to re-assign `paintingComponent`. Few steps later, we meet the comparison
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/java.desktop/share/classes/javax/swing/JComponent.java#L5213
and then, `paintingComponent` is known to be `this` (still under the assumption there are no overloads of `isOptimizedDrawingEnabled`).

Overall, C1 is right to believe we are comparing `this` with itself. So, in
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp#L1636
`left` and `right` are the same thing. In the callee, if `UseCompactObjectHeaders`:
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/cpu/x86/macroAssembler_x86.cpp#L5722-L5733
we assert that `left` (`tmp1`) and `right` (`tmp2`) are distinct (among other). This doesn't sound very necessary, but on the other hand, the test is rather redundant if `tmp1 == tmp2`. It is also weird we aren't doing this test in the `else` branch. The non-COH case is a bit cheaper, and so a bit less bad to have uselessly, but it doesn't sound like a very convincing reason. Let's say it's because of history.

We could remove the assert, but can save from a useless class comparison. Also, the callee is older than the caller. I suggest we simply bypass the test in the caller if `left == right`. In this case, it is obvious the test would be successful, and we can just emit an unconditional jump.

Another option would be to shortcut the whole function by adding
```cpp
  if (left == right) {
    move(op->equal_result(), op->result_opr());
    return;
  }
```
immediately after
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp#L1599-L1600
but then we don't run
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp#L1652
and so we hit this assert
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/share/c1/c1_LIRAssembler.cpp#L157

Maybe
```cpp
  if (left == right) {
    __ bind(*op->stub()->continuation());  // Just to bind it
    move(op->equal_result(), op->result_opr());
    return;
  }
```
would be enough, but I'm scared to break a subtle invariant somewhere about stubs, by not going in. Moreover, because of
https://github.com/openjdk/valhalla/blob/e391f76e7db834f50c1a0af466daf95a65a79f23/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp#L1602-L1603
we already don't execute any of this code at runtime. The runtime gain is minimal, so I tend toward stability (it's just C1 after all...), at least for now, with Valhalla integration getting close. I suppose a better improvement might be to simply fold the substitutability check entirely, but that might be too much for C1's limited responsibilities and simple behavior.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382776](https://bugs.openjdk.org/browse/JDK-8382776): [lworld] applications/ctw/modules/java_desktop.java fails with COH (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2359/head:pull/2359` \
`$ git checkout pull/2359`

Update a local copy of the PR: \
`$ git checkout pull/2359` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2359`

View PR using the GUI difftool: \
`$ git pr show -t 2359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2359.diff">https://git.openjdk.org/valhalla/pull/2359.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2359#issuecomment-4301980406)
</details>
