### PR TITLE
8381268: [lworld] C2: assert(adr->is_top() || C->get_alias_index(gvn.type(adr)->is_ptr(), true) == C->get_alias_index(adr_type, true)) failed: adr and adr_type must agree

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -323,7 +323,12 @@ Node* PhaseMacroExpand::make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, 
   if (ac->is_clonebasic()) {
     assert(ac->in(ArrayCopyNode::Src) != ac->in(ArrayCopyNode::Dest), "clone source equals destination");
     adr = _igvn.transform(AddPNode::make_with_base(base, _igvn.MakeConX(offset)));
-    adr_type = _igvn.type(base)->is_ptr()->add_offset(offset);
+    adr_type = _igvn.type(base)->is_ptr();
+    if (adr_type->isa_aryptr()) {
+      adr_type = adr_type->is_aryptr()->add_field_offset_and_offset(offset);
+    } else {
+      adr_type = adr_type->add_offset(offset);
+    }
   } else {
     if (!ac->modifies(offset, offset, &_igvn, true)) {
       // If the arraycopy does not copy to this offset, we cannot generate a rematerialization load for it.

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5783,29 +5783,32 @@ const TypeAryPtr* TypeAryPtr::with_field_offset(int offset) const {
 }
 
 const TypePtr* TypeAryPtr::add_field_offset_and_offset(intptr_t offset) const {
+  if (!is_flat() || !klass_is_exact() || offset == OffsetBot || offset == OffsetTop) {
+    return add_offset(offset);
+  }
+
+  // Handle flat concrete value class array with known 'offset' which could refer to an actual field in the flat storage.
   int adj = 0;
-  if (is_flat() && klass_is_exact() && offset != Type::OffsetBot && offset != Type::OffsetTop) {
-    if (_offset.get() != OffsetBot && _offset.get() != OffsetTop) {
-      adj = _offset.get();
-      offset += _offset.get();
+  if (_offset != Offset::bottom && _offset != Offset::top) {
+    adj = _offset.get();
+    offset += _offset.get();
+  }
+  uint header = arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT);
+  if (_field_offset != Offset::bottom && _field_offset != Offset::top) {
+    offset += _field_offset.get();
+    if (_offset == Offset::bottom || _offset == Offset::top) {
+      offset += header;
     }
-    uint header = arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT);
-    if (_field_offset.get() != OffsetBot && _field_offset.get() != OffsetTop) {
-      offset += _field_offset.get();
-      if (_offset.get() == OffsetBot || _offset.get() == OffsetTop) {
-        offset += header;
-      }
-    }
-    if (elem()->make_oopptr()->is_inlinetypeptr() && (offset >= (intptr_t)header || offset < 0)) {
-      // Try to get the field of the inline type array element we are pointing to
-      ciInlineKlass* vk = elem()->inline_klass();
-      int shift = flat_log_elem_size();
-      int mask = (1 << shift) - 1;
-      intptr_t field_offset = ((offset - header) & mask);
-      ciField* field = vk->get_field_by_offset(field_offset + vk->payload_offset(), false);
-      if (field != nullptr || field_offset == vk->null_marker_offset_in_payload()) {
-        return with_field_offset(field_offset)->add_offset(offset - field_offset - adj);
-      }
+  }
+  if (elem()->make_oopptr()->is_inlinetypeptr() && (offset >= (intptr_t)header || offset < 0)) {
+    // Try to get the field of the inline type array element we are pointing to
+    ciInlineKlass* vk = elem()->inline_klass();
+    int shift = flat_log_elem_size();
+    int mask = (1 << shift) - 1;
+    int field_offset = static_cast<int>((offset - header) & mask);
+    ciField* field = vk->get_field_by_offset(field_offset + vk->payload_offset(), false);
+    if (field != nullptr || field_offset == vk->null_marker_offset_in_payload()) {
+      return with_field_offset(field_offset)->add_offset(offset - field_offset - adj);
     }
   }
   return add_offset(offset - adj);

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -209,9 +209,6 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 # Valhalla failures start here:
 compiler/c2/irTests/TestFloat16ScalarOperations.java 8377808 linux-aarch64
 compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
-compiler/c2/TestGVNCrash.java 8381268 generic-all
-compiler/valhalla/inlinetypes/TestArrays.java#id1 8381268 generic-all
-compiler/valhalla/inlinetypes/TestArrays.java#id5 8381268 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id0       8382504 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id1       8382504 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id3       8382504 generic-all


### PR DESCRIPTION
### Failing Test
The assert added in mainline to verify that `adr_type` and `adr`'s type match fails in Valhalla when facing a load from a cloned flat array (i.e. called `clone()`) in `TestArrays::test28()`:
https://github.com/openjdk/valhalla/blob/cfda30f3735276318c291718ca1f3daaa0e124c8/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java#L808-L813

This triggers when trying to add array elements to safepoints.

### Mismatched `AddP` Type vs. Calculated `adr_type`
In `PhaseMacroExpand::make_arraycopy_load()`, we have the following type for the `base` of the flat array `src`:
```
//  gvn.type(base) with _offset = 0, _field_offset = bottom:
aryptr:flat:instptr:.../MyValue2 (...):NotNull:exact *,iid=bot[int:10] (...):NotNull:exact:flat(+bot):null free
```
We then try to add the flat array load for `src.x` which is at `offset = 32` (16 bytes for the array object header + another 16 bytes to get to `x` at offset 16 (`src.v` is first at offset 0)). Here we get a mismatch between the computed `adr_type` and the type stored for `adr` (i.e. an `AddP`) which is later used when creating the `LoadNode`:
```
// adr_type with _offset = 32, _field_offset = bottom:
aryptr:flat:instptr:.../MyValue2 (...):NotNull:exact *,iid=bot[int:10] (...):NotNull:exact:flat(+bot):null free[2]

// gvn.type(adr) with _offset = 16, _field_offset = 16:
aryptr:flat:instptr:.../MyValue2 (...):NotNull:exact *,iid=bot[int:10] (...):NotNull:exact:flat(+16):null free[0]
```
The types have different `_field_offset` values and thus end up on a different alias class which triggers the assert. 

### Reason for Mismatch
The problem is that in `PhaseMacroExpand::make_arraycopy_load()`, we simply call `add_offset()`, regardless of whether it's a flat array or not:
https://github.com/openjdk/valhalla/blob/cfda30f3735276318c291718ca1f3daaa0e124c8/src/hotspot/share/opto/macro.cpp#L323-L326

This ignores `_field_offset` and leaves it at `bottom`. But when calling `AddPNode::Value()`, we call `TypeAryPtr::add_field_offset_and_offset()` which also considers `_field_offset` and properly sets it to 16 and correspondingly `_offset` to 16.

### Fixing the Mismatch
A straight forward fix is to use `add_field_offset_and_offset()` instead of `add_offset()` when having an array pointer. This works to address the observing assertion failure. This is what's suggested in this patch. I also applied some small clean-ups.

### Another Lurking Bug
In `add_field_offset_and_offset()`, we have special code to find out what the `_field_offset` is for a flat array pointer:
https://github.com/openjdk/valhalla/blob/583bdbc45a0c044eb0e26436983e9f416f806ed6/src/hotspot/share/opto/type.cpp#L5799-L5809

This assumes that `_field_offset` is implicitly 0 even when it's set to `bottom` which could actually mean any field offset. This most likely seems to hold in all the cases we currently know of but is not correct in the general case. We should fix that as well. But when restricting this to `_field_offset != bottom`, we hit other assertions. This requires more investigation.

To move forward with this patch and enable more testing again, I suggest to fix this second issue separately, either with [JDK-8358079](https://bugs.openjdk.org/browse/JDK-8358079) or a new issue.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8381268](https://bugs.openjdk.org/browse/JDK-8381268): [lworld] C2: assert(adr-&gt;is_top() || C-&gt;get_alias_index(gvn.type(adr)-&gt;is_ptr(), true) == C-&gt;get_alias_index(adr_type, true)) failed: adr and adr_type must agree (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2370/head:pull/2370` \
`$ git checkout pull/2370`

Update a local copy of the PR: \
`$ git checkout pull/2370` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2370`

View PR using the GUI difftool: \
`$ git pr show -t 2370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2370.diff">https://git.openjdk.org/valhalla/pull/2370.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2370#issuecomment-4326722259)
</details>
