### PR TITLE
8383242: [lworld] Update on copy-of-copy in ClassFileParser::fetch_field_classes

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6286,7 +6286,8 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
 //      are guaranteed to be found in this step even if the current class
 //      has not been recompiled with JEP 401 features enabled
 void ClassFileParser::fetch_field_classes(ConstantPool* cp, TRAPS) {
-  for (FieldInfo fieldinfo : *_temp_field_info) {
+  for (int i = 0; i < _temp_field_info->length(); i++) {
+    FieldInfo& fieldinfo = _temp_field_info->at(i);
     if (fieldinfo.access_flags().is_static()) continue;  // Only non-static fields are processed at load time
     Symbol* sig = fieldinfo.signature(cp);
     if (Signature::has_envelope(sig)) {
@@ -6319,7 +6320,7 @@ void ClassFileParser::fetch_field_classes(ConstantPool* cp, TRAPS) {
                                      "field was annotated with @NullRestricted but loaded class is not a value class, "
                                      "the annotation is ignored",
                                      name->as_C_string(), _class_name->as_C_string());
-              fieldinfo.field_flags().update_null_free_inline_type(false);
+              fieldinfo.field_flags_addr()->update_null_free_inline_type(false);
             }
           }
         } else {
@@ -6332,7 +6333,7 @@ void ClassFileParser::fetch_field_classes(ConstantPool* cp, TRAPS) {
                                    "field was annotated with @NullRestricted but class is unknown, "
                                    "the annotation is ignored",
                                    name->as_C_string(), _class_name->as_C_string());
-            fieldinfo.field_flags().update_null_free_inline_type(false);
+            fieldinfo.field_flags_addr()->update_null_free_inline_type(false);
           }
 
           // Loads triggered by the LoadableDescriptors attribute are speculative, failures must not
@@ -6359,7 +6360,7 @@ void ClassFileParser::fetch_field_classes(ConstantPool* cp, TRAPS) {
                                  "@NullRestricted, the annotation is ignored",
                                  _class_name->as_C_string(), name->as_C_string());
           }
-          fieldinfo.field_flags().update_null_free_inline_type(false);
+          fieldinfo.field_flags_addr()->update_null_free_inline_type(false);
         }
       }
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
@@ -32,6 +32,7 @@
  * @run main PreloadCircularityTest
  */
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -67,7 +68,11 @@ public class PreloadCircularityTest {
     }
 
     void test_0() throws Exception {
-        OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class0a");
+        OutputAnalyzer out = tryLoadClassAndCheckNullRestricted("PreloadCircularityTest$Class0a",
+                                                                "PreloadCircularityTest$Class0b",
+                                                                "vc",
+                                                                true);
+
         out.shouldHaveExitValue(0);
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class0b during loading of class PreloadCircularityTest$Class0a. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class0c during loading of class PreloadCircularityTest$Class0b. Cause: field type in LoadableDescriptors attribute");
@@ -117,7 +122,10 @@ public class PreloadCircularityTest {
     }
 
     void test_2() throws Exception {
-        OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class2a");
+        OutputAnalyzer out = tryLoadClassAndCheckNullRestricted("PreloadCircularityTest$Class2a",
+                                                                "PreloadCircularityTest$Class2c",
+                                                                "vb",
+                                                                false);
         out.shouldHaveExitValue(0);
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class2b during loading of class PreloadCircularityTest$Class2a. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class2c during loading of class PreloadCircularityTest$Class2b. Cause: field type in LoadableDescriptors attribute");
@@ -162,11 +170,14 @@ public class PreloadCircularityTest {
 
     static value class Class4b {
         @NullRestricted
-        Class4a vc = new Class4a();
+        Class4a va = new Class4a();
     }
 
     void test_4() throws Exception {
-        OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class4a");
+        OutputAnalyzer out = tryLoadClassAndCheckNullRestricted("PreloadCircularityTest$Class4a",
+                                                                "PreloadCircularityTest$Class4b",
+                                                                "va",
+                                                                false);
         out.shouldHaveExitValue(0);
 
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class4b during loading of class PreloadCircularityTest$Class4a. Cause: field type in LoadableDescriptors attribute");
@@ -286,7 +297,21 @@ public class PreloadCircularityTest {
     public static class TestHelper {
         public static void main(String[] args) {
             try {
-                Class c = Class.forName(args[0]);
+                switch (args[0]) {
+                    case "load":
+                        Class.forName(args[1]);
+                        break;
+                    case "isNullRestricted":
+                        Class.forName(args[1]);
+
+                        Class fieldClass = Class.forName(args[2]);
+                        Field field = fieldClass.getDeclaredField(args[3]);
+                        Boolean isNullRestricted = Boolean.parseBoolean(args[4]);
+                        Asserts.assertEquals(ValueClass.isNullRestrictedField(field), isNullRestricted);
+                        break;
+                    default:
+                        throw new RuntimeException("Unknown mode: " + args[0]);
+              }
             } catch (Throwable ex) {
                 ex.printStackTrace();
                 System.exit(1);
@@ -296,7 +321,23 @@ public class PreloadCircularityTest {
     }
 
     static OutputAnalyzer tryLoadingClass(String className) throws Exception {
-        ProcessBuilder pb = exec("PreloadCircularityTest$TestHelper", className);
+        ProcessBuilder pb = exec("PreloadCircularityTest$TestHelper",
+                                 "load",
+                                 className);
+
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        System.out.println(out.getOutput());
+        return out;
+    }
+
+    static OutputAnalyzer tryLoadClassAndCheckNullRestricted(String loadClass, String fieldClass, String field, boolean isNullRestricted) throws Exception {
+        ProcessBuilder pb = exec("PreloadCircularityTest$TestHelper",
+                                 "isNullRestricted",
+                                 loadClass,
+                                 fieldClass,
+                                 field,
+                                 Boolean.toString(isNullRestricted));
+
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         System.out.println(out.getOutput());
         return out;
@@ -305,6 +346,7 @@ public class PreloadCircularityTest {
     static ProcessBuilder exec(String... args) throws Exception {
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, "--enable-preview");
+        Collections.addAll(argsList, "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED");
         Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
         Collections.addAll(argsList, "-Xlog:class+preload=info");
         Collections.addAll(argsList, args);


### PR DESCRIPTION
Hello,

The updates to the field_flags in `ClassFileParser::fetch_field_classes` are updating on a copy of field_flags instead of a reference. And the field_flags are in turn gotten from a copy of the fieldinfo, not a reference.

This ends up keeping the field marked as a null_free_inline_type, which is not true given that we've downgraded the field from null-restricted to nullable, so anyone asking if this field is null-free might be fooled. 

I've adapted/enhanced the `test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java` test to check for this using reflection and the internal ValueClass API.

Testing:
* Adapted `test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java` fails before fix, passes after.
* Running Oracle's tier1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383242](https://bugs.openjdk.org/browse/JDK-8383242): [lworld] Update on copy-of-copy in ClassFileParser::fetch_field_classes (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2367/head:pull/2367` \
`$ git checkout pull/2367`

Update a local copy of the PR: \
`$ git checkout pull/2367` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2367`

View PR using the GUI difftool: \
`$ git pr show -t 2367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2367.diff">https://git.openjdk.org/valhalla/pull/2367.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2367#issuecomment-4325297883)
</details>
