### PR TITLE
8383415: [lworld] Flat contended oop field might not be included in OopMap

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -174,8 +174,7 @@ FieldGroup::FieldGroup(int contended_group) :
   _small_primitive_fields(nullptr),
   _big_primitive_fields(nullptr),
   _oop_fields(nullptr),
-  _contended_group(contended_group),  // -1 means no contended group, 0 means default contended group
-  _has_embedded_oops(false) {}
+  _contended_group(contended_group) {} // -1 means no contended group, 0 means default contended group
 
 void FieldGroup::add_primitive_field(int idx, BasicType type) {
   int size = type2aelembytes(type);
@@ -194,7 +193,6 @@ void FieldGroup::add_oop_field(int idx) {
     _oop_fields = new GrowableArray<LayoutRawBlock*>(INITIAL_LIST_SIZE);
   }
   _oop_fields->append(block);
-  _has_embedded_oops = true;
 }
 
 void FieldGroup::add_flat_field(int idx, InlineKlass* vk, LayoutKind lk) {
@@ -206,10 +204,6 @@ void FieldGroup::add_flat_field(int idx, InlineKlass* vk, LayoutKind lk) {
   block->set_layout_kind(lk);
   if (block->size() >= heapOopSize) {
     add_to_big_primitive_list(block);
-
-    if (vk->contains_oops()) {
-      _has_embedded_oops = true;
-    }
   } else {
     assert(!vk->contains_oops(), "Size of Inline klass with oops should be >= heapOopSize");
     add_to_small_primitive_list(block);
@@ -1344,8 +1338,7 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
   epilogue();
 }
 
-void FieldLayoutBuilder::add_flat_field_oopmap(OopMapBlocksBuilder* nonstatic_oop_maps,
-                InlineKlass* vklass, int offset) {
+void FieldLayoutBuilder::add_flat_field_oopmap(OopMapBlocksBuilder* nonstatic_oop_maps, InlineKlass* vklass, int offset) {
   int diff = offset - vklass->payload_offset();
   const OopMapBlock* map = vklass->start_of_nonstatic_oop_maps();
   const OopMapBlock* last_map = map + vklass->nonstatic_oop_map_count();
@@ -1356,7 +1349,10 @@ void FieldLayoutBuilder::add_flat_field_oopmap(OopMapBlocksBuilder* nonstatic_oo
 }
 
 void FieldLayoutBuilder::register_embedded_oops_from_list(OopMapBlocksBuilder* nonstatic_oop_maps, GrowableArray<LayoutRawBlock*>* list) {
-  if (list == nullptr) return;
+  if (list == nullptr) {
+    return;
+  }
+
   for (int i = 0; i < list->length(); i++) {
     LayoutRawBlock* f = list->at(i);
     if (f->block_kind() == LayoutRawBlock::FLAT) {
@@ -1537,9 +1533,7 @@ void FieldLayoutBuilder::epilogue() {
   if (!_contended_groups.is_empty()) {
     for (int i = 0; i < _contended_groups.length(); i++) {
       FieldGroup* cg = _contended_groups.at(i);
-      if (cg->has_embedded_oops()) {
-        register_embedded_oops(nonstatic_oop_maps, cg);
-      }
+      register_embedded_oops(nonstatic_oop_maps, cg);
     }
   }
   nonstatic_oop_maps->compact();

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -175,7 +175,7 @@ FieldGroup::FieldGroup(int contended_group) :
   _big_primitive_fields(nullptr),
   _oop_fields(nullptr),
   _contended_group(contended_group),  // -1 means no contended group, 0 means default contended group
-  _oop_count(0) {}
+  _has_embedded_oops(false) {}
 
 void FieldGroup::add_primitive_field(int idx, BasicType type) {
   int size = type2aelembytes(type);
@@ -194,7 +194,7 @@ void FieldGroup::add_oop_field(int idx) {
     _oop_fields = new GrowableArray<LayoutRawBlock*>(INITIAL_LIST_SIZE);
   }
   _oop_fields->append(block);
-  _oop_count++;
+  _has_embedded_oops = true;
 }
 
 void FieldGroup::add_flat_field(int idx, InlineKlass* vk, LayoutKind lk) {
@@ -206,6 +206,10 @@ void FieldGroup::add_flat_field(int idx, InlineKlass* vk, LayoutKind lk) {
   block->set_layout_kind(lk);
   if (block->size() >= heapOopSize) {
     add_to_big_primitive_list(block);
+
+    if (vk->contains_oops()) {
+      _has_embedded_oops = true;
+    }
   } else {
     assert(!vk->contains_oops(), "Size of Inline klass with oops should be >= heapOopSize");
     add_to_small_primitive_list(block);
@@ -1533,8 +1537,7 @@ void FieldLayoutBuilder::epilogue() {
   if (!_contended_groups.is_empty()) {
     for (int i = 0; i < _contended_groups.length(); i++) {
       FieldGroup* cg = _contended_groups.at(i);
-      if (cg->oop_count() > 0) {
-        assert(cg->oop_fields() != nullptr && cg->oop_fields()->at(0) != nullptr, "oop_count > 0 but no oop fields found");
+      if (cg->has_embedded_oops()) {
         register_embedded_oops(nonstatic_oop_maps, cg);
       }
     }

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -144,7 +144,7 @@ class FieldGroup : public ResourceObj {
   GrowableArray<LayoutRawBlock*>* _big_primitive_fields;
   GrowableArray<LayoutRawBlock*>* _oop_fields;
   int _contended_group;
-  int _oop_count;
+  bool _has_embedded_oops;
   static const int INITIAL_LIST_SIZE = 16;
 
  public:
@@ -156,7 +156,7 @@ class FieldGroup : public ResourceObj {
   GrowableArray<LayoutRawBlock*>* big_primitive_fields() const { return _big_primitive_fields; }
   GrowableArray<LayoutRawBlock*>* oop_fields() const { return _oop_fields; }
   int contended_group() const { return _contended_group; }
-  int oop_count() const { return _oop_count; }
+  bool has_embedded_oops() const { return _has_embedded_oops; }
 
   void add_primitive_field(int idx, BasicType type);
   void add_oop_field(int idx);

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -144,7 +144,6 @@ class FieldGroup : public ResourceObj {
   GrowableArray<LayoutRawBlock*>* _big_primitive_fields;
   GrowableArray<LayoutRawBlock*>* _oop_fields;
   int _contended_group;
-  bool _has_embedded_oops;
   static const int INITIAL_LIST_SIZE = 16;
 
  public:
@@ -156,7 +155,6 @@ class FieldGroup : public ResourceObj {
   GrowableArray<LayoutRawBlock*>* big_primitive_fields() const { return _big_primitive_fields; }
   GrowableArray<LayoutRawBlock*>* oop_fields() const { return _oop_fields; }
   int contended_group() const { return _contended_group; }
-  bool has_embedded_oops() const { return _has_embedded_oops; }
 
   void add_primitive_field(int idx, BasicType type);
   void add_oop_field(int idx);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
@@ -31,7 +31,7 @@ import jdk.test.whitebox.WhiteBox;
 /*
  * @test ContendedFlatFieldOopMap
  * @library /test/lib
- * @requires vm.gc != "Z"
+ * @requires vm.gc != "Z" & (vm.opt.RestrictContended == null | vm.opt.RestrictContended == "false")
  * @modules java.base/jdk.internal.vm.annotation
  * @build jdk.test.whitebox.WhiteBox
  * @enablePreview

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package runtime.valhalla.inlinetypes;
+
+import jdk.test.lib.Asserts;
+import jdk.internal.vm.annotation.Contended;
+import java.lang.ref.WeakReference;
+
+/*
+ * @test ContendedFlatFieldOopMap
+ * @library /test/lib
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @run main/othervm -XX:-RestrictContended runtime.valhalla.inlinetypes.ContendedFlatFieldOopMap
+ */
+public class ContendedFlatFieldOopMap {
+
+    private static value class Payload {
+        Object ref;
+
+        Payload(Object ref) {
+            this.ref = ref;
+        }
+    }
+
+    private static class Holder {
+        @Contended
+        Payload payload;
+
+        Holder(Object ref) {
+            payload = new Payload(ref);
+        }
+    }
+
+    private static Holder holder;
+
+    public static void main(String[] args) {
+        Object[] obj = new Object[1024 * 1024];
+        WeakReference ref = new WeakReference(obj);
+        holder = new Holder(obj);
+        obj = null;
+
+        Asserts.assertNotEquals(ref.get(), null);
+
+        System.gc();
+
+        // obj must have stayed alive after we've run a GC. If it stayed alive,
+        // it must mean that obj was reachable through the Holder class' OopMap.
+        Asserts.assertNotEquals(ref.get(), null);
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
@@ -22,17 +22,23 @@
  */
 package runtime.valhalla.inlinetypes;
 
-import jdk.test.lib.Asserts;
 import jdk.internal.vm.annotation.Contended;
 import java.lang.ref.WeakReference;
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
 
 /*
  * @test ContendedFlatFieldOopMap
  * @library /test/lib
- * @requires vm.flagless
+ * @requires vm.gc != "Z"
  * @modules java.base/jdk.internal.vm.annotation
+ * @build jdk.test.whitebox.WhiteBox
  * @enablePreview
- * @run main/othervm -XX:-RestrictContended runtime.valhalla.inlinetypes.ContendedFlatFieldOopMap
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -XX:-RestrictContended
+ *                   -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   runtime.valhalla.inlinetypes.ContendedFlatFieldOopMap
  */
 public class ContendedFlatFieldOopMap {
 
@@ -55,6 +61,8 @@ public class ContendedFlatFieldOopMap {
 
     private static Holder holder;
 
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+
     public static void main(String[] args) {
         Object[] obj = new Object[1024 * 1024];
         WeakReference ref = new WeakReference(obj);
@@ -63,7 +71,7 @@ public class ContendedFlatFieldOopMap {
 
         Asserts.assertNotEquals(ref.get(), null);
 
-        System.gc();
+        WB.fullGC();
 
         // obj must have stayed alive after we've run a GC. If it stayed alive,
         // it must mean that obj was reachable through the Holder class' OopMap.


### PR DESCRIPTION
Hello,

Embdedded flat contended fields might not be included in the class' OopMap if there are no other oop fields in the holder class.

Flat fields are handled separately in fieldLayoutBuilder.cpp, resulting in the current `_oop_count` not being updated if a flat field contains oops. This is OK, since the oop fields are handled at a later point in time. However, for contended fields, which are part of the contended group, embedded oop fields are only tracked if: `cg->oop_count() > 0`, which is not guaranteed to be true.

I've written a test to see if the oop field is included in the class' OopMap and also changed the `_oop_count` field `_has_embedded_oops`, and changed that to a boolean property, which is how we've used it so far.

Since embedded fields in flat paylods are not tracked in `cg->oop_fields()`, we can't do the assert that is currently there, so I just removed that.

Testing:
* New test fails without the fixes in fieldLayoutBuilder and passes with fixes
* Running Oracle's tier1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383415](https://bugs.openjdk.org/browse/JDK-8383415): [lworld] Flat contended oop field might not be included in OopMap (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer) ⚠️ Review applies to [83974110](https://git.openjdk.org/valhalla/pull/2371/files/83974110de00a3a3230603da937f17490e0e2135)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2371/head:pull/2371` \
`$ git checkout pull/2371`

Update a local copy of the PR: \
`$ git checkout pull/2371` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2371`

View PR using the GUI difftool: \
`$ git pr show -t 2371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2371.diff">https://git.openjdk.org/valhalla/pull/2371.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2371#issuecomment-4327838042)
</details>
