### PR TITLE
8383141: [lworld] Update javax.lang.model.element.Modifier.VALUE with preview tag

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.lang.model.element;
 
+import jdk.internal.javac.PreviewFeature;
 
 /**
  * Represents a modifier on a program element such
@@ -122,11 +123,6 @@ public enum Modifier {
     },
 
     /**
-     * The modifier {@code value}
-     * @since Valhalla
-     */
-    VALUE,
-    /**
      * The modifier {@code final}
      *
      * @jls 8.1.1.2 {@code sealed}, {@code non-sealed}, and {@code final} Classes
@@ -170,7 +166,16 @@ public enum Modifier {
      * @jls 8.4.3.5 {@code strictfp} Methods
      * @jls 9.1.1.2 {@code strictfp} Interfaces
      */
-    STRICTFP;
+    STRICTFP,
+
+    /**
+     * The modifier {@code value}
+     *
+     * @jls value-objects-9.1.1.5 {@code value} Classes
+     * @since Valhalla
+     */
+    @PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+    VALUE;
 
     /**
      * Returns this modifier's name as defined in <cite>The

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -577,7 +577,7 @@ public class Flags {
         LocalVarFlags                     = FINAL | PARAMETER,
         ReceiverParamFlags                = PARAMETER;
 
-    @SuppressWarnings("preview")
+    @SuppressWarnings("preview") // allow use of VALUE_CLASS when building jdk.compiler.interim
     public static Set<Modifier> asModifierSet(long flags) {
         Set<Modifier> modifiers = modifierSets.get(flags);
         if (modifiers == null) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -577,6 +577,7 @@ public class Flags {
         LocalVarFlags                     = FINAL | PARAMETER,
         ReceiverParamFlags                = PARAMETER;
 
+    @SuppressWarnings("preview")
     public static Set<Modifier> asModifierSet(long flags) {
         Set<Modifier> modifiers = modifierSets.get(flags);
         if (modifiers == null) {

--- a/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
@@ -60,7 +60,7 @@ public class TestValueClasses extends JavadocTester {
 
         checkOutput("p/ValueClass.html", true,
                 """
-                <div class="type-signature"><span class="modifiers">public value final class </span><span class="element-name type-name-label">ValueClass</span>
+                <div class="type-signature"><span class="modifiers">public final value class </span><span class="element-name type-name-label">ValueClass</span>
                 """);
     }
 

--- a/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
+++ b/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
@@ -111,11 +111,11 @@ public class TestValueClasses extends TestRunner {
 
         List<String> expected = List.of(
                 "- compiler.note.proc.messager: visiting: Interface Modifiers: [abstract]",
-                "- compiler.note.proc.messager: visiting: ValueClass Modifiers: [value, final]",
+                "- compiler.note.proc.messager: visiting: ValueClass Modifiers: [final, value]",
                 "- compiler.note.proc.messager:     constructor modifiers: []",
                 "- compiler.note.proc.messager: visiting: IdentityClass Modifiers: []",
                 "- compiler.note.proc.messager:     constructor modifiers: []",
-                "- compiler.note.proc.messager: visiting: ValueRecord Modifiers: [value, final]",
+                "- compiler.note.proc.messager: visiting: ValueRecord Modifiers: [final, value]",
                 "- compiler.note.proc.messager:     constructor modifiers: []",
                 "- compiler.note.preview.filename: Interface.java, DEFAULT",
                 "- compiler.note.preview.recompile"


### PR DESCRIPTION
Need to mark Modifier.VALUE as a preview API. (Also reordered the enum for a more natural ordering of printed modifier lists.)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383141](https://bugs.openjdk.org/browse/JDK-8383141): [lworld] Update javax.lang.model.element.Modifier.VALUE with preview tag (**Bug** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer) ⚠️ Review applies to [1378d0d5](https://git.openjdk.org/valhalla/pull/2362/files/1378d0d56c12508d8da8e1b7c8fbc61a92477aaa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2362/head:pull/2362` \
`$ git checkout pull/2362`

Update a local copy of the PR: \
`$ git checkout pull/2362` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2362`

View PR using the GUI difftool: \
`$ git pr show -t 2362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2362.diff">https://git.openjdk.org/valhalla/pull/2362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2362#issuecomment-4308887092)
</details>
