### PR TITLE
8383636: [lworld] ContendedFlatFieldOopMap.java fails due to missing -XX:+UnlockDiagnosticVMOptions

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java
@@ -36,7 +36,7 @@ import jdk.test.whitebox.WhiteBox;
  * @build jdk.test.whitebox.WhiteBox
  * @enablePreview
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -XX:-RestrictContended
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-RestrictContended
  *                   -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   runtime.valhalla.inlinetypes.ContendedFlatFieldOopMap
  */


### PR DESCRIPTION
WhiteBoxAPI needs UnlockDiagnosticVMOptions. Let's give it.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383636](https://bugs.openjdk.org/browse/JDK-8383636): [lworld] ContendedFlatFieldOopMap.java fails due to missing -XX:+UnlockDiagnosticVMOptions (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2378/head:pull/2378` \
`$ git checkout pull/2378`

Update a local copy of the PR: \
`$ git checkout pull/2378` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2378`

View PR using the GUI difftool: \
`$ git pr show -t 2378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2378.diff">https://git.openjdk.org/valhalla/pull/2378.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2378#issuecomment-4351264483)
</details>
