### PR TITLE
8382704: [lworld] GetLocalObject/GetLocalInstance for THIS value objects during construction

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="jvmti.xsl"?>
 <!--
- Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -5889,7 +5889,7 @@ class C2 extends C1 implements I2 {
             <description>
               On return, points to the variable's value.
               If the frame's method is a value object constructor and
-              the requested local is the "<code>this</code>" object then the
+              the requested local is the "<code>this</code>" object. the
               value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
@@ -5944,7 +5944,7 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              If the frame's method is a value object constructor then the 
+              If the frame's method is a value object constructor, the 
               value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5889,7 +5889,7 @@ class C2 extends C1 implements I2 {
             <description>
               On return, points to the variable's value.
               If the frame's method is a value object constructor and
-              the requested local is the "<code>this</code>" object. the
+              the requested local is the "<code>this</code>" object, the
               value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5888,6 +5888,9 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
+              If the frame's method is a value object constructor and
+              the requested local is the "<code>this</code>" object then the
+              value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
       </parameters>
@@ -5941,6 +5944,8 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
+              If the frame's method is a value object constructor then the 
+              value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
       </parameters>

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -48,7 +48,7 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.hpp"
-#include "runtime/jniHandles.hpp"
+#include "runtime/jniHandles.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/serviceThread.hpp"
 #include "runtime/signature.hpp"
@@ -327,6 +327,7 @@ VM_BaseGetOrSetLocal::VM_BaseGetOrSetLocal(JavaThread* calling_thread, jint dept
   , _jvf(nullptr)
   , _set(set)
   , _self(self)
+  , _need_clone(false)
   , _result(JVMTI_ERROR_NONE)
 {
 }
@@ -476,6 +477,30 @@ bool VM_BaseGetOrSetLocal::check_slot_type_no_lvt(javaVFrame* jvf) {
   return true;
 }
 
+void VM_BaseGetOrSetLocal::check_and_clone_this_value_object() {
+  oop obj = JNIHandles::resolve(_value.l);
+  HandleMark hm(_calling_thread);
+  Handle obj_h(_calling_thread, obj);
+
+  assert(_type == T_OBJECT, "sanity check");
+  assert(obj != nullptr, "expected non-null oop");
+  assert(obj_h()->is_inline(), "expected inline oop");
+  assert(_index == 0, "expected slot 0 for THIS object");
+
+  InlineKlass* klass = InlineKlass::cast(obj_h()->klass());
+  inlineOop obj_copy = klass->allocate_instance(_calling_thread);
+  if (obj_copy == nullptr) {
+    _result = JVMTI_ERROR_OUT_OF_MEMORY;
+  } else {
+    inlineOop thisObj = inlineOop(obj_h());
+    // copy object payload into the object snapshot
+    BufferedValuePayload src(thisObj);
+    BufferedValuePayload dst(obj_copy, klass);
+    src.copy_to(dst);
+  }
+  _value.l = JNIHandles::make_local(_calling_thread, obj_copy);
+}
+
 static bool can_be_deoptimized(vframe* vf) {
   return (vf->is_compiled_frame() && vf->fr().can_be_deoptimized());
 }
@@ -610,12 +635,25 @@ void VM_BaseGetOrSetLocal::doit() {
           // Wrap the oop to be returned in a local JNI handle since
           // oops_do() no longer applies after doit() is finished.
           oop obj = locals->obj_at(_index)();
+
+          if (Arguments::is_valhalla_enabled()) {
+            bool is_ctor = _jvf->method()->is_object_constructor();
+            if (is_ctor && _index == 0 && obj != nullptr && obj->is_inline()) {
+              _need_clone = true; // need to allocate an object snapshot in doit_epilogue
+            }
+          }
           _value.l = JNIHandles::make_local(_calling_thread, obj);
           break;
         }
         default: ShouldNotReachHere();
       }
     }
+  }
+}
+
+void VM_BaseGetOrSetLocal::doit_epilogue() {
+  if (_need_clone) {
+    check_and_clone_this_value_object();
   }
 }
 

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -500,7 +500,8 @@ void VM_BaseGetOrSetLocal::check_and_clone_this_value_object() {
 
     // Must ensure the content of the buffered value is visible
     // before publishing the buffered value oop
-    OrderAccess::storestore();  }
+    OrderAccess::storestore();
+  }
   _value.l = JNIHandles::make_local(_calling_thread, obj_copy);
 }
 

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -497,7 +497,10 @@ void VM_BaseGetOrSetLocal::check_and_clone_this_value_object() {
     BufferedValuePayload src(thisObj);
     BufferedValuePayload dst(obj_copy, klass);
     src.copy_to(dst);
-  }
+
+    // Must ensure the content of the buffered value is visible
+    // before publishing the buffered value oop
+    OrderAccess::storestore();  }
   _value.l = JNIHandles::make_local(_calling_thread, obj_copy);
 }
 

--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -180,6 +180,7 @@ class VM_BaseGetOrSetLocal : public VM_Operation {
   javaVFrame* _jvf;
   bool        _set;
   bool        _self;
+  bool        _need_clone; // THIS object is in a value object constructor
 
   static const jvalue _DEFAULT_VALUE;
 
@@ -192,6 +193,7 @@ class VM_BaseGetOrSetLocal : public VM_Operation {
   virtual javaVFrame* get_java_vframe() = 0;
   bool check_slot_type_lvt(javaVFrame* vf);
   bool check_slot_type_no_lvt(javaVFrame* vf);
+  void check_and_clone_this_value_object();
 
 public:
   VM_BaseGetOrSetLocal(JavaThread* calling_thread, jint depth, jint index,
@@ -201,6 +203,7 @@ public:
   jvmtiError result()    { return _result; }
 
   void doit();
+  void doit_epilogue();
   bool allow_nested_vm_operations() const;
   virtual const char* name() const = 0;
 

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/ValueGetCtorLocal.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/ValueGetCtorLocal.java
@@ -53,13 +53,9 @@ public class ValueGetCtorLocal {
 
         public ValueHolder(int v) {
             f1 = new ValueClass(v, v + 100);
-            if (!nTestCtorThis(Thread.currentThread())) {
-                throw new RuntimeException("Failed: error in nTestCtorThis #1");
-            }
+            testCtorThis(Thread.currentThread());
             f2 = new ValueClass(v + 1, v + 200);
-            if (!nTestCtorThis(Thread.currentThread())) {
-                throw new RuntimeException("Failed: error in nTestCtorThis #2");
-            }
+            testCtorThis(Thread.currentThread());
         }
     }
 
@@ -68,5 +64,5 @@ public class ValueGetCtorLocal {
         ValueHolder testObj2 = new ValueHolder(9);
     }
 
-    private static native boolean nTestCtorThis(Thread thread);
+    private static native void testCtorThis(Thread thread);
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/ValueGetCtorLocal.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/ValueGetCtorLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,18 @@
 
 /**
  * @test
- * @summary Sanity tests for GetLocalObject/SetLocalObject/GetLocalInstance with value classes.
+ * @summary Sanity tests for GetLocalObject/GetLocalInstance with value classes.
  * @requires vm.jvmti
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
- * @run main/othervm/native -agentlib:ValueGetSetLocal ValueGetSetLocal
+ * @run main/othervm/native -agentlib:ValueGetCtorLocal ValueGetCtorLocal
  */
 
 import java.util.Objects;
 import jdk.internal.vm.annotation.LooselyConsistentValue;
 import jdk.internal.vm.annotation.NullRestricted;
 
-public class ValueGetSetLocal {
+public class ValueGetCtorLocal {
 
     @LooselyConsistentValue
     private static value class ValueClass {
@@ -53,21 +53,12 @@ public class ValueGetSetLocal {
 
         public ValueHolder(int v) {
             f1 = new ValueClass(v, v + 100);
-            f2 = new ValueClass(v + 1, v + 200);
-        }
-
-        // slot 0 is "this"
-        public void meth(ValueClass obj1,       // slot 1
-                         ValueHolder obj2) {    // slot 2
-            Object obj3 = obj2;                 // slot 3
-            // SetLocalObject can only set locals for top frame of virtual threads.
-            boolean testSetLocal = !Thread.currentThread().isVirtual();
-            if (!nTestLocals(Thread.currentThread(), testSetLocal)) {
-                throw new RuntimeException("Failed: error in nTestLocals");
+            if (!nTestCtorThis(Thread.currentThread())) {
+                throw new RuntimeException("Failed: error in nTestCtorThis #1");
             }
-            // nTestLocals sets obj3 = obj1
-            if (testSetLocal && !Objects.equals(obj3, obj1)) {
-                throw new RuntimeException("Failed: obj3 != obj1" + " (obj3 = " + obj3 + ")");
+            f2 = new ValueClass(v + 1, v + 200);
+            if (!nTestCtorThis(Thread.currentThread())) {
+                throw new RuntimeException("Failed: error in nTestCtorThis #2");
             }
         }
     }
@@ -75,8 +66,7 @@ public class ValueGetSetLocal {
     public static void main(String[] args) throws Exception {
         ValueClass testObj1 = new ValueClass(7, 8);
         ValueHolder testObj2 = new ValueHolder(9);
-        testObj2.meth(testObj1, testObj2);
     }
 
-    private static native boolean nTestLocals(Thread thread, boolean testSetLocal);
+    private static native boolean nTestCtorThis(Thread thread);
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
@@ -76,7 +76,8 @@ Java_ValueGetCtorLocal_testCtorThis(JNIEnv *jni, jclass thisClass, jthread threa
   if (cached_this == nullptr) { // first call to testCtorThis
     cached_this = jni->NewGlobalRef(obj_this);
   } else {
-    // cached_this must be a snapshot that not mutate with the ctor changes
+    // cached_this must be a snapshot that idoes not mutate
+    // when the ctor changes field values
     if (jni->IsSameObject(cached_this, obj_this)) {
       fatal(jni, "Failed: unexpected: cached_this == obj_this\n");
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
@@ -76,7 +76,7 @@ Java_ValueGetCtorLocal_testCtorThis(JNIEnv *jni, jclass thisClass, jthread threa
   if (cached_this == nullptr) { // first call to testCtorThis
     cached_this = jni->NewGlobalRef(obj_this);
   } else {
-    // cached_this must be a snapshot that idoes not mutate
+    // cached_this must be a snapshot that does not mutate
     // when the ctor changes field values
     if (jni->IsSameObject(cached_this, obj_this)) {
       fatal(jni, "Failed: unexpected: cached_this == obj_this\n");

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,11 +78,6 @@ static jobject get_local(JNIEnv *jni, jthread thread, jint depth, jint slot) {
   return value;
 }
 
-static void set_local(jthread thread, jint depth, jint slot, jobject value) {
-  LOG("SetLocalObject for slot %d\n", (int)slot);
-  check_jvmti_error(jvmti->SetLocalObject(thread, depth, slot, value), "SetLocalObject");
-}
-
 static jobject get_this(JNIEnv *jni, jthread thread, jint depth) {
   LOG("GetLocalInstance\n");
   jobject value = nullptr;
@@ -94,37 +89,36 @@ static jobject get_this(JNIEnv *jni, jthread thread, jint depth) {
 }
 
 JNIEXPORT jboolean JNICALL
-Java_ValueGetSetLocal_nTestLocals(JNIEnv *jni, jclass thisClass, jthread thread, jboolean testSetLocal) {
-  bool result = true;
+Java_ValueGetCtorLocal_nTestCtorThis(JNIEnv *jni, jclass thisClass, jthread thread) {
   const jint depth = 1;
 
-  LOG("\nnTestLocals\n");
+  jmethodID method = get_frame_method(jvmti, jni, thread, depth);
+  char* mname = get_method_name(jvmti, jni, method);
+
+  LOG("\nnTestCtorThis: frame method: %s\n", mname);
   jobject obj0 = get_local(jni, thread, depth, 0);
-  jobject obj1 = get_local(jni, thread, depth, 1);
-  jobject obj2 = get_local(jni, thread, depth, 2);
-  jobject obj3 = get_local(jni, thread, depth, 3);
   jobject obj_this = get_this(jni, thread, depth);
 
-  // obj0 is expected to be equal "this"
-  if (!jni->IsSameObject(obj0, obj_this)) {
+  // obj0 is expected to be equal to "this"
+  jboolean result = jni->IsSameObject(obj0, obj_this);
+  LOG("nTestCtorThis: obj0: %p obj_this: %p objects are equal: %d\n",
+      (void*)obj0, (void*)obj_this, result);
+
+  if (!result) {
     fatal(jni, "Failed: obj0 != obj_this\n");
-    result = false;
   }
-  // obj3 is expected to be equal obj2
-  if (!jni->IsSameObject(obj3, obj2)) {
-    fatal(jni, "Failed: obj3 != obj2\n");
-    result = false;
+  if (cached_this == nullptr) { // first call to nTestCtorThis
+    cached_this = jni->NewGlobalRef(obj_this);
+  } else {
+    // cached_this must be a snapshot that not mutate with the ctor changes
+    if (jni->IsSameObject(cached_this, obj_this)) {
+      fatal(jni, "Failed: unexpected: cached_this == obj_this\n");
+    }
   }
-
-  if (testSetLocal) {
-    // set obj3 = obj1
-    set_local(thread, depth, 3, obj1);
-  }
-
-  return result ? JNI_TRUE : JNI_FALSE;
+  deallocate(jvmti, jni, (void*)mname);
+  return result;
 }
 
 #ifdef __cplusplus
 }
 #endif
-

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal/libValueGetCtorLocal.cpp
@@ -54,60 +54,26 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   return JNI_OK;
 }
 
-static void log_value(JNIEnv *jni, jobject value) {
-  jclass cls = jni->GetObjectClass(value);
-  if (cls == nullptr) {
-    fatal(jni, "Failed: value class is nullptr\n");
-    return;
-  }
-
-  char* sig = nullptr;
-  check_jvmti_error(jvmti->GetClassSignature(cls, &sig, nullptr), "GetClassSignature");
-
-  LOG(" - the value class: %s\n", sig);
-  jvmti->Deallocate((unsigned char *)sig);
-}
-
-static jobject get_local(JNIEnv *jni, jthread thread, jint depth, jint slot) {
-  LOG("GetLocalObject for slot %d\n", (int)slot);
-  jobject value = nullptr;
-  check_jvmti_error(jvmti->GetLocalObject(thread, depth, slot, &value), "GetLocalObject");
-
-  log_value(jni, value);
-
-  return value;
-}
-
-static jobject get_this(JNIEnv *jni, jthread thread, jint depth) {
-  LOG("GetLocalInstance\n");
-  jobject value = nullptr;
-  check_jvmti_error(jvmti->GetLocalInstance(thread, depth, &value), "GetLocalInstance");
-
-  log_value(jni, value);
-
-  return value;
-}
-
-JNIEXPORT jboolean JNICALL
-Java_ValueGetCtorLocal_nTestCtorThis(JNIEnv *jni, jclass thisClass, jthread thread) {
+JNIEXPORT void JNICALL
+Java_ValueGetCtorLocal_testCtorThis(JNIEnv *jni, jclass thisClass, jthread thread) {
   const jint depth = 1;
 
   jmethodID method = get_frame_method(jvmti, jni, thread, depth);
   char* mname = get_method_name(jvmti, jni, method);
 
-  LOG("\nnTestCtorThis: frame method: %s\n", mname);
-  jobject obj0 = get_local(jni, thread, depth, 0);
-  jobject obj_this = get_this(jni, thread, depth);
+  LOG("\ntestCtorThis: frame method: %s\n", mname);
+  jobject obj0 = get_local_object(jvmti, jni, thread, depth, 0);
+  jobject obj_this = get_local_instance(jvmti, jni, thread, depth);
 
   // obj0 is expected to be equal to "this"
-  jboolean result = jni->IsSameObject(obj0, obj_this);
-  LOG("nTestCtorThis: obj0: %p obj_this: %p objects are equal: %d\n",
-      (void*)obj0, (void*)obj_this, result);
+  jboolean is_equal = jni->IsSameObject(obj0, obj_this);
+  LOG("testCtorThis: obj0: %p obj_this: %p objects are equal: %d\n",
+      (void*)obj0, (void*)obj_this, is_equal);
 
-  if (!result) {
+  if (!is_equal) {
     fatal(jni, "Failed: obj0 != obj_this\n");
   }
-  if (cached_this == nullptr) { // first call to nTestCtorThis
+  if (cached_this == nullptr) { // first call to testCtorThis
     cached_this = jni->NewGlobalRef(obj_this);
   } else {
     // cached_this must be a snapshot that not mutate with the ctor changes
@@ -116,7 +82,6 @@ Java_ValueGetCtorLocal_nTestCtorThis(JNIEnv *jni, jclass thisClass, jthread thre
     }
   }
   deallocate(jvmti, jni, (void*)mname);
-  return result;
 }
 
 #ifdef __cplusplus

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java
@@ -62,13 +62,7 @@ public class ValueGetSetLocal {
             Object obj3 = obj2;                 // slot 3
             // SetLocalObject can only set locals for top frame of virtual threads.
             boolean testSetLocal = !Thread.currentThread().isVirtual();
-            if (!nTestLocals(Thread.currentThread(), testSetLocal)) {
-                throw new RuntimeException("Failed: error in nTestLocals");
-            }
-            // nTestLocals sets obj3 = obj1
-            if (testSetLocal && !Objects.equals(obj3, obj1)) {
-                throw new RuntimeException("Failed: obj3 != obj1" + " (obj3 = " + obj3 + ")");
-            }
+            testLocals(Thread.currentThread(), testSetLocal);
         }
     }
 
@@ -78,5 +72,5 @@ public class ValueGetSetLocal {
         testObj2.meth(testObj1, testObj2);
     }
 
-    private static native boolean nTestLocals(Thread thread, boolean testSetLocal);
+    private static native void testLocals(Thread thread, boolean testSetLocal);
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/libValueGetSetLocal.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/libValueGetSetLocal.cpp
@@ -32,7 +32,6 @@ extern "C" {
 #endif
 
 static jvmtiEnv *jvmti = nullptr;
-static jobject cached_this = nullptr;
 
 JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
@@ -54,74 +53,34 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   return JNI_OK;
 }
 
-static void log_value(JNIEnv *jni, jobject value) {
-  jclass cls = jni->GetObjectClass(value);
-  if (cls == nullptr) {
-    fatal(jni, "Failed: value class is nullptr\n");
-    return;
-  }
-
-  char* sig = nullptr;
-  check_jvmti_error(jvmti->GetClassSignature(cls, &sig, nullptr), "GetClassSignature");
-
-  LOG(" - the value class: %s\n", sig);
-  jvmti->Deallocate((unsigned char *)sig);
-}
-
-static jobject get_local(JNIEnv *jni, jthread thread, jint depth, jint slot) {
-  LOG("GetLocalObject for slot %d\n", (int)slot);
-  jobject value = nullptr;
-  check_jvmti_error(jvmti->GetLocalObject(thread, depth, slot, &value), "GetLocalObject");
-
-  log_value(jni, value);
-
-  return value;
-}
-
-static void set_local(jthread thread, jint depth, jint slot, jobject value) {
-  LOG("SetLocalObject for slot %d\n", (int)slot);
-  check_jvmti_error(jvmti->SetLocalObject(thread, depth, slot, value), "SetLocalObject");
-}
-
-static jobject get_this(JNIEnv *jni, jthread thread, jint depth) {
-  LOG("GetLocalInstance\n");
-  jobject value = nullptr;
-  check_jvmti_error(jvmti->GetLocalInstance(thread, depth, &value), "GetLocalInstance");
-
-  log_value(jni, value);
-
-  return value;
-}
-
-JNIEXPORT jboolean JNICALL
-Java_ValueGetSetLocal_nTestLocals(JNIEnv *jni, jclass thisClass, jthread thread, jboolean testSetLocal) {
-  bool result = true;
+JNIEXPORT void JNICALL
+Java_ValueGetSetLocal_testLocals(JNIEnv *jni, jclass thisClass, jthread thread, jboolean testSetLocal) {
   const jint depth = 1;
 
-  LOG("\nnTestLocals\n");
-  jobject obj0 = get_local(jni, thread, depth, 0);
-  jobject obj1 = get_local(jni, thread, depth, 1);
-  jobject obj2 = get_local(jni, thread, depth, 2);
-  jobject obj3 = get_local(jni, thread, depth, 3);
-  jobject obj_this = get_this(jni, thread, depth);
+  LOG("\ntestLocals\n");
+  jobject obj0 = get_local_object(jvmti, jni, thread, depth, 0);
+  jobject obj1 = get_local_object(jvmti, jni, thread, depth, 1);
+  jobject obj2 = get_local_object(jvmti, jni, thread, depth, 2);
+  jobject obj3 = get_local_object(jvmti, jni, thread, depth, 3);
+  jobject obj_this = get_local_instance(jvmti, jni, thread, depth);
 
   // obj0 is expected to be equal "this"
   if (!jni->IsSameObject(obj0, obj_this)) {
     fatal(jni, "Failed: obj0 != obj_this\n");
-    result = false;
   }
   // obj3 is expected to be equal obj2
   if (!jni->IsSameObject(obj3, obj2)) {
     fatal(jni, "Failed: obj3 != obj2\n");
-    result = false;
   }
 
   if (testSetLocal) {
     // set obj3 = obj1
-    set_local(thread, depth, 3, obj1);
+    set_local_object(jvmti, thread, depth, 3, obj1);
+    obj3 = get_local_object(jvmti, jni, thread, depth, 3);
+    if (!jni->IsSameObject(obj3, obj1)) {
+      fatal(jni, "Failed: obj3 != obj1\n");
+    }
   }
-
-  return result ? JNI_TRUE : JNI_FALSE;
 }
 
 #ifdef __cplusplus

--- a/test/jdk/com/sun/jdi/valhalla/CtorDebuggingTest.java
+++ b/test/jdk/com/sun/jdi/valhalla/CtorDebuggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -398,8 +398,8 @@ public class CtorDebuggingTest extends TestScaffold {
             // No other references.
             // ObjectID is generated at the 1st breakpoint (reference to heap object being constructed),
             // and later we get the same oop (although it's content is changing).
-            assertEquals(breakpointHandler.thisAtBreakpoint(bkpt1), breakpointHandler.thisAtBreakpoint(bkpt2));
-            assertEquals(breakpointHandler.thisAtBreakpoint(bkpt2), breakpointHandler.thisAtBreakpoint(bkpt3));
+            assertNotEquals(breakpointHandler.thisAtBreakpoint(bkpt1), breakpointHandler.thisAtBreakpoint(bkpt2));
+            assertNotEquals(breakpointHandler.thisAtBreakpoint(bkpt2), breakpointHandler.thisAtBreakpoint(bkpt3));
             // There is no breakpoints with instance filter.
         } else if (v1 != null && v2 != null && v3 != null) {
             // Existing references to value objects with the same content as the object being constructed.
@@ -421,7 +421,7 @@ public class CtorDebuggingTest extends TestScaffold {
             assertNotEquals(thisAt2, null);
             assertNotEquals(thisAt2, v1);
             // Now thisAt2 has the same content as v3.
-            assertEquals(thisAt2, v3);
+            assertNotEquals(thisAt2, v3);
             // At breakpoint 1 this == v1.
             assertEquals(breakpointHandler.thisAtBreakpoint(bkpt1), v1);
             assertEquals(breakpointHandler.thisAtBreakpoint(bkpt1_v1), v1);

--- a/test/jdk/com/sun/jdi/valhalla/CtorDebuggingTest.java
+++ b/test/jdk/com/sun/jdi/valhalla/CtorDebuggingTest.java
@@ -396,8 +396,8 @@ public class CtorDebuggingTest extends TestScaffold {
         // Analyze gathered data depending on the testcase.
         if (v1 == null && v2 == null && v3 == null) {
             // No other references.
-            // ObjectID is generated at the 1st breakpoint (reference to heap object being constructed),
-            // and later we get the same oop (although it's content is changing).
+            // ObjectID is generated at the 1st breakpoint (reference to a snapshot of heap object being constructed),
+            // and later we get snapshots of the updated oop as it's content is changing.
             assertNotEquals(breakpointHandler.thisAtBreakpoint(bkpt1), breakpointHandler.thisAtBreakpoint(bkpt2));
             assertNotEquals(breakpointHandler.thisAtBreakpoint(bkpt2), breakpointHandler.thisAtBreakpoint(bkpt3));
             // There is no breakpoints with instance filter.
@@ -420,7 +420,7 @@ public class CtorDebuggingTest extends TestScaffold {
             ObjectReference thisAt2 = breakpointHandler.thisAtBreakpoint(bkpt2);
             assertNotEquals(thisAt2, null);
             assertNotEquals(thisAt2, v1);
-            // Now thisAt2 has the same content as v3.
+            // Now thisAt2 should not have the same content as v3.
             assertNotEquals(thisAt2, v3);
             // At breakpoint 1 this == v1.
             assertEquals(breakpointHandler.thisAtBreakpoint(bkpt1), v1);

--- a/test/jdk/com/sun/jdi/valhalla/CtorDebuggingTest.java
+++ b/test/jdk/com/sun/jdi/valhalla/CtorDebuggingTest.java
@@ -397,7 +397,7 @@ public class CtorDebuggingTest extends TestScaffold {
         if (v1 == null && v2 == null && v3 == null) {
             // No other references.
             // ObjectID is generated at the 1st breakpoint (reference to a snapshot of heap object being constructed),
-            // and later we get snapshots of the updated oop as it's content is changing.
+            // and later we get snapshots of the updated oop as its content is changing.
             assertNotEquals(breakpointHandler.thisAtBreakpoint(bkpt1), breakpointHandler.thisAtBreakpoint(bkpt2));
             assertNotEquals(breakpointHandler.thisAtBreakpoint(bkpt2), breakpointHandler.thisAtBreakpoint(bkpt3));
             // There is no breakpoints with instance filter.

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -279,6 +279,15 @@ get_frame_count(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread) {
   return frame_count;
 }
 
+static jmethodID
+get_frame_method(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jint depth) {
+  jmethodID method;
+  jlocation loc;
+  jvmtiError err = jvmti->GetFrameLocation(thread, depth, &method, &loc);
+  check_jvmti_status(jni, err, "notifyFramePop: Failed in JVMTI GetFrameLocation");
+  return method;
+}
+
 static jvmtiThreadInfo
 get_thread_info(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread) {
   jvmtiThreadInfo thr_info;

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -284,7 +284,7 @@ get_frame_method(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jint depth) {
   jmethodID method;
   jlocation loc;
   jvmtiError err = jvmti->GetFrameLocation(thread, depth, &method, &loc);
-  check_jvmti_status(jni, err, "notifyFramePop: Failed in JVMTI GetFrameLocation");
+  check_jvmti_status(jni, err, "get_frame_method: error in JVMTI GetFrameLocation");
   return method;
 }
 
@@ -428,7 +428,7 @@ static void
 log_object_class(jvmtiEnv *jvmti, JNIEnv *jni, jobject obj) {
   jclass cls = jni->GetObjectClass(obj);
   if (cls == nullptr) {
-    fatal(jni, "Failed: class is nullptr\n");
+    fatal(jni, "log_object_class: class is nullptr\n");
     return;
   }
   char* sig = nullptr;

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -424,6 +424,46 @@ find_method(jvmtiEnv *jvmti, JNIEnv *jni, jclass klass, const char* mname) {
   return method;
 }
 
+static void
+log_object_class(jvmtiEnv *jvmti, JNIEnv *jni, jobject obj) {
+  jclass cls = jni->GetObjectClass(obj);
+  if (cls == nullptr) {
+    fatal(jni, "Failed: class is nullptr\n");
+    return;
+  }
+  char* sig = nullptr;
+  check_jvmti_error(jvmti->GetClassSignature(cls, &sig, nullptr), "GetClassSignature");
+
+  LOG(" - got an object of class: %s\n", sig);
+  jvmti->Deallocate((unsigned char *)sig);
+}
+
+static jobject
+get_local_object(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jint depth, jint slot) {
+  LOG("GetLocalObject: depth: %d slot %d\n", (int)depth, (int)slot);
+  jobject obj = nullptr;
+  check_jvmti_error(jvmti->GetLocalObject(thread, depth, slot, &obj), "GetLocalObject");
+
+  log_object_class(jvmti, jni, obj);
+  return obj;
+}
+
+static jobject
+get_local_instance(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jint depth) {
+  LOG("GetLocalInstance: depth: %d\n", (int)depth);
+  jobject obj = nullptr;
+  check_jvmti_error(jvmti->GetLocalInstance(thread, depth, &obj), "GetLocalInstance");
+
+  log_object_class(jvmti, jni, obj);
+  return obj;
+}
+
+static void
+set_local_object(jvmtiEnv *jvmti, jthread thread, jint depth, jint slot, jobject obj) {
+  LOG("SetLocalObject for slot %d\n", (int)slot);
+  check_jvmti_error(jvmti->SetLocalObject(thread, depth, slot, obj), "SetLocalObject");
+}
+
 // Wait for target thread to reach the required JVMTI thread state.
 // The state jint bitmask is returned by the JVMTI GetThreadState.
 // Some examples are:


### PR DESCRIPTION
This enhancement is to a add JVMTI debugging support for value object construction.
The fix includes:
 - Minor `GetLocalObject` and `GetLocalInstance` spec clarifications
 - JVMTI functions `GetLocalObject` and `GetLocalInstance` now return a snapshot of the `THIS` object if it is requested during a value object construction.
 - This update adds new test with a needed test coverage: `test/hotspot/jtreg/serviceability/jvmti/valhalla/GetCtorLocal`.
 - Some corrections in the test `test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal` for unification with the test above.

Testing:
  - Tested locally with new test `GetCtorLocal`
  - Tested with mach5 tiers 1-6

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382704](https://bugs.openjdk.org/browse/JDK-8382704): [lworld] GetLocalObject/GetLocalInstance for THIS value objects during construction (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2363/head:pull/2363` \
`$ git checkout pull/2363`

Update a local copy of the PR: \
`$ git checkout pull/2363` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2363`

View PR using the GUI difftool: \
`$ git pr show -t 2363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2363.diff">https://git.openjdk.org/valhalla/pull/2363.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2363#issuecomment-4310443986)
</details>
