### PR TITLE
8382882: [lworld] Various cleanups of TODOs/FIXMEs in core libraries

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
@@ -44,16 +44,16 @@ import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@link Attributes#loadableDescriptors() LoadableDescriptors}
- * attribute (JVMS {@jvms value-objects-4.7.32}), which suggests the JVM may load mentioned
- * types before the {@code class} file carrying this attribute is loaded.
+ * attribute (JVMS {@jvms value-objects-4.7.32}), which permits the JVM to
+ * load mentioned classes and interfaces before the {@code class} file carrying
+ * this attribute is loaded.
  * <p>
  * This attribute only appears on classes, and does not permit {@linkplain
  * AttributeMapper#allowMultiple multiple instances} in a class.  It has a
  * data dependency on the {@linkplain AttributeMapper.AttributeStability#CP_REFS
  * constant pool}.
  * <p>
- * The attribute was introduced in the Java SE Platform version XX, major
- * version {@value ClassFile#JAVA_25_VERSION}. (FIXME)
+ * The attribute is a preview VM feature in the current Java SE release.
  *
  * @see Attributes#loadableDescriptors()
  * @jvms value-objects-4.7.32 The {@code LoadableDescriptors} Attribute

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -89,7 +89,6 @@ public final class BufWriterImpl implements BufWriter {
     }
 
     private boolean doStrictFieldsMatchCheck(ClassModel cm) {
-        // TODO only check for preview class files?
         // UTF8 Entry can be used as equality objects
         var checks = new HashSet<>(Arrays.asList(getStrictInstanceFields()));
         for (var f : cm.fields()) {
@@ -116,6 +115,7 @@ public final class BufWriterImpl implements BufWriter {
         this.labelsMatch = labelsMatch;
     }
 
+    // Always empty for older majors where STRICT_INIT was not defined
     public WritableField.UnsetField[] getStrictInstanceFields() {
         assert strictInstanceFields != null : "should access only after setter call in DirectClassBuilder";
         return strictInstanceFields;

--- a/test/jdk/jdk/classfile/StrictStackMapsTest.java
+++ b/test/jdk/jdk/classfile/StrictStackMapsTest.java
@@ -147,16 +147,16 @@ class StrictStackMapsTest {
                         .iconst_0()
                         .ifThenElse(thb -> thb
                                 .iconst_3()
-                                .putfield(classDesc, "fPlain", CD_int), elb -> elb
+                                .putfield(classDesc, "fPlain", CD_char), elb -> elb
                                 .iconst_2()
-                                .putfield(classDesc, "fPlain", CD_int))
+                                .putfield(classDesc, "fPlain", CD_char))
                         .aload(0)
                         .iconst_5()
                         .putfield(classDesc, "fsf", CD_int)
                         .aload(0)
                         .invokespecial(CD_Object, INIT_NAME, MTD_void)
                         .return_()));
-        // runtimeVerify(className, classBytes); // TODO VM fix branching
+        runtimeVerify(className, classBytes);
         var classModel = ClassFile.of().parse(classBytes);
         var ctorModel = classModel.methods().getFirst();
         var stackMaps = ctorModel.code().orElseThrow().findAttribute(Attributes.stackMapTable()).orElseThrow();
@@ -351,7 +351,7 @@ class StrictStackMapsTest {
                            // jump to else - fs, fsf unset
                            frames.add(StackMapFrameInfo.of(elb.startLabel(),
                                    List.of(StackMapFrameInfo.SimpleVerificationTypeInfo.UNINITIALIZED_THIS),
-                                   List.of(),
+                                   List.of(StackMapFrameInfo.SimpleVerificationTypeInfo.UNINITIALIZED_THIS),
                                    List.of(elb.constantPool().nameAndTypeEntry("fs", CD_int),
                                            elb.constantPool().nameAndTypeEntry("fsf", CD_int))));
                            elb.iconst_2()
@@ -376,7 +376,7 @@ class StrictStackMapsTest {
                     cob.return_()
                        .with(StackMapTableAttribute.of(frames));
                 }));
-        // runtimeVerify(className, classBytes); // TODO VM fix
+        runtimeVerify(className, classBytes);
         var classModel = ClassFile.of().parse(classBytes);
         var ctorModel = classModel.methods().getFirst();
         var stackMaps = ctorModel.code().orElseThrow().findAttribute(Attributes.stackMapTable()).orElseThrow();

--- a/test/jdk/valhalla/valuetypes/Reflection.java
+++ b/test/jdk/valhalla/valuetypes/Reflection.java
@@ -126,9 +126,8 @@ public class Reflection {
     public void testArrays(Class<?> arrayClass, Object[] array, boolean nullRestricted, Object element) {
         Class<?> componentType = arrayClass.getComponentType();
         assertTrue(arrayClass.isArray());
-        // TODO: check Array.getComponentType(array) instead
-        assertTrue(array.getClass() == arrayClass || nullRestricted);
-        assertTrue(array.getClass().getComponentType() == componentType || nullRestricted);
+        assertSame(arrayClass, array.getClass());
+        assertSame(componentType, array.getClass().getComponentType());
 
         for (int i = 0; i < array.length; i++) {
             Object o = Array.get(array, i);


### PR DESCRIPTION
Tobias did a search in lworld for introduced TODOs. These are the ones in core library code except jimage, and they are all addressed in this patch.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382882](https://bugs.openjdk.org/browse/JDK-8382882): [lworld] Various cleanups of TODOs/FIXMEs in core libraries (**Enhancement** - P4)


### Reviewers
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2360/head:pull/2360` \
`$ git checkout pull/2360`

Update a local copy of the PR: \
`$ git checkout pull/2360` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2360`

View PR using the GUI difftool: \
`$ git pr show -t 2360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2360.diff">https://git.openjdk.org/valhalla/pull/2360.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2360#issuecomment-4302301547)
</details>
