### PR TITLE
8382941: [lworld] Incorrect handling of naturally atomic values

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -79,7 +79,7 @@ static LayoutKind field_layout_selection(FieldInfo field_info, Array<InlineLayou
   if (field_info.field_flags().is_null_free_inline_type()) {
     assert(field_info.access_flags().is_strict(), "null-free fields must be strict");
     if (vk->must_be_atomic() || AlwaysAtomicAccesses) {
-      if (vk->is_naturally_atomic() && vk->has_null_free_non_atomic_layout()) return LayoutKind::NULL_FREE_NON_ATOMIC_FLAT;
+      if (vk->is_naturally_atomic(true) && vk->has_null_free_non_atomic_layout()) return LayoutKind::NULL_FREE_NON_ATOMIC_FLAT;
       return (vk->has_null_free_atomic_layout() && can_use_atomic_flat) ? LayoutKind::NULL_FREE_ATOMIC_FLAT : LayoutKind::REFERENCE;
     } else {
       return vk->has_null_free_non_atomic_layout() ? LayoutKind::NULL_FREE_NON_ATOMIC_FLAT : LayoutKind::REFERENCE;
@@ -976,7 +976,7 @@ void FieldLayoutBuilder::inline_class_field_sorting() {
         assert(_inline_layout_info_array->adr_at(field_index)->klass() != nullptr, "Klass must have been set");
         _has_inlined_fields = true;
         InlineKlass* vk = _inline_layout_info_array->adr_at(field_index)->klass();
-        if (!vk->is_naturally_atomic()) _has_non_naturally_atomic_fields = true;
+        if (!vk->is_naturally_atomic(true)) _has_non_naturally_atomic_fields = true;
         group->add_flat_field(idx, vk, lk);
         _inline_layout_info_array->adr_at(field_index)->set_kind(lk);
         _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
@@ -1190,8 +1190,19 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
 
   // Determining if the value class is naturally atomic:
   if ((!_layout->super_has_nonstatic_fields() && _declared_nonstatic_fields_count <= 1 && !_has_non_naturally_atomic_fields)
-      || (_layout->super_has_nonstatic_fields() && _super_klass->is_naturally_atomic() && _declared_nonstatic_fields_count == 0)) {
-        _is_naturally_atomic = true;
+      || (_layout->super_has_nonstatic_fields() && _super_klass->is_naturally_atomic(true) && _declared_nonstatic_fields_count == 0)) {
+    if (_declared_nonstatic_fields_count == 1) {
+        LayoutRawBlock* field = _layout->first_field_block();
+        bool is_nullable_flat = LayoutKindHelper::is_nullable_flat(field->layout_kind());
+        bool is_empty_value = is_nullable_flat ? field->inline_klass()->is_empty_inline_type() : false;
+        if (is_nullable_flat && !is_empty_value) {
+          _is_naturally_atomic = false;
+        } else {
+          _is_naturally_atomic = true;
+        }
+    } else {
+      _is_naturally_atomic = true;
+    }
   }
 
   // At this point, the characteristics of the raw layout (used in standalone instances) are known.

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -79,7 +79,7 @@ static LayoutKind field_layout_selection(FieldInfo field_info, Array<InlineLayou
   if (field_info.field_flags().is_null_free_inline_type()) {
     assert(field_info.access_flags().is_strict(), "null-free fields must be strict");
     if (vk->must_be_atomic() || AlwaysAtomicAccesses) {
-      if (vk->is_naturally_atomic(true) && vk->has_null_free_non_atomic_layout()) return LayoutKind::NULL_FREE_NON_ATOMIC_FLAT;
+      if (vk->is_naturally_atomic(true /* null-free */) && vk->has_null_free_non_atomic_layout()) return LayoutKind::NULL_FREE_NON_ATOMIC_FLAT;
       return (vk->has_null_free_atomic_layout() && can_use_atomic_flat) ? LayoutKind::NULL_FREE_ATOMIC_FLAT : LayoutKind::REFERENCE;
     } else {
       return vk->has_null_free_non_atomic_layout() ? LayoutKind::NULL_FREE_NON_ATOMIC_FLAT : LayoutKind::REFERENCE;
@@ -1190,7 +1190,7 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
 
   // Determining if the value class is naturally atomic:
   if (_declared_nonstatic_fields_count == 0) {
-    _is_naturally_atomic = _super_klass == vmClasses::Object_klass() || _super_klass->is_naturally_atomic(true);
+    _is_naturally_atomic = _super_klass == vmClasses::Object_klass() || _super_klass->is_naturally_atomic(true /* null-free */);
   } else if (_declared_nonstatic_fields_count == 1) {
     _is_naturally_atomic = !_layout->super_has_nonstatic_fields() && !_has_non_naturally_atomic_fields;
   } else {

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -976,7 +976,7 @@ void FieldLayoutBuilder::inline_class_field_sorting() {
         assert(_inline_layout_info_array->adr_at(field_index)->klass() != nullptr, "Klass must have been set");
         _has_inlined_fields = true;
         InlineKlass* vk = _inline_layout_info_array->adr_at(field_index)->klass();
-        if (!vk->is_naturally_atomic(true)) _has_non_naturally_atomic_fields = true;
+        if (!vk->is_naturally_atomic(LayoutKindHelper::is_null_free_flat(lk))) _has_non_naturally_atomic_fields = true;
         group->add_flat_field(idx, vk, lk);
         _inline_layout_info_array->adr_at(field_index)->set_kind(lk);
         _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
@@ -1189,20 +1189,12 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
   }
 
   // Determining if the value class is naturally atomic:
-  if ((!_layout->super_has_nonstatic_fields() && _declared_nonstatic_fields_count <= 1 && !_has_non_naturally_atomic_fields)
-      || (_layout->super_has_nonstatic_fields() && _super_klass->is_naturally_atomic(true) && _declared_nonstatic_fields_count == 0)) {
-    if (_declared_nonstatic_fields_count == 1) {
-        LayoutRawBlock* field = _layout->first_field_block();
-        bool is_nullable_flat = LayoutKindHelper::is_nullable_flat(field->layout_kind());
-        bool is_empty_value = is_nullable_flat ? field->inline_klass()->is_empty_inline_type() : false;
-        if (is_nullable_flat && !is_empty_value) {
-          _is_naturally_atomic = false;
-        } else {
-          _is_naturally_atomic = true;
-        }
-    } else {
-      _is_naturally_atomic = true;
-    }
+  if (_declared_nonstatic_fields_count == 0) {
+    _is_naturally_atomic = _super_klass == vmClasses::Object_klass() || _super_klass->is_naturally_atomic(true);
+  } else if (_declared_nonstatic_fields_count == 1) {
+    _is_naturally_atomic = !_layout->super_has_nonstatic_fields() && !_has_non_naturally_atomic_fields;
+  } else {
+    _is_naturally_atomic = false;
   }
 
   // At this point, the characteristics of the raw layout (used in standalone instances) are known.

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -179,6 +179,13 @@ void InlineLayoutInfo::print_on(outputStream* st) const {
   st->print("_null_marker_offset: %d", _null_marker_offset);
 }
 
+bool InstanceKlass::is_naturally_atomic(bool null_free) const {
+  assert(!is_identity_class(), "Doesn't have sense for an identity class");
+  if (!_misc_flags.is_naturally_atomic()) return false;
+  if (null_free) return true;
+  return InlineKlass::cast(this)->is_empty_inline_type();
+}
+
 bool InstanceKlass::_finalization_enabled = true;
 static int call_class_initializer_counter = 0;   // for debugging
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -179,11 +179,25 @@ void InlineLayoutInfo::print_on(outputStream* st) const {
   st->print("_null_marker_offset: %d", _null_marker_offset);
 }
 
+// A value class is considered naturally atomic if its layout,
+// once all fields flattening have been applied, contains a single primitive
+// or oop field. Because primitive types and oops are already handled
+// atomically by the JVM, it means that there's no need to take
+// special precautions when reading or writing this value to guarantee
+// cross-fields invariants. Nullability has to be taken into consideration,
+// as the null-marker has to be considered as a pseudo-field which must
+// be kept consistent with the payload. The only kind of value class
+// that can be considered naturally atomic when nullable is the empty
+// value classes because the dummy field is re-used as a null-marker.
 bool InstanceKlass::is_naturally_atomic(bool null_free) const {
   assert(!is_identity_class(), "Doesn't have sense for an identity class");
-  if (!_misc_flags.is_naturally_atomic()) return false;
-  if (null_free) return true;
-  return InlineKlass::cast(this)->is_empty_inline_type();
+  if (null_free) {
+    // No extra null-marker, just check the layout of the fields
+    return _misc_flags.is_naturally_atomic();
+  } else {
+    // Requires a null-marker, can't have any other fields
+    return InlineKlass::cast(this)->is_empty_inline_type();
+  }
 }
 
 bool InstanceKlass::_finalization_enabled = true;

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -406,7 +406,7 @@ class InstanceKlass: public Klass {
   bool has_inlined_fields() const { return _misc_flags.has_inlined_fields(); }
   void set_has_inlined_fields()   { _misc_flags.set_has_inlined_fields(true); }
 
-  bool is_naturally_atomic() const  { return _misc_flags.is_naturally_atomic(); }
+  bool is_naturally_atomic(bool null_free) const;
   void set_is_naturally_atomic()    { _misc_flags.set_is_naturally_atomic(true); }
 
   // Query if this class has atomicity requirements (default is yes)

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -201,7 +201,7 @@ ArrayDescription ObjArrayKlass::array_layout_selection(Klass* element, ArrayProp
       }
     } else {
       // Null-restricted + atomic
-      if (vk->is_naturally_atomic(true) && vk->has_null_free_non_atomic_layout()) {
+      if (vk->is_naturally_atomic(true /* null-free */) && vk->has_null_free_non_atomic_layout()) {
         return ArrayDescription(FlatArrayKlassKind, props, LayoutKind::NULL_FREE_NON_ATOMIC_FLAT);
       } else if (vk->has_null_free_atomic_layout()) {
         return ArrayDescription(FlatArrayKlassKind, props, LayoutKind::NULL_FREE_ATOMIC_FLAT);

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -201,7 +201,7 @@ ArrayDescription ObjArrayKlass::array_layout_selection(Klass* element, ArrayProp
       }
     } else {
       // Null-restricted + atomic
-      if (vk->is_naturally_atomic() && vk->has_null_free_non_atomic_layout()) {
+      if (vk->is_naturally_atomic(true) && vk->has_null_free_non_atomic_layout()) {
         return ArrayDescription(FlatArrayKlassKind, props, LayoutKind::NULL_FREE_NON_ATOMIC_FLAT);
       } else if (vk->has_null_free_atomic_layout()) {
         return ArrayDescription(FlatArrayKlassKind, props, LayoutKind::NULL_FREE_ATOMIC_FLAT);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -592,7 +592,8 @@ JVM_ENTRY(jboolean, JVM_IsAtomicArray(JNIEnv *env, jarray array))
     if (LayoutKindHelper::is_atomic_flat(fak->layout_kind())) {
       return true;
     }
-    if (fak->element_klass()->is_naturally_atomic()) {
+    bool is_null_free = !LayoutKindHelper::is_nullable_flat(fak->layout_kind());
+    if (fak->element_klass()->is_naturally_atomic(is_null_free)) {
       return true;
     }
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java
@@ -382,13 +382,45 @@ public class ValueCompositionTest {
 
   static public void check_9(FieldLayoutAnalyzer fla) {
     FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest$Container9");
-    FieldLayoutAnalyzer.FieldBlock f2 = cl.getFieldFromName("f2", false);
     if(useNullableNonAtomicFlat) {
+      FieldLayoutAnalyzer.FieldBlock f2 = cl.getFieldFromName("f2", false);
       // Flat null-free naturally atomic value, should have a NULL_FREE_NON_ATOMIC_FLAT layout
       Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULL_FREE_NON_ATOMIC_FLAT, f2.layoutKind());
       // Flat null-free non-naturally atomic value, must not have a NULL_FREE_NON_ATOMIC_FLAT layout
       FieldLayoutAnalyzer.FieldBlock f3 = cl.getFieldFromName("f3", false);
       Asserts.assertNotEquals(FieldLayoutAnalyzer.LayoutKind.NULL_FREE_NON_ATOMIC_FLAT, f3.layoutKind());
+    }
+  }
+
+  static abstract value class Value10a { }
+
+  static value class Value10b extends Value10a {}
+
+  static class Container10 {
+    @NullRestricted
+    Value10b f0;
+    Value10b f1;
+
+    Container10() {
+      f0 = new Value10b();
+      f1 = new Value10b();
+      super();
+    }
+  }
+
+  static public void test_10() {
+    var c = new Container10();
+  }
+
+  static  public void check_10(FieldLayoutAnalyzer fla) {
+    FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest$Container10");
+    if(useNullableNonAtomicFlat) {
+      FieldLayoutAnalyzer.FieldBlock f0 = cl.getFieldFromName("f0", false);
+      // Flat null-free empty value, should have a NULL_FREE_NON_ATOMIC_FLAT layout
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULL_FREE_NON_ATOMIC_FLAT, f0.layoutKind());
+      // Flat nullable empty value, should have a NULLABLE_NON_ATOMIC_FLAT layout
+      FieldLayoutAnalyzer.FieldBlock f1 = cl.getFieldFromName("f1", false);
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULLABLE_NON_ATOMIC_FLAT, f1.layoutKind());
     }
   }
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java
@@ -345,6 +345,53 @@ public class ValueCompositionTest {
   }
 
 
+  // Naturally atomic value
+  static value class Value9a {
+    int i = 0;
+  }
+
+  // Also a naturally atomic value
+  static value class Value9b {
+    @NullRestricted
+    Value9a f0 = new Value9a();
+  }
+
+  // Not a naturally atomic value because it contains two "fields":
+  //   - the int field from class Value9a
+  //   - the null marker of field f1 (included in f1 flat payload)
+  static value class Value9c {
+    Value9a f1 = new Value9a();
+  }
+
+  static class Container9 {
+    @NullRestricted
+    Value9b f2;
+    @NullRestricted
+    Value9c f3;
+
+    Container9() {
+      f2 = new Value9b();
+      f3 = new Value9c();
+      super();
+    }
+  }
+
+  static public void test_9() {
+    var c = new Container9();
+  }
+
+  static public void check_9(FieldLayoutAnalyzer fla) {
+    FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest$Container9");
+    FieldLayoutAnalyzer.FieldBlock f2 = cl.getFieldFromName("f2", false);
+    if(useNullableNonAtomicFlat) {
+      // Flat null-free naturally atomic value, should have a NULL_FREE_NON_ATOMIC_FLAT layout
+      Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NULL_FREE_NON_ATOMIC_FLAT, f2.layoutKind());
+      // Flat null-free non-naturally atomic value, must not have a NULL_FREE_NON_ATOMIC_FLAT layout
+      FieldLayoutAnalyzer.FieldBlock f3 = cl.getFieldFromName("f3", false);
+      Asserts.assertNotEquals(FieldLayoutAnalyzer.LayoutKind.NULL_FREE_NON_ATOMIC_FLAT, f3.layoutKind());
+    }
+  }
+
   static ProcessBuilder exec(String... args) throws Exception {
     List<String> argsList = new ArrayList<>();
     Collections.addAll(argsList, "--enable-preview");


### PR DESCRIPTION
Fixes in the logic to determine if a value class is naturally atomic or not. The previous implementation incorrectly considered values classes with a single non-empty nullable field as being naturally atomic.
Also includes improvements to the InstanceKlass::is_naturally_atomic() to prevent bad usages.

Tested locally.
More testing in progress on Mach5 (tiers 1-4).



---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382941](https://bugs.openjdk.org/browse/JDK-8382941): [lworld] Incorrect handling of naturally atomic values (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer) ⚠️ Review applies to [0301f5d2](https://git.openjdk.org/valhalla/pull/2361/files/0301f5d20505b209994c38cd488cb92fda5df1f1)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2361/head:pull/2361` \
`$ git checkout pull/2361`

Update a local copy of the PR: \
`$ git checkout pull/2361` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2361`

View PR using the GUI difftool: \
`$ git pr show -t 2361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2361.diff">https://git.openjdk.org/valhalla/pull/2361.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2361#issuecomment-4307367070)
</details>
