### PR TITLE
8383390: [lworld] jcheck whitespace errors in test/micro

### DIFF
--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
@@ -1619,8 +1619,8 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
             while (!t[index].isValue()) {
                 count ++;
                 index = (index + REHASH_HASH) & lowbitmask;
-		if (index == 0)
-		    return -1;
+                if (index == 0)
+                    return -1;
             }
             return index;
         }

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/README.md
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/README.md
@@ -3,7 +3,7 @@
    **NOTE: The implementations have NOT been optimized or tuned.**
 
 ## HashMap uses Open Addressing to store all entries in a table of inline classes
-The hash of the key is used as the first index into the table. 
+The hash of the key is used as the first index into the table.
 If there is a collision, double hashing (with a static offset) is used to probe subsequent locations for available storage.
 The Robin Hood hashing variation on insertion is used to reduce worst case lookup times.
 On key removal, the subsequent double-hashed entries are compressed into the entry being removed.
@@ -15,7 +15,7 @@ Inserting entries into the HashMap may resize the table but otherwise does
 not use any additional memory on each get or put.
 
 ## XHashMap stores the initial entry in a table of inline classes
-The hash of the key is used as the first index into the table. 
+The hash of the key is used as the first index into the table.
 If there is a collision, subsequent entries add the familiar link list of Nodes.
 On key removal, direct entries in the table are replaced by the first linked node;
 for Nodes in the link list, the Node is unlinked.
@@ -24,7 +24,7 @@ for Nodes in the link list, the Node is unlinked.
 Typical storage usage for a table near its load factor is 32 bytes per entry.
 
 ## java.util.HashMap (the original)
-HashMap uses a table of references to the initial Node entries, collisions are handled by 
+HashMap uses a table of references to the initial Node entries, collisions are handled by
 linked Nodes.
 
 ### HashMap Storage requirements:


### PR DESCRIPTION
Removed tabs and whitespace

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383390](https://bugs.openjdk.org/browse/JDK-8383390): [lworld] jcheck whitespace errors in test/micro (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2369/head:pull/2369` \
`$ git checkout pull/2369`

Update a local copy of the PR: \
`$ git checkout pull/2369` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2369`

View PR using the GUI difftool: \
`$ git pr show -t 2369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2369.diff">https://git.openjdk.org/valhalla/pull/2369.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2369#issuecomment-4326221590)
</details>
