### PR TITLE
8383387: [lworld] Address HotSpot TODOs

### DIFF
--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -991,7 +991,7 @@ void AOTMapLogger::print_oop_details(FakeOop fake_oop, outputStream* st) {
     fake_oop.as_type_array().print_elements_on(st);
   } else if (real_klass->is_flatArray_klass()) {
     // Archiving FlatArrayOop with embedded oops is not supported.
-    // TODO: add restriction.
+    // TODO: a restriction may be necessary, tracked by JDK-8383389
     fake_oop.as_flat_array().print_elements_on(st);
   } else if (real_klass->is_refArray_klass()) {
     FakeRefArray fake_obj_array = fake_oop.as_ref_array();

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -467,7 +467,7 @@ void HeapShared::make_archived_object_cache_gc_safe() {
         // need to reference value objects.
         //
         // Also TODO: the AOT heap should de-duplicate value objects with identical
-        // values.
+        // values. See JDK-8383381
       } else {
         new_cache->put_when_absent(oh, info);
       }

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -531,6 +531,7 @@ void FieldLayout::fill_holes(const InstanceKlass* super_klass) {
     if (b->next_block()->offset() > (b->offset() + b->size())) {
       int size = b->next_block()->offset() - (b->offset() + b->size());
       // FIXME it would be better if initial empty block where tagged as PADDING for value classes
+      // Tracked by JDK-8383383
       LayoutRawBlock* empty = new LayoutRawBlock(filling_type, size);
       empty->set_offset(b->offset() + b->size());
       empty->set_next_block(b->next_block());

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -239,7 +239,8 @@ address VtableStubs::find_stub(bool is_vtable_stub, int vtable_index, bool calle
       // all locks. Only post this event if a new state is not required. Creating a new state would
       // cause a safepoint and the caller of this code has a NoSafepointVerifier.
       if (JvmtiExport::should_post_dynamic_code_generated()) {
-        JvmtiExport::post_dynamic_code_generated_while_holding_locks(is_vtable_stub? "vtable stub": "itable stub",  // FIXME: need to pass caller_is_c1??
+        // FIXME: Is it needed to pass caller_is_c1? Tracked by JDK-8383384
+        JvmtiExport::post_dynamic_code_generated_while_holding_locks(is_vtable_stub? "vtable stub": "itable stub",
                                                                      s->code_begin(), s->code_end());
       }
     }

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -119,7 +119,7 @@ public:
     return _visit_stack->pop();
   }
 
-  bool is_visited(const JvmtiHeapwalkObject& obj) /*const*/ { // TODO: _bitset.is_marked() should be const
+  bool is_visited(const JvmtiHeapwalkObject& obj) {
     // The method is called only for objects from visit_stack to ensure an object is not visited twice.
     // Flat objects can be added to visit_stack only when we visit their holder object, so we cannot get duplicate reference to it.
     if (obj.is_flat()) {

--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -26,7 +26,8 @@
 #include "unittest.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-// TODO FIXME This test needs to be rewritten after objArray/refArray/flatArray rework
+// FIXME This test needs to be rewritten after objArray/refArray/flatArray rework
+// Tracked by JDK-8383386
 
 TEST_VM(objArrayOop, osize) {
   static const struct {


### PR DESCRIPTION
Hi all,

This adds issues to all the TODOs in HotSpot code. 

I also evaluated whether `bool is_visited(const JvmtiHeapwalkObject& obj)` can become `const`. The blocker is `_bitset.is_marked()`, which cannot be made `const` since it calls an internal method that modifies fields. It does not seem worth to work around this limitation, especially given that `is_visited` does not exist in mainline.

Testing: tier1, GHA. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383387](https://bugs.openjdk.org/browse/JDK-8383387): [lworld] Address HotSpot TODOs (**Bug** - P4)


### Reviewers
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2368/head:pull/2368` \
`$ git checkout pull/2368`

Update a local copy of the PR: \
`$ git checkout pull/2368` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2368`

View PR using the GUI difftool: \
`$ git pr show -t 2368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2368.diff">https://git.openjdk.org/valhalla/pull/2368.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2368#issuecomment-4325977074)
</details>
