### PR TITLE
8381826: [lworld] [REDO] Improve acmp expansion

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -40,6 +40,7 @@
 #include "opto/locknode.hpp"
 #include "opto/machnode.hpp"
 #include "opto/matcher.hpp"
+#include "opto/memnode.hpp"
 #include "opto/movenode.hpp"
 #include "opto/parse.hpp"
 #include "opto/regalloc.hpp"
@@ -1192,66 +1193,14 @@ Node* CallStaticJavaNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     }
   }
 
-  // Try to replace the runtime call to the substitutability test emitted by acmp if (at least) one operand is a known type
-  if (can_reshape && !control()->is_top() && method() != nullptr && method()->holder() == phase->C->env()->ValueObjectMethods_klass() &&
-      (method()->name() == ciSymbols::isSubstitutable_name())) {
-    Node* left = in(TypeFunc::Parms);
-    Node* right = in(TypeFunc::Parms + 1);
-    if (!left->is_top() && !right->is_top() && (left->is_InlineType() || right->is_InlineType())) {
-      if (!left->is_InlineType()) {
-        swap(left, right);
-      }
-      InlineTypeNode* vt = left->as_InlineType();
-
-      // Check if the field layout can be optimized
-      if (vt->can_emit_substitutability_check(right)) {
-        PhaseIterGVN* igvn = phase->is_IterGVN();
-        if (UseAcmpFastPath) {
-          // Sabotage the fast acmp path
-          IfNode* fast_path_if = Parse::acmp_fast_path_if_from_substitutable_call(phase, this);
-          if (fast_path_if != nullptr) {
-            fast_path_if->set_req(1, phase->intcon(1));
-            igvn->_worklist.push(fast_path_if);
-          }
-        }
-
-        Node* ctrl = control();
-        RegionNode* region = new RegionNode(1);
-        Node* phi = new PhiNode(region, TypeInt::POS);
-
-        Node* base = right;
-        Node* ptr = right;
-        if (!base->is_InlineType()) {
-          // Parse time checks guarantee that both operands are non-null and have the same type
-          base = igvn->register_new_node_with_optimizer(new CheckCastPPNode(ctrl, base, vt->bottom_type()));
-          ptr = base;
-        }
-        // Emit IR for field-wise comparison
-        vt->check_substitutability(igvn, region, phi, &ctrl, in(TypeFunc::Memory), base, ptr);
-
-        // Equals
-        region->add_req(ctrl);
-        phi->add_req(igvn->intcon(1));
-
-        ctrl = igvn->register_new_node_with_optimizer(region);
-        Node* res = igvn->register_new_node_with_optimizer(phi);
-
-        // Kill exception projections and return a tuple that will replace the call
-        CallProjections* projs = extract_projections(false /*separate_io_proj*/);
-        if (projs->fallthrough_catchproj != nullptr) {
-          igvn->replace_node(projs->fallthrough_catchproj, ctrl);
-        }
-        if (projs->catchall_memproj != nullptr) {
-          igvn->replace_node(projs->catchall_memproj, igvn->C->top());
-        }
-        if (projs->catchall_ioproj != nullptr) {
-          igvn->replace_node(projs->catchall_ioproj, igvn->C->top());
-        }
-        if (projs->catchall_catchproj != nullptr) {
-          igvn->replace_node(projs->catchall_catchproj, igvn->C->top());
-        }
-        return TupleNode::make(tf()->range_cc(), ctrl, i_o(), memory(), frameptr(), returnadr(), res);
-      }
+  // Try to replace the runtime call to the substitutability test emitted by acmp if we can reason
+  // about the operands
+  if (can_reshape && !control()->is_top() && method() != nullptr &&
+      method()->holder() == phase->C->env()->ValueObjectMethods_klass() &&
+      method()->name() == ciSymbols::isSubstitutable_name()) {
+    Node* res = replace_is_substitutable(phase->is_IterGVN());
+    if (res != nullptr) {
+      return res;
     }
   }
 
@@ -1447,6 +1396,61 @@ bool CallStaticJavaNode::remove_unknown_flat_array_load(PhaseIterGVN* igvn, Node
   return true;
 }
 
+// Try to replace a runtime call to the substitutability test by either a simple pointer comparison
+// if either operand is not a value object, or comparing their fields if either operand is an
+// object of a known value type
+Node* CallStaticJavaNode::replace_is_substitutable(PhaseIterGVN* igvn) {
+  // Delay IGVN during macro expansion
+  assert(!igvn->delay_transform(), "must not delay during Ideal");
+  igvn->set_delay_transform(true);
+
+  // Prepare to inline, clone the jvms
+  JVMState* jvms = this->jvms()->clone_shallow(igvn->C);
+  assert(jvms->map()->next_exception() == nullptr, "this call does not throw");
+  SafePointNode* map = new SafePointNode(req(), jvms);
+  igvn->register_new_node_with_optimizer(map);
+  for (uint i = 0; i < req(); i++) {
+    map->init_req(i, in(i));
+  }
+  MergeMemNode* mem = MergeMemNode::make(map->memory());
+  igvn->register_new_node_with_optimizer(mem);
+  map->set_memory(mem);
+  jvms->set_map(map);
+  GraphKit kit(jvms, igvn);
+
+  Node* left = in(TypeFunc::Parms);
+  Node* right = in(TypeFunc::Parms + 1);
+  Node* replace = InlineTypeNode::emit_substitutability_check(&kit, left, right);
+  igvn->set_delay_transform(false);
+  if (replace == nullptr) {
+    return nullptr;
+  }
+
+  if (UseAcmpFastPath) {
+    // Sabotage the fast acmp path
+    IfNode* fast_path_if = Parse::acmp_fast_path_if_from_substitutable_call(igvn, this);
+    if (fast_path_if != nullptr) {
+      fast_path_if->set_req(1, igvn->intcon(1));
+      igvn->_worklist.push(fast_path_if);
+    }
+  }
+
+  // Kill exception projections and return a tuple that will replace the call
+  CallProjections* projs = extract_projections(false /*separate_io_proj*/);
+  if (projs->fallthrough_catchproj != nullptr) {
+    igvn->replace_node(projs->fallthrough_catchproj, kit.control());
+  }
+  if (projs->catchall_memproj != nullptr) {
+    igvn->replace_node(projs->catchall_memproj, igvn->C->top());
+  }
+  if (projs->catchall_ioproj != nullptr) {
+    igvn->replace_node(projs->catchall_ioproj, igvn->C->top());
+  }
+  if (projs->catchall_catchproj != nullptr) {
+    igvn->replace_node(projs->catchall_catchproj, igvn->C->top());
+  }
+  return TupleNode::make(tf()->range_cc(), igvn->C->top(), kit.i_o(), kit.reset_memory(), kit.frameptr(), kit.returnadr(), replace);
+}
 
 #ifndef PRODUCT
 void CallStaticJavaNode::dump_spec(outputStream *st) const {

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1401,18 +1401,20 @@ bool CallStaticJavaNode::remove_unknown_flat_array_load(PhaseIterGVN* igvn, Node
 // if either operand is not a value object, or comparing their fields if either operand is an
 // object of a known value type
 Node* CallStaticJavaNode::replace_is_substitutable(PhaseIterGVN* igvn) {
+  Node* left = in(TypeFunc::Parms);
+  Node* right = in(TypeFunc::Parms + 1);
+  if (!InlineTypeNode::can_emit_substitutability_check(left, right)) {
+    return nullptr;
+  }
+
   // Delay IGVN during macro expansion
   assert(!igvn->delay_transform(), "must not delay during Ideal");
   igvn->set_delay_transform(true);
   GraphKit kit(this, *igvn);
 
-  Node* left = in(TypeFunc::Parms);
-  Node* right = in(TypeFunc::Parms + 1);
   Node* replace = InlineTypeNode::emit_substitutability_check(&kit, left, right);
   igvn->set_delay_transform(false);
-  if (replace == nullptr) {
-    return nullptr;
-  }
+  assert(replace != nullptr, "must succeed");
 
   if (UseAcmpFastPath) {
     // Sabotage the fast acmp path

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -47,6 +47,7 @@
 #include "opto/regmask.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/runtime.hpp"
+#include "opto/type.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -1403,20 +1404,7 @@ Node* CallStaticJavaNode::replace_is_substitutable(PhaseIterGVN* igvn) {
   // Delay IGVN during macro expansion
   assert(!igvn->delay_transform(), "must not delay during Ideal");
   igvn->set_delay_transform(true);
-
-  // Prepare to inline, clone the jvms
-  JVMState* jvms = this->jvms()->clone_shallow(igvn->C);
-  assert(jvms->map()->next_exception() == nullptr, "this call does not throw");
-  SafePointNode* map = new SafePointNode(req(), jvms);
-  igvn->register_new_node_with_optimizer(map);
-  for (uint i = 0; i < req(); i++) {
-    map->init_req(i, in(i));
-  }
-  MergeMemNode* mem = MergeMemNode::make(map->memory());
-  igvn->register_new_node_with_optimizer(mem);
-  map->set_memory(mem);
-  jvms->set_map(map);
-  GraphKit kit(jvms, igvn);
+  GraphKit kit(this, *igvn);
 
   Node* left = in(TypeFunc::Parms);
   Node* right = in(TypeFunc::Parms + 1);
@@ -1449,7 +1437,9 @@ Node* CallStaticJavaNode::replace_is_substitutable(PhaseIterGVN* igvn) {
   if (projs->catchall_catchproj != nullptr) {
     igvn->replace_node(projs->catchall_catchproj, igvn->C->top());
   }
-  return TupleNode::make(tf()->range_cc(), igvn->C->top(), kit.i_o(), kit.reset_memory(), kit.frameptr(), kit.returnadr(), replace);
+  Node* new_mem = kit.reset_memory();
+  assert(in(TypeFunc::Memory) == new_mem, "must not modify memory");
+  return TupleNode::make(tf()->range_cc(), igvn->C->top(), kit.i_o(), new_mem, kit.frameptr(), kit.returnadr(), replace);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -901,6 +901,7 @@ class CallStaticJavaNode : public CallJavaNode {
   virtual uint size_of() const; // Size is bigger
 
   bool remove_unknown_flat_array_load(PhaseIterGVN* igvn, Node* ctl, Node* mem, Node* unc_arg);
+  Node* replace_is_substitutable(PhaseIterGVN* igvn);
 
 public:
   CallStaticJavaNode(Compile* C, const TypeFunc* tf, address addr, ciMethod* method)

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -117,7 +117,7 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Push cast through InlineTypeNode
   InlineTypeNode* vt = in(1)->isa_InlineType();
-  if (vt != nullptr && phase->type(vt)->filter_speculative(_type) != Type::TOP) {
+  if (vt != nullptr && vt->is_allocated(phase)) {
     Node* cast = clone();
     cast->set_req(1, vt->get_oop());
     vt = vt->clone()->as_InlineType();

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1571,19 +1571,22 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
 //------------------------------cast_not_null----------------------------------
 // Cast obj to not-null on this path
 Node* GraphKit::cast_not_null(Node* obj, bool do_replace_in_map) {
+  const Type* t = _gvn.type(obj);
+  const Type* t_not_null = t->join_speculative(TypePtr::NOTNULL);
+  if (t == t_not_null) {
+    return obj;
+  }
+
   if (obj->is_InlineType()) {
-    Node* vt = obj->isa_InlineType()->clone_if_required(&gvn(), map(), do_replace_in_map);
-    vt->as_InlineType()->set_null_marker(_gvn);
-    vt = _gvn.transform(vt);
+    InlineTypeNode* vt = obj->isa_InlineType()->clone_if_required(&gvn(), map(), do_replace_in_map);
+    vt->set_null_marker(_gvn);
+    vt->set_type(t_not_null);
+    vt = _gvn.transform(vt)->as_InlineType();
     if (do_replace_in_map) {
       replace_in_map(obj, vt);
     }
     return vt;
   }
-  const Type *t = _gvn.type(obj);
-  const Type *t_not_null = t->join_speculative(TypePtr::NOTNULL);
-  // Object is already not-null?
-  if( t == t_not_null ) return obj;
 
   Node* cast = new CastPPNode(control(), obj,t_not_null);
   cast = _gvn.transform( cast );

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -114,7 +114,7 @@ GraphKit::GraphKit(const SafePointNode* sft, PhaseIterGVN& igvn)
     current->set_map(cloned_map);
   }
   set_jvms(cloned_jvms);
-  set_all_memory(reset_memory());
+  set_all_memory(cloned_map->memory());
 }
 
 //---------------------------clean_stack---------------------------------------
@@ -1675,11 +1675,19 @@ Node* GraphKit::reset_memory() {
 
 //------------------------------set_all_memory---------------------------------
 void GraphKit::set_all_memory(Node* newmem) {
-  Node* mergemem = MergeMemNode::make(newmem);
-  gvn().set_type_bottom(mergemem);
-  if (_gvn.is_IterGVN() != nullptr) {
-    record_for_igvn(mergemem);
+  // The 2 cases are semantically equivalent
+  MergeMemNode* mergemem;
+  if (_gvn.is_IterGVN()) {
+    // During IGVN, create a more predictable pattern so it is easier to verify that the GraphKit
+    // does not modify memory
+    mergemem = MergeMemNode::make(C->top());
+    mergemem->set_base_memory(newmem);
+  } else {
+    // During parsing, be a little more aggressive so that GVN can fold accesses more easily
+    mergemem = MergeMemNode::make(newmem);
   }
+  _gvn.set_type_bottom(mergemem);
+  record_for_igvn(mergemem);
   map()->set_memory(mergemem);
 }
 
@@ -3768,13 +3776,6 @@ Node* GraphKit::gen_checkcast(Node* obj, Node* superklass, Node** failure_contro
   bool speculative_not_null = false;
   bool never_see_null = ((failure_control == nullptr)  // regular case only
                          && seems_never_null(obj, data, speculative_not_null));
-
-  if (obj->is_InlineType()) {
-    // Re-execute if buffering during triggers deoptimization
-    PreserveReexecuteState preexecs(this);
-    jvms()->set_should_reexecute(true);
-    obj = obj->as_InlineType()->buffer(this, safe_for_replace);
-  }
 
   // Null check; get casted pointer; set region slot 3
   Node* null_ctl = top();

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -614,6 +614,85 @@ void InlineTypeNode::store(GraphKit* kit, Node* base, Node* ptr, bool immutable_
   }
 }
 
+// If a value class contains cycle, bail out from trying to expand substitutability check involving it
+static bool check_cycle(ciInlineKlass* vk) {
+  ResourceMark rm;
+  GrowableArray<Pair<ciInlineKlass*, int>> visited;
+  visited.push(Pair(vk, 0));
+  while (visited.is_nonempty()) {
+    ciInlineKlass* current = visited.top().first;
+    bool finish = true;
+    for (int field_idx = visited.top().second; field_idx < current->nof_nonstatic_fields(); field_idx++) {
+      ciField* field = current->nonstatic_field_at(field_idx);
+      ciType* ft = field->type();
+      if (!ft->is_inlinetype()) {
+        continue;
+      } else if (visited.find_if([&](const auto& entry) { return entry.first == ft; }) >= 0) {
+        return true;
+      } else {
+        visited.top().second = field_idx + 1;
+        visited.push(Pair(ft->as_inline_klass(), 0));
+        finish = false;
+        break;
+      }
+    }
+    if (finish) {
+      visited.pop();
+    }
+  }
+  return false;
+}
+
+// Check if a substitutability check between 'lhs' and 'rhs' can be implemented in IR
+bool InlineTypeNode::can_emit_substitutability_check(Node* lhs, Node* rhs) {
+  if (!lhs->bottom_type()->isa_ptr() ||
+      (rhs != nullptr && !rhs->bottom_type()->isa_ptr())) {
+    return false;
+  }
+
+  if (rhs != nullptr && lhs->eqv_uncast(rhs)) {
+    return true;
+  }
+
+  if (!lhs->bottom_type()->is_ptr()->can_be_inline_type() ||
+      (rhs != nullptr && !rhs->bottom_type()->is_ptr()->can_be_inline_type())) {
+    return true;
+  }
+
+  if (!lhs->is_InlineType() && (rhs == nullptr || !rhs->is_InlineType())) {
+    return false;
+  }
+
+  if (!lhs->is_InlineType()) {
+    swap(lhs, rhs);
+  }
+
+  InlineTypeNode* lhs_inline = lhs->as_InlineType();
+  InlineTypeNode* rhs_inline = rhs != nullptr ? rhs->isa_InlineType() : nullptr;
+  if (rhs_inline != nullptr && lhs_inline->type()->inline_klass() != rhs_inline->type()->inline_klass()) {
+    // Dead code, can skip the substitutability check
+    return true;
+  }
+
+  if (check_cycle(lhs_inline->inline_klass())) {
+    return false;
+  }
+
+  for (uint i = 0; i < lhs_inline->field_count(); i++) {
+    ciType* ft = lhs_inline->field(i)->type();
+    if (!ft->can_be_inline_klass()) {
+      continue;
+    }
+
+    Node* lhs_fv = lhs_inline->field_value(i);
+    Node* rhs_fv = rhs_inline != nullptr ? rhs_inline->field_value(i) : nullptr;
+    if (!can_emit_substitutability_check(lhs_fv, rhs_fv)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Compare lhs and rhs given they are not value objects
 static void emit_substitutability_check_primitive(GraphKit* kit, PhiNode* result, Node* lhs, Node* rhs, BasicType bt) {
   PhaseGVN& gvn = kit->gvn();
@@ -646,35 +725,6 @@ static void emit_substitutability_check_primitive(GraphKit* kit, PhiNode* result
   kit->set_control(iff_true);
 }
 
-// If a value class contains cycle, bail out from trying to expand substitutability check involving it
-static bool check_cycle(ciInlineKlass* vk) {
-  ResourceMark rm;
-  GrowableArray<Pair<ciInlineKlass*, int>> visited;
-  visited.push(Pair(vk, 0));
-  while (visited.is_nonempty()) {
-    ciInlineKlass* current = visited.top().first;
-    bool finish = true;
-    for (int field_idx = visited.top().second; field_idx < current->nof_nonstatic_fields(); field_idx++) {
-      ciField* field = current->nonstatic_field_at(field_idx);
-      ciType* ft = field->type();
-      if (!ft->is_inlinetype()) {
-        continue;
-      } else if (visited.find_if([&](const auto& entry) { return entry.first == ft; }) >= 0) {
-        return true;
-      } else {
-        visited.top().second = field_idx + 1;
-        visited.push(Pair(ft->as_inline_klass(), 0));
-        finish = false;
-        break;
-      }
-    }
-    if (finish) {
-      visited.pop();
-    }
-  }
-  return false;
-}
-
 // Try to see what should be done with lhs and rhs. Either we can emit the answer if it is simple,
 // give up and emit a call to runtime, or start comparing the value objects field-by-field. In the
 // last case, NodeSentinel is returned.
@@ -691,7 +741,9 @@ static Node* emit_substitutability_check_pointer(GraphKit* kit, PhiNode* result,
   }
 
   Node* cmp = nullptr;
-  if (!lhs_type->is_ptr()->can_be_inline_type() || !rhs_type->is_ptr()->can_be_inline_type()) {
+  if (lhs->eqv_uncast(rhs)) {
+    cmp = kit->intcon(0);
+  } else if (!lhs_type->is_ptr()->can_be_inline_type() || !rhs_type->is_ptr()->can_be_inline_type()) {
     // If one of the sides is not a value object, can only be substitutable if they are the same
     cmp = kit->CmpP(lhs, rhs);
   } else if (lhs_type->is_instptr()->as_klass_type()->join(rhs_type->is_instptr()->as_klass_type())->empty()) {

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -26,9 +26,11 @@
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
 #include "gc/shared/gc_globals.hpp"
+#include "memory/resourceArea.hpp"
 #include "oops/accessDecorators.hpp"
 #include "opto/addnode.hpp"
 #include "opto/castnode.hpp"
+#include "opto/cfgnode.hpp"
 #include "opto/compile.hpp"
 #include "opto/convertnode.hpp"
 #include "opto/graphKit.hpp"
@@ -37,11 +39,16 @@
 #include "opto/movenode.hpp"
 #include "opto/multnode.hpp"
 #include "opto/narrowptrnode.hpp"
+#include "opto/node.hpp"
 #include "opto/opcodes.hpp"
 #include "opto/phaseX.hpp"
 #include "opto/rootnode.hpp"
+#include "opto/subnode.hpp"
 #include "opto/type.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/growableArray.hpp"
+#include "utilities/pair.hpp"
+#include "utilities/tuple.hpp"
 
 // Clones the inline type to handle control flow merges involving multiple inline types.
 // The inputs are replaced by PhiNodes to represent the merged values for the given region.
@@ -607,159 +614,363 @@ void InlineTypeNode::store(GraphKit* kit, Node* base, Node* ptr, bool immutable_
   }
 }
 
-// Adds a check between val1 and val2. Jumps to 'region' if check passes and optionally sets the corresponding phi input to false.
-static void acmp_val_guard(PhaseIterGVN* igvn, RegionNode* region, Node* phi, Node** ctrl, BasicType bt, BoolTest::mask test, Node* val1, Node* val2) {
-  Node* cmp = nullptr;
-  switch (bt) {
-  case T_FLOAT:
-    val1 = igvn->register_new_node_with_optimizer(new MoveF2INode(val1));
-    val2 = igvn->register_new_node_with_optimizer(new MoveF2INode(val2));
-    // Fall-through to the int case
-  case T_BOOLEAN:
-  case T_CHAR:
-  case T_BYTE:
-  case T_SHORT:
-  case T_INT:
-    cmp = igvn->register_new_node_with_optimizer(new CmpINode(val1, val2));
-    break;
-  case T_DOUBLE:
-    val1 = igvn->register_new_node_with_optimizer(new MoveD2LNode(val1));
-    val2 = igvn->register_new_node_with_optimizer(new MoveD2LNode(val2));
-    // Fall-through to the long case
-  case T_LONG:
-    cmp = igvn->register_new_node_with_optimizer(new CmpLNode(val1, val2));
-    break;
-  default:
-    assert(is_reference_type(bt), "must be");
-    cmp = igvn->register_new_node_with_optimizer(new CmpPNode(val1, val2));
+// Compare lhs and rhs given they are not value objects
+static void emit_substitutability_check_primitive(GraphKit* kit, PhiNode* result, Node* lhs, Node* rhs, BasicType bt) {
+  PhaseGVN& gvn = kit->gvn();
+  Node* cmp;
+  if (bt == T_INT || is_subword_type(bt)) {
+    cmp = kit->CmpI(lhs, rhs);
+  } else if (bt == T_LONG) {
+    cmp = kit->CmpL(lhs, rhs);
+  } else if (bt == T_FLOAT) {
+    lhs = gvn.transform(new MoveF2INode(lhs));
+    rhs = gvn.transform(new MoveF2INode(rhs));
+    cmp = kit->CmpI(lhs, rhs);
+  } else if (bt == T_DOUBLE) {
+    lhs = gvn.transform(new MoveD2LNode(lhs));
+    rhs = gvn.transform(new MoveD2LNode(rhs));
+    cmp = kit->CmpL(lhs, rhs);
+  } else {
+    assert(is_reference_type(bt), "unexpected bt %s", type2name(bt));
+    cmp = kit->CmpP(lhs, rhs);
   }
-  Node* bol = igvn->register_new_node_with_optimizer(new BoolNode(cmp, test));
-  IfNode* iff = igvn->register_new_node_with_optimizer(new IfNode(*ctrl, bol, PROB_MAX, COUNT_UNKNOWN))->as_If();
-  Node* if_f = igvn->register_new_node_with_optimizer(new IfFalseNode(iff));
-  Node* if_t = igvn->register_new_node_with_optimizer(new IfTrueNode(iff));
 
-  region->add_req(if_t);
-  if (phi != nullptr) {
-    phi->add_req(igvn->intcon(0));
-  }
-  *ctrl = if_f;
+  Node* bol = kit->Bool(cmp, BoolTest::eq);
+  IfNode* iff = kit->create_and_map_if(kit->control(), bol, PROB_FAIR, COUNT_UNKNOWN);
+
+  Node* iff_false = kit->IfFalse(iff);
+  result->add_req(kit->intcon(0));
+  result->region()->add_req(iff_false);
+
+  Node* iff_true = kit->IfTrue(iff);
+  kit->set_control(iff_true);
 }
 
-// Check if a substitutability check between 'this' and 'other' can be implemented in IR
-bool InlineTypeNode::can_emit_substitutability_check(Node* other) const {
-  if (other != nullptr && other->is_InlineType() && bottom_type() != other->bottom_type()) {
-    // Different types, this is dead code because there's a check above that guarantees this.
-    return false;
-  }
-  for (uint i = 0; i < field_count(); i++) {
-    ciType* ft = field(i)->type();
-    Node* fv = field_value(i);
-    if (ft->is_inlinetype() && fv->is_InlineType()) {
-      // Check recursively
-      if (!fv->as_InlineType()->can_emit_substitutability_check(nullptr)){
-        return false;
-      }
-    } else if (ft->can_be_inline_klass()) {
-      // Comparing this field might require (another) substitutability check, bail out
-      return false;
-    }
-  }
-  return true;
-}
-
-// Emit IR to check substitutability between 'this' (left operand) and the value object referred to by 'other' (right operand).
-// Parse-time checks guarantee that both operands have the same type. If 'other' is not an InlineTypeNode, we need to emit loads for the field values.
-void InlineTypeNode::check_substitutability(PhaseIterGVN* igvn, RegionNode* region, Node* phi, Node** ctrl, Node* mem, Node* base, Node* other, bool flat) const {
-  BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  DecoratorSet decorators = IN_HEAP | MO_UNORDERED | C2_READ_ACCESS | C2_CONTROL_DEPENDENT_LOAD;
-  MergeMemNode* local_mem = igvn->register_new_node_with_optimizer(MergeMemNode::make(mem))->as_MergeMem();
-
-  ciInlineKlass* vk = inline_klass();
-  for (uint i = 0; i < field_count(); i++) {
-    ciField* field = this->field(i);
-    int field_off = field->offset_in_bytes();
-    if (flat) {
-      // Flat access, no header
-      field_off -= vk->payload_offset();
-    }
-    Node* this_field = field_value(i);
-    ciType* ft = field->type();
-    BasicType bt = ft->basic_type();
-
-    Node* other_base = base;
-    Node* other_field = other;
-
-    // Get field value of the other operand
-    if (other->is_InlineType()) {
-      other_field = other->as_InlineType()->field_value(i);
-      other_base = nullptr;
-    } else {
-      // 'other' is an oop, compute address of the field
-      other_field = igvn->register_new_node_with_optimizer(AddPNode::make_with_base(base, other, igvn->MakeConX(field_off)));
-      if (field->is_flat()) {
-        // Flat field, load is handled recursively below
-        assert(this_field->is_InlineType(), "inconsistent field value");
+// If a value class contains cycle, bail out from trying to expand substitutability check involving it
+static bool check_cycle(ciInlineKlass* vk) {
+  ResourceMark rm;
+  GrowableArray<Pair<ciInlineKlass*, int>> visited;
+  visited.push(Pair(vk, 0));
+  while (visited.is_nonempty()) {
+    ciInlineKlass* current = visited.top().first;
+    bool finish = true;
+    for (int field_idx = visited.top().second; field_idx < current->nof_nonstatic_fields(); field_idx++) {
+      ciField* field = current->nonstatic_field_at(field_idx);
+      ciType* ft = field->type();
+      if (!ft->is_inlinetype()) {
+        continue;
+      } else if (visited.find_if([&](const auto& entry) { return entry.first == ft; }) >= 0) {
+        return true;
       } else {
-        // Non-flat field, load the field value and update the base because we are now operating on a different object
-        assert(is_java_primitive(bt) || other_field->bottom_type()->is_ptr_to_narrowoop() == UseCompressedOops, "inconsistent field type");
-        C2AccessValuePtr addr(other_field, other_field->bottom_type()->is_ptr());
-        C2OptAccess access(*igvn, *ctrl, local_mem, decorators, bt, base, addr);
-        other_field = bs->load_at(access, Type::get_const_type(ft));
-        other_base = other_field;
+        visited.top().second = field_idx + 1;
+        visited.push(Pair(ft->as_inline_klass(), 0));
+        finish = false;
+        break;
+      }
+    }
+    if (finish) {
+      visited.pop();
+    }
+  }
+  return false;
+}
+
+// Try to see what should be done with lhs and rhs. Either we can emit the answer if it is simple,
+// give up and emit a call to runtime, or start comparing the value objects field-by-field. In the
+// last case, NodeSentinel is returned.
+static Node* emit_substitutability_check_pointer(GraphKit* kit, PhiNode* result, Node* lhs, Node* rhs) {
+  PhaseGVN& gvn = kit->gvn();
+  Node* top = kit->C->top();
+  const Type* lhs_type = gvn.type(lhs);
+  const Type* rhs_type = gvn.type(rhs);
+
+  // Dead graph
+  if (lhs_type == Type::TOP || rhs_type == Type::TOP) {
+    kit->set_control(top);
+    return top;
+  }
+
+  Node* cmp = nullptr;
+  if (!lhs_type->is_ptr()->can_be_inline_type() || !rhs_type->is_ptr()->can_be_inline_type()) {
+    // If one of the sides is not a value object, can only be substitutable if they are the same
+    cmp = kit->CmpP(lhs, rhs);
+  } else if (lhs_type->is_instptr()->as_klass_type()->join(rhs_type->is_instptr()->as_klass_type())->empty()) {
+    // Both belongs to provably different types, must be different unless both are null. Cannot
+    // rely on the pointer independence alone because different pointers may still be
+    // substitutable.
+    cmp = kit->CmpP(lhs, rhs);
+  }
+  if (cmp != nullptr) {
+    Node* res = kit->Bool(cmp, BoolTest::eq);
+    IfNode* iff = kit->create_and_map_if(kit->control(), res, PROB_FAIR, COUNT_UNKNOWN);
+
+    Node* iff_false = kit->IfFalse(iff);
+    result->region()->add_req(iff_false);
+    result->add_req(gvn.intcon(0));
+
+    Node* iff_true = kit->IfTrue(iff);
+    kit->set_control(iff_true);
+    return iff_true;
+  }
+
+  if (!lhs_type->is_inlinetypeptr() && !rhs_type->is_inlinetypeptr()) {
+    return nullptr;
+  }
+
+  // A cycle, give up
+  ciInlineKlass* vk = lhs_type->is_inlinetypeptr() ? lhs_type->inline_klass() : rhs_type->inline_klass();
+  if (check_cycle(vk)) {
+    return nullptr;
+  }
+
+  return NodeSentinel;
+}
+
+Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node* rhs) {
+  if (!kit->C->allow_macro_nodes()) {
+    // After macro expansion, InlineTypeNodes are also eliminated, creation of new ones then is not
+    // allowed
+    return nullptr;
+  }
+
+  PhaseIterGVN& igvn = *kit->gvn().is_IterGVN();
+  RegionNode* region = new RegionNode(1);
+  PhiNode* result = new PhiNode(region, TypeInt::BOOL);
+  igvn.register_new_node_with_optimizer(region);
+  igvn.register_new_node_with_optimizer(result);
+
+  Node* preprocess = emit_substitutability_check_pointer(kit, result, lhs, rhs);
+  if (preprocess == nullptr) {
+    return nullptr;
+  } else if (preprocess != NodeSentinel) {
+    region->add_req(kit->control());
+    result->add_req(igvn.intcon(1));
+    kit->set_control(region);
+    return result;
+  }
+
+  const Type* lhs_type = igvn.type(lhs);
+  const Type* rhs_type = igvn.type(rhs);
+  assert(!lhs_type->maybe_null() && !rhs_type->maybe_null(), "must check null beforehand");
+  ciInlineKlass* vk = lhs_type->is_inlinetypeptr() ? lhs_type->inline_klass() : rhs_type->inline_klass();
+  const TypeInstPtr* vk_type = TypeOopPtr::make_from_klass(vk)->join(TypePtr::NOTNULL)->is_instptr();
+
+  if (!lhs->is_InlineType()) {
+    if (!lhs_type->higher_equal(vk_type)) {
+      lhs = igvn.transform(new CheckCastPPNode(kit->control(), lhs, vk_type, ConstraintCastNode::DependencyType::NonFloatingNarrowing));
+    }
+    lhs = InlineTypeNode::make_from_oop(kit, lhs, vk);
+  }
+  if (!rhs->is_InlineType()) {
+    if (!rhs_type->higher_equal(vk_type)) {
+      rhs = igvn.transform(new CheckCastPPNode(kit->control(), rhs, vk_type, ConstraintCastNode::DependencyType::NonFloatingNarrowing));
+    }
+    rhs = InlineTypeNode::make_from_oop(kit, rhs, vk);
+  }
+
+  RegionNode* true_region = new RegionNode(3);
+  igvn.register_new_node_with_optimizer(true_region);
+  region->add_req(true_region);
+  result->add_req(igvn.intcon(1));
+
+  // To verify the substitutability of 2 notnull value objects of the same type, we need to check
+  // the substitutability of each field in the objects:
+  //
+  // substitutable(cur_lhs, cur_rhs) {
+  //   cur_start_region:
+  //
+  //   if (cur_lhs.field1 == null && cur_rhs.field1 == null) {
+  //     goto cur_true_field1_region;
+  //   } else if ((cur_lhs.field1 == null) != (cur_rhs.field1 == null) {
+  //     return false;
+  //   } else if (cur_lhs.field1.klass != cur_rhs.field1.klass) {
+  //     return false;
+  //   }
+  //
+  //   cur_start_field1_region:
+  //   if (substitutable(cur_lhs.field1, cur_rhs.field1)) {
+  //     return false;
+  //   }
+  //   cur_true_field1_region:
+  //
+  //   if (cur_lhs.field2 == null && cur_rhs.field2 == null) {
+  //     goto cur_true_field2_region;
+  //   } else if ((cur_lhs.field2 == null) != (cur_rhs.field2 == null) {
+  //     return false;
+  //   } else if (cur_lhs.field2.klass != cur_rhs.field2.klass) {
+  //     return false;
+  //   }
+  //
+  //   cur_start_field2_region:
+  //   if (!substitutable(cur_lhs.field1, cur_rhs.field1)) {
+  //     return false;
+  //   }
+  //   cur_true_field2_region:
+  //
+  //   ...
+  //
+  //   cur_true_fieldn_region:
+  //
+  //   cur_true_region:
+  // }
+  //
+  // To avoid recursion, for field values that are value objects, we create the start and end
+  // region for the substitutability check of that field when both sides are notnull, save them on
+  // the worklist to process them later.
+  ResourceMark rm;
+  using WorklistEntry = Tuple<Node*, RegionNode*, InlineTypeNode*, InlineTypeNode*>;
+  GrowableArray<WorklistEntry> worklist;
+  worklist.push(WorklistEntry(kit->control(), true_region, lhs->as_InlineType(), rhs->as_InlineType()));
+  while (worklist.is_nonempty()) {
+    WorklistEntry entry = worklist.pop();
+    Node* cur_start_region = entry.get<0>();
+    RegionNode* cur_true_region = entry.get<1>();
+    InlineTypeNode* cur_lhs = entry.get<2>();
+    InlineTypeNode* cur_rhs = entry.get<3>();
+
+    kit->set_control(cur_start_region);
+    if (kit->stopped()) {
+      break;
+    }
+    ciInlineKlass* vk = cur_lhs->inline_klass();
+    assert(vk == cur_rhs->inline_klass(), "should not reach here otherwise");
+
+    auto is_simple_field = [](ciField* field) {
+      ciType* ft = field->type();
+      return is_java_primitive(ft->basic_type()) || !ft->as_klass()->can_be_inline_klass();
+    };
+
+    // Go through all fields, process the simple ones first
+    for (int field_idx = 0; field_idx < vk->nof_declared_nonstatic_fields(); field_idx++) {
+      ciField* field = vk->declared_nonstatic_field_at(field_idx);
+      if (is_simple_field(field)) {
+        Node* cur_lhs_field = cur_lhs->field_value(field_idx);
+        Node* cur_rhs_field = cur_rhs->field_value(field_idx);
+        emit_substitutability_check_primitive(kit, result, cur_lhs_field, cur_rhs_field, field->type()->basic_type());
       }
     }
 
-    if (this_field->is_InlineType()) {
-      RegionNode* done_region = new RegionNode(1);
-      assert(!field->is_flat() || field->type()->is_inlinetype(), "must be an inline type");
-      if (!field->is_null_free()) {
-        // Nullable field, check null marker before accessing the fields
-        if (field->is_flat()) {
-          // Flat field, check embedded null marker
-          Node* null_marker = nullptr;
-          if (other_field->is_InlineType()) {
-            // TODO 8350865 Should we add an IGVN optimization to fold null marker loads from InlineTypeNodes?
-            null_marker = other_field->as_InlineType()->get_null_marker();
-          } else {
-            Node* nm_offset = igvn->MakeConX(ft->as_inline_klass()->null_marker_offset_in_payload());
-            Node* nm_adr = igvn->register_new_node_with_optimizer(AddPNode::make_with_base(base, other_field, nm_offset));
-            C2AccessValuePtr addr(nm_adr, nm_adr->bottom_type()->is_ptr());
-            C2OptAccess access(*igvn, *ctrl, local_mem, decorators, T_BOOLEAN, base, addr);
-            null_marker = bs->load_at(access, TypeInt::BOOL);
-          }
-          // Return false if null markers are not equal
-          acmp_val_guard(igvn, region, phi, ctrl, T_INT, BoolTest::ne, this_field->as_InlineType()->get_null_marker(), null_marker);
+    for (int field_idx = 0; field_idx < vk->nof_declared_nonstatic_fields(); field_idx++) {
+      ciField* field = vk->declared_nonstatic_field_at(field_idx);
+      if (is_simple_field(field)) {
+        // These fields have already been processed
+        continue;
+      }
 
-          // Null markers are equal. If both operands are null, skip the comparison of the fields.
-          acmp_val_guard(igvn, done_region, nullptr, ctrl, T_INT, BoolTest::eq, this_field->as_InlineType()->get_null_marker(), igvn->intcon(0));
-        } else {
-          // Non-flat field, check if oop is null
+      Node* cur_lhs_field = cur_lhs->field_value(field_idx);
+      Node* cur_rhs_field = cur_rhs->field_value(field_idx);
 
-          // Check if 'this' is null
-          RegionNode* not_null_region = new RegionNode(1);
-          acmp_val_guard(igvn, not_null_region, nullptr, ctrl, T_INT, BoolTest::ne, this_field->as_InlineType()->get_null_marker(), igvn->intcon(0));
+      Node* preprocess = emit_substitutability_check_pointer(kit, result, cur_lhs_field, cur_rhs_field);
+      if (kit->stopped()) {
+        break;
+      } else if (preprocess == nullptr) {
+        // Must emit a substitutability check for this field, give up for now
+        return nullptr;
+      } else if (preprocess != NodeSentinel) {
+        continue;
+      }
 
-          // 'this' is null. If 'other' is non-null, return false.
-          acmp_val_guard(igvn, region, phi, ctrl, T_OBJECT, BoolTest::ne, other_field, igvn->zerocon(T_OBJECT));
+      // When field is not null-free, the shape would look like this:
+      //
+      // current_control:
+      // if (cur_lhs_field == null) {
+      //   if (cur_rhs_field == null) {
+      //     goto field_true_region;
+      //   } else {
+      //     return false;
+      //   }
+      // } else {
+      //   if (cur_rhs_field == null) {
+      //     return false;
+      //   }
+      // }
+      // if (cur_lhs_field.klass != cur_rhs_field.klass) {
+      //   return false;
+      // }
+      //
+      // field_start_region:
+      // if (!substitutable(cur_lhs_field, cur_rhs_field)) {
+      //   return false;
+      // }
+      // field_true_region:
+      //
+      // The substitutability test between the fields of cur_lhs_field and cur_rhs_field is then
+      // pushed on the worklist to be expanded later.
+      RegionNode* field_true_region = new RegionNode(3);
+      igvn.register_new_node_with_optimizer(field_true_region);
 
-          // Both are null, skip comparing the fields
-          done_region->add_req(*ctrl);
+      // Firstly, filter the cases when either is null
+      Node* null_unknown = kit->top();
+      cur_lhs_field = kit->null_check_common(cur_lhs_field, T_OBJECT, false, &null_unknown);
+      if (!null_unknown->is_top()) {
+        PreserveJVMState pjvms(kit);
+        kit->set_control(null_unknown);
+        Node* null_null = kit->top();
+        kit->null_check_common(cur_rhs_field, T_OBJECT, false, &null_null);
 
-          // 'this' is not null. If 'other' is null, return false.
-          *ctrl = igvn->register_new_node_with_optimizer(not_null_region);
-          acmp_val_guard(igvn, region, phi, ctrl, T_OBJECT, BoolTest::eq, other_field, igvn->zerocon(T_OBJECT));
+        // null - null, skip other checks
+        field_true_region->init_req(1, null_null);
+
+        // null - notnull
+        if (!kit->stopped()) {
+          region->add_req(kit->control());
+          result->add_req(igvn.intcon(0));
         }
       }
-      // Both operands are non-null, compare all the fields recursively
-      this_field->as_InlineType()->check_substitutability(igvn, region, phi, ctrl, mem, other_base, other_field, field->is_flat());
+      if (kit->stopped()) {
+        // cur_lhs_field is always null
+        kit->set_control(field_true_region);
+        continue;
+      }
 
-      done_region->add_req(*ctrl);
-      *ctrl = igvn->register_new_node_with_optimizer(done_region);
-    } else {
-      assert(!ft->can_be_inline_klass(), "Needs substitutability test");
-      acmp_val_guard(igvn, region, phi, ctrl, bt, BoolTest::ne, this_field, other_field);
+      Node* notnull_null = kit->top();
+      cur_rhs_field = kit->null_check_common(cur_rhs_field, T_OBJECT, false, &notnull_null);
+      if (!notnull_null->is_top()) {
+        region->add_req(notnull_null);
+        result->add_req(igvn.intcon(0));
+      }
+
+      if (kit->stopped()) {
+        // cur_rhs_field is always null
+        kit->set_control(field_true_region);
+        continue;
+      }
+      assert(!igvn.type(cur_lhs_field)->maybe_null() && !igvn.type(cur_rhs_field)->maybe_null(), "must be notnull");
+
+      // Can expand this comparison
+      const Type* cur_lhs_field_type = igvn.type(cur_lhs_field);
+      const Type* cur_rhs_field_type = igvn.type(cur_rhs_field);
+      ciInlineKlass* vk = cur_lhs_field_type->is_inlinetypeptr() ? cur_lhs_field_type->inline_klass() : cur_rhs_field_type->inline_klass();
+      const TypeInstKlassPtr* vk_klass_type = TypeInstKlassPtr::make(vk, Type::ignore_interfaces);
+      Node* vk_klass = igvn.makecon(vk_klass_type);
+
+      // Both must be vk
+      Node* not_vk = kit->top();
+      cur_lhs_field = kit->gen_checkcast(cur_lhs_field, vk_klass, &not_vk);
+      if (!not_vk->is_top()) {
+        region->add_req(not_vk);
+        result->add_req(igvn.intcon(0));
+      }
+      not_vk = kit->top();
+      cur_rhs_field = kit->gen_checkcast(cur_rhs_field, vk_klass, &not_vk);
+      if (!not_vk->is_top()) {
+        region->add_req(not_vk);
+        result->add_req(igvn.intcon(0));
+      }
+      if (!kit->stopped()) {
+        // Push the expanded InlineTypeNodes for processing later
+        worklist.push(WorklistEntry(kit->control(), field_true_region, cur_lhs_field->as_InlineType(), cur_rhs_field->as_InlineType()));
+      }
+
+      kit->set_control(field_true_region);
     }
+
+    cur_true_region->init_req(2, kit->control());
+    kit->set_control(cur_true_region);
   }
+
+  kit->set_control(region);
+  return result;
 }
 
 InlineTypeNode* InlineTypeNode::buffer(GraphKit* kit, bool safe_for_replace) {
@@ -1127,6 +1338,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
       vt = vt->clone_with_phis(&gvn, region, kit->map());
       vt->merge_with(&gvn, null_vt, 2, true);
       vt->set_oop(gvn, oop);
+      vt->set_is_buffered(gvn);
       kit->set_control(gvn.transform(region));
     }
   } else {

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -134,8 +134,7 @@ public:
   InlineTypeNode* adjust_scalarization_depth(GraphKit* kit);
 
   // Implementation of the substitutability check for acmp
-  bool can_emit_substitutability_check(Node* other) const;
-  void check_substitutability(PhaseIterGVN* igvn, RegionNode* region, Node* phi, Node** ctrl, Node* mem, Node* base, Node* other, bool flat = false) const;
+  static Node* emit_substitutability_check(GraphKit* kit, Node* lhs, Node* rhs);
 
   // Allocates the inline type (if not yet allocated)
   InlineTypeNode* buffer(GraphKit* kit, bool safe_for_replace = true);

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -134,6 +134,7 @@ public:
   InlineTypeNode* adjust_scalarization_depth(GraphKit* kit);
 
   // Implementation of the substitutability check for acmp
+  static bool can_emit_substitutability_check(Node* lhs, Node* rhs);
   static Node* emit_substitutability_check(GraphKit* kit, Node* lhs, Node* rhs);
 
   // Allocates the inline type (if not yet allocated)

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -6136,6 +6136,11 @@ Node* MergeMemNode::Identity(PhaseGVN* phase) {
 //------------------------------Ideal------------------------------------------
 // This method is invoked recursively on chains of MergeMem nodes
 Node *MergeMemNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+  if (Identity(phase) != this) {
+    // Let Identity handle this case
+    return nullptr;
+  }
+
   // Remove chain'd MergeMems
   //
   // This is delicate, because the each "in(i)" (i >= Raw) is interpreted

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1315,7 +1315,7 @@ static Node* see_through_inline_type(PhaseValues* phase, const LoadNode* load, N
   // but we should not recklessly fold the load
   ciInstanceKlass* expected_type = base_type->instance_klass();
   ciInlineKlass* actual_type = vt->type()->inline_klass();
-  if (expected_type == actual_type && offset >= actual_type->payload_offset()) {
+  if (expected_type == actual_type && actual_type->get_field_by_offset(offset, false) != nullptr) {
     Node* value = vt->field_value_by_offset(offset, true);
     assert(value != nullptr, "must see some value");
     return value;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -25,6 +25,7 @@
 
 #include "ci/ciFlatArrayKlass.hpp"
 #include "ci/ciInlineKlass.hpp"
+#include "ci/ciInstanceKlass.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmIntrinsics.hpp"
@@ -1295,9 +1296,26 @@ Node* LoadNode::can_see_arraycopy_value(Node* st, PhaseGVN* phase) const {
   return nullptr;
 }
 
-static Node* see_through_inline_type(PhaseValues* phase, const MemNode* load, Node* base, int offset) {
-  if (!load->is_mismatched_access() && base != nullptr && base->is_InlineType() && offset > oopDesc::klass_offset_in_bytes()) {
-    InlineTypeNode* vt = base->as_InlineType();
+static Node* see_through_inline_type(PhaseValues* phase, const LoadNode* load, Node* base, int offset) {
+  if (load->is_mismatched_access() || base == nullptr) {
+    return nullptr;
+  }
+
+  InlineTypeNode* vt = base->uncast()->isa_InlineType();
+  if (vt == nullptr) {
+    return nullptr;
+  }
+
+  const TypeInstPtr* base_type = phase->type(base)->isa_instptr();
+  if (base_type == nullptr) {
+    return nullptr;
+  }
+
+  // There can be cases when an InlineTypeNode is casted to some unrelated type, the graph is dead
+  // but we should not recklessly fold the load
+  ciInstanceKlass* expected_type = base_type->instance_klass();
+  ciInlineKlass* actual_type = vt->type()->inline_klass();
+  if (expected_type == actual_type && offset >= actual_type->payload_offset()) {
     Node* value = vt->field_value_by_offset(offset, true);
     assert(value != nullptr, "must see some value");
     return value;
@@ -1318,12 +1336,9 @@ Node* LoadNode::can_see_stored_value_through_membars(Node* st, PhaseValues* phas
   intptr_t ld_off = 0;
   Node* ld_base = AddPNode::Ideal_base_and_offset(ld_adr, phase, ld_off);
   // Try to see through an InlineTypeNode
-  // LoadN is special because the input is not compressed
-  if (Opcode() != Op_LoadN) {
-    Node* value = see_through_inline_type(phase, this, ld_base, ld_off);
-    if (value != nullptr) {
-      return value;
-    }
+  Node* value = see_through_inline_type(phase, this, ld_base, ld_off);
+  if (value != nullptr) {
+    return value;
   }
 
   const TypeInstPtr* tp = phase->type(ld_adr)->isa_instptr();
@@ -2743,17 +2758,8 @@ const Type* LoadSNode::Value(PhaseGVN* phase) const {
 }
 
 Node* LoadNNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  // Loading from an InlineType, find the input and make an EncodeP
-  Node* addr = in(Address);
-  intptr_t offset;
-  Node* base = AddPNode::Ideal_base_and_offset(addr, phase, offset);
-  Node* value = see_through_inline_type(phase, this, base, offset);
-  if (value != nullptr) {
-    return new EncodePNode(value, type());
-  }
-
   // Can see the corresponding value, may need to add an EncodeP
-  value = can_see_stored_value(in(Memory), phase);
+  Node* value = can_see_stored_value_through_membars(in(Memory), phase);
   if (value != nullptr && phase->type(value)->isa_ptr() && type()->isa_narrowoop()) {
     return new EncodePNode(value, type());
   }

--- a/src/hotspot/share/utilities/tuple.hpp
+++ b/src/hotspot/share/utilities/tuple.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ private:
   Tuple<Ts...> _remaining;
 
 public:
+  constexpr explicit Tuple() noexcept : _first(), _remaining() {}
+
   constexpr Tuple(const T& first, const Ts&... remaining) noexcept
     : _first(first), _remaining(remaining...) {}
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -5234,6 +5234,74 @@ public class TestLWorld {
         Asserts.assertTrue(test182(val3, val4));
     }
 
+        @Test
+    @IR(failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ALLOC})
+    public boolean test183(Integer o1, Value181 o2) {
+        // The only intersection is null
+        return getter(new Value181(o1)) == getter(new Value181(o2));
+    }
+
+    @Run(test = "test183")
+    public void test183_verifier() {
+        Value181 val = new Value181(null);
+        Asserts.assertTrue(test183(null, null));
+        Asserts.assertFalse(test183(null, val));
+        Asserts.assertFalse(test183(0, null));
+        Asserts.assertFalse(test183(0, val));
+    }
+
+    @Test
+    @IR(failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ALLOC})
+    @IR(counts = {IRNode.CMP_P, "1"})
+    public boolean test184(MyClass152 o1, Object o2) {
+        // One side is not a value object
+        return getter(new Value181(o1)) == getter(new Value181(o2));
+    }
+
+    @Run(test = "test184")
+    public void test184_verifier() {
+        MyClass152 identity = new MyClass152(0);
+        Asserts.assertTrue(test184(null, null));
+        Asserts.assertFalse(test184(null, identity));
+        Asserts.assertFalse(test184(identity, 0));
+        Asserts.assertTrue(test184(identity, identity));
+        Asserts.assertFalse(test184(identity, new MyClass152(0)));
+    }
+
+    @Test
+    @IR(failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ALLOC})
+    public boolean test185(MyValue152 o1, Object o2) {
+        // One side is a value object
+        return getter(new Value181(o1)) == getter(new Value181(o2));
+    }
+
+    @Run(test = "test185")
+    public void test185_verifier() {
+        MyValue152 value = new MyValue152(0);
+        Asserts.assertTrue(test185(null, null));
+        Asserts.assertFalse(test185(null, value));
+        Asserts.assertFalse(test185(value, 0));
+        Asserts.assertTrue(test185(value, value));
+        Asserts.assertTrue(test185(value, new MyValue152(0)));
+    }
+
+    @Test
+    @IR(failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
+    public boolean test186(MyClass152 o1, Object o2) {
+        // One side is not a value object
+        return getter(o1) == getter(o2);
+    }
+
+    @Run(test = "test186")
+    public void test186_verifier() {
+        MyClass152 identity = new MyClass152(0);
+        Asserts.assertTrue(test186(null, null));
+        Asserts.assertFalse(test186(null, identity));
+        Asserts.assertFalse(test186(identity, 0));
+        Asserts.assertTrue(test186(identity, identity));
+        Asserts.assertFalse(test186(identity, new MyClass152(0)));
+    }
+
     @LooselyConsistentValue
     static value class V1MismatchedStore {
         int x;
@@ -5409,4 +5477,3 @@ public class TestLWorld {
         }
     }
 }
-

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -5116,7 +5116,7 @@ public class TestLWorld {
     }
 
     // Same as test178 but with object argument
-    @Test
+    @Test(allowNotCompilable = true) // TODO 8378943: reason should be "failed spill-split-recycle sanity check"
     @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
     public boolean test179(Value178 x, Object y) {
         return getter(x) == getter(y);
@@ -5234,7 +5234,7 @@ public class TestLWorld {
         Asserts.assertTrue(test182(val3, val4));
     }
 
-        @Test
+    @Test
     @IR(failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ALLOC})
     public boolean test183(Integer o1, Value181 o2) {
         // The only intersection is null


### PR DESCRIPTION
Hi,

This PR redoes [JDK-8377414](https://bugs.openjdk.org/browse/JDK-8377414). While at it, I encountered [JDK-8383416](https://bugs.openjdk.org/browse/JDK-8383416) when a `CastPPNode` is pushed through an unbuffered `InlineTypeNode`, which results in the oop input being `top`. This incorrectly kills the graph. I tried fixing JDK-8383416 alone but I encountered the issue with acmp expansion passing the incorrect base to `InlineTypeNode::check_substitutability`. As a result, this PR aims at fixing both issues.

It is easier reviewing each commit. The first one just reverts the backout PR, the second one ensures that the expansion does not modify the memory, and the third commit fixes JDK-8383416.

Testing:

- [x] tier1-4,valhalla-comp-stress

Please take a look and leave your review, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issues
 * [JDK-8381826](https://bugs.openjdk.org/browse/JDK-8381826): [lworld] [REDO] Improve acmp expansion (**Enhancement** - P4)
 * [JDK-8383416](https://bugs.openjdk.org/browse/JDK-8383416): [lworld] C2: ConstraintCastNode::Ideal incorrectly pushes the cast through an InlineTypeNode (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2376/head:pull/2376` \
`$ git checkout pull/2376`

Update a local copy of the PR: \
`$ git checkout pull/2376` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2376`

View PR using the GUI difftool: \
`$ git pr show -t 2376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2376.diff">https://git.openjdk.org/valhalla/pull/2376.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2376#issuecomment-4346378827)
</details>
