### PR TITLE
8383628: [lworld] C1 parts of JDK-8350865

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1570,14 +1570,6 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
   // declared type is Object[], abstract[], interface[] or VT.ref[]).
   // If this array is a flat array, take the slow path.
   __ test_flat_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
-  if (!op->value()->is_illegal()) {
-    // The array is not a flat array, but it might be null-free. If we are storing
-    // a null into a null-free array, take the slow path (which will throw NPE).
-    Label skip;
-    __ cbnz(op->value()->as_register(), skip);
-    __ test_null_free_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
-    __ bind(skip);
-  }
 }
 
 void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
@@ -2352,7 +2344,6 @@ void LIR_Assembler::arraycopy_inlinetype_check(Register obj, Register tmp, CodeS
   }
   if (is_dest) {
     __ test_null_free_array_oop(obj, tmp, *slow_path->entry());
-    // TODO 8350865 Flat no longer implies null-free, so we need to check for flat dest. Can we do better here?
     __ test_flat_array_oop(obj, tmp, *slow_path->entry());
   } else {
     __ test_flat_array_oop(obj, tmp, *slow_path->entry());

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1566,16 +1566,6 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
   // declared type is Object[], abstract[], interface[] or VT.ref[]).
   // If this array is a flat array, take the slow path.
   __ test_flat_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
-  if (!op->value()->is_illegal()) {
-    // TODO 8350865 This is also used for profiling code, right? And in that case we don't care about null but just want to know if the array is flat or not.
-    // The array is not a flat array, but it might be null-free. If we are storing
-    // a null into a null-free array, take the slow path (which will throw NPE).
-    Label skip;
-    __ cmpptr(op->value()->as_register(), NULL_WORD);
-    __ jcc(Assembler::notEqual, skip);
-    __ test_null_free_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
-    __ bind(skip);
-  }
 }
 
 void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
@@ -2510,7 +2500,6 @@ void LIR_Assembler::arraycopy_inlinetype_check(Register obj, Register tmp, CodeS
   }
   if (is_dest) {
     __ test_null_free_array_oop(obj, tmp, *slow_path->entry());
-    // TODO 8350865 Flat no longer implies null-free, so we need to check for flat dest. Can we do better here?
     __ test_flat_array_oop(obj, tmp, *slow_path->entry());
   } else {
     __ test_flat_array_oop(obj, tmp, *slow_path->entry());

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2040,6 +2040,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                 assert(!needs_patching, "Can't patch delayed field access");
                 pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->payload_offset());
                 NewInstance* vt = new NewInstance(inline_klass, pending_load_indexed()->state_before(), false, true);
+                // TODO should we do that for all NewInstance??
                 vt->set_null_free(true);
                 _memory->new_instance(vt);
                 pending_load_indexed()->load_instr()->set_vt(vt);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1074,13 +1074,11 @@ void GraphBuilder::load_indexed(BasicType type) {
   }
 
   bool need_membar = false;
-  bool is_null_free = false;
   LoadIndexed* load_indexed = nullptr;
   Instruction* result = nullptr;
   if (array->is_loaded_flat_array()) {
     ciType* array_type = array->declared_type();
     ciFlatArrayKlass* array_klass = array_type->as_flat_array_klass();
-    is_null_free = array_klass->is_elem_null_free();
     ciInlineKlass* elem_klass = array_klass->element_klass()->as_inline_klass();
 
     bool can_delay_access = false;
@@ -1088,6 +1086,7 @@ void GraphBuilder::load_indexed(BasicType type) {
     s.force_bci(bci());
     s.next();
     if (s.cur_bc() == Bytecodes::_getfield) {
+      bool is_null_free = array_klass->is_elem_null_free();
       bool will_link;
       ciField* next_field = s.get_field(will_link);
       bool next_needs_patching = !next_field->holder()->is_initialized() ||

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1109,9 +1109,6 @@ void GraphBuilder::load_indexed(BasicType type) {
       buffer->set_null_free(true);
       _memory->new_instance(buffer);
       result = append_split(buffer);
-      if (is_null_free) {
-        apush(result);
-      }
       load_indexed = new LoadIndexed(array, index, length, type, state_before);
       load_indexed->set_buffer(buffer);
       // The LoadIndexed node will initialize this instance by copying from
@@ -1133,9 +1130,7 @@ void GraphBuilder::load_indexed(BasicType type) {
     append(new MemBar(lir_membar_storestore));
   }
   assert(!load_indexed->should_profile() || load_indexed == result, "should not be optimized out");
-  if (!array->is_loaded_flat_array() || !is_null_free) {
-    push(as_ValueType(type), result);
-  }
+  push(as_ValueType(type), result);
 }
 
 

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -44,7 +44,6 @@
 #include "interpreter/bytecode.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "memory/resourceArea.hpp"
-#include "oops/layoutKind.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "utilities/checkedCast.hpp"
@@ -1094,7 +1093,7 @@ void GraphBuilder::load_indexed(BasicType type) {
       bool next_needs_patching = !next_field->holder()->is_initialized() ||
                                  !next_field->will_link(method(), Bytecodes::_getfield) ||
                                  PatchALot;
-      bool needs_atomic_access = LayoutKindHelper::is_atomic_flat(array_klass->layout_kind());
+      bool needs_atomic_access = array_klass->is_elem_atomic();
       can_delay_access = is_null_free && C1UseDelayedFlattenedFieldReads &&
                          !next_needs_patching && !needs_atomic_access;
     }

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -44,6 +44,7 @@
 #include "interpreter/bytecode.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/layoutKind.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "utilities/checkedCast.hpp"
@@ -1074,12 +1075,14 @@ void GraphBuilder::load_indexed(BasicType type) {
   }
 
   bool need_membar = false;
+  bool is_null_free = false;
   LoadIndexed* load_indexed = nullptr;
   Instruction* result = nullptr;
   if (array->is_loaded_flat_array()) {
-    // TODO 8350865 This is currently dead code. Can we use set_null_free on the result here if the array is null-free?
     ciType* array_type = array->declared_type();
-    ciInlineKlass* elem_klass = array_type->as_flat_array_klass()->element_klass()->as_inline_klass();
+    ciFlatArrayKlass* array_klass = array_type->as_flat_array_klass();
+    is_null_free = array_klass->is_elem_null_free();
+    ciInlineKlass* elem_klass = array_klass->element_klass()->as_inline_klass();
 
     bool can_delay_access = false;
     ciBytecodeStream s(method());
@@ -1091,7 +1094,9 @@ void GraphBuilder::load_indexed(BasicType type) {
       bool next_needs_patching = !next_field->holder()->is_initialized() ||
                                  !next_field->will_link(method(), Bytecodes::_getfield) ||
                                  PatchALot;
-      can_delay_access = C1UseDelayedFlattenedFieldReads && !next_needs_patching;
+      bool needs_atomic_access = LayoutKindHelper::is_atomic_flat(array_klass->layout_kind());
+      can_delay_access = is_null_free && C1UseDelayedFlattenedFieldReads &&
+                         !next_needs_patching && !needs_atomic_access;
     }
     if (can_delay_access) {
       // potentially optimizable array access, storing information for delayed decision
@@ -1102,8 +1107,13 @@ void GraphBuilder::load_indexed(BasicType type) {
       return; // Nothing else to do for now
     } else {
       NewInstance* new_instance = new NewInstance(elem_klass, state_before, false, true);
+      new_instance->set_null_free(true);
       _memory->new_instance(new_instance);
-      apush(append_split(new_instance));
+      Instruction* buffer = append_split(new_instance);
+      // TODO ???
+      if (is_null_free) {
+        apush(buffer);
+      }
       load_indexed = new LoadIndexed(array, index, length, type, state_before);
       load_indexed->set_vt(new_instance);
       // The LoadIndexed node will initialise this instance by copying from
@@ -1125,7 +1135,7 @@ void GraphBuilder::load_indexed(BasicType type) {
     append(new MemBar(lir_membar_storestore));
   }
   assert(!load_indexed->should_profile() || load_indexed == result, "should not be optimized out");
-  if (!array->is_loaded_flat_array()) {
+  if (!array->is_loaded_flat_array() || !is_null_free) {
     push(as_ValueType(type), result);
   }
 }
@@ -2030,6 +2040,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                 assert(!needs_patching, "Can't patch delayed field access");
                 pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->payload_offset());
                 NewInstance* vt = new NewInstance(inline_klass, pending_load_indexed()->state_before(), false, true);
+                vt->set_null_free(true);
                 _memory->new_instance(vt);
                 pending_load_indexed()->load_instr()->set_vt(vt);
                 apush(append_split(vt));

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1105,17 +1105,16 @@ void GraphBuilder::load_indexed(BasicType type) {
       set_pending_load_indexed(dli);
       return; // Nothing else to do for now
     } else {
-      NewInstance* new_instance = new NewInstance(elem_klass, state_before, false, true);
-      new_instance->set_null_free(true);
-      _memory->new_instance(new_instance);
-      Instruction* buffer = append_split(new_instance);
-      // TODO ???
+      NewInstance* buffer = new NewInstance(elem_klass, state_before, false, true);
+      buffer->set_null_free(true);
+      _memory->new_instance(buffer);
+      result = append_split(buffer);
       if (is_null_free) {
-        apush(buffer);
+        apush(result);
       }
       load_indexed = new LoadIndexed(array, index, length, type, state_before);
-      load_indexed->set_vt(new_instance);
-      // The LoadIndexed node will initialise this instance by copying from
+      load_indexed->set_buffer(buffer);
+      // The LoadIndexed node will initialize this instance by copying from
       // the flat field.  Ensure these stores are visible before any
       // subsequent store that publishes this reference.
       need_membar = true;
@@ -2038,23 +2037,22 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                 assert(field->is_null_free(), "nullable fields do not support delayed accesses yet");
                 assert(!needs_patching, "Can't patch delayed field access");
                 pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->payload_offset());
-                NewInstance* vt = new NewInstance(inline_klass, pending_load_indexed()->state_before(), false, true);
-                // TODO should we do that for all NewInstance??
-                vt->set_null_free(true);
-                _memory->new_instance(vt);
-                pending_load_indexed()->load_instr()->set_vt(vt);
-                apush(append_split(vt));
+                NewInstance* buffer = new NewInstance(inline_klass, pending_load_indexed()->state_before(), false, true);
+                buffer->set_null_free(true);
+                _memory->new_instance(buffer);
+                pending_load_indexed()->load_instr()->set_buffer(buffer);
+                apush(append_split(buffer));
                 append(pending_load_indexed()->load_instr());
                 set_pending_load_indexed(nullptr);
               } else if (has_pending_field_access()) {
                 assert(field->is_null_free(), "nullable fields do not support delayed accesses yet");
                 state_before = pending_field_access()->state_before();
-                NewInstance* new_instance = new NewInstance(inline_klass, state_before, false, true);
-                _memory->new_instance(new_instance);
-                apush(append_split(new_instance));
+                NewInstance* buffer = new NewInstance(inline_klass, state_before, false, true);
+                _memory->new_instance(buffer);
+                apush(append_split(buffer));
                 copy_inline_content(inline_klass, pending_field_access()->obj(),
                                     pending_field_access()->offset() + field->offset_in_bytes() - field->holder()->as_inline_klass()->payload_offset(),
-                                    new_instance, inline_klass->payload_offset(), state_before);
+                                    buffer, inline_klass->payload_offset(), state_before);
                 set_pending_field_access(nullptr);
               } else {
                 if (!field->is_null_free() && !inline_klass->is_initialized()) {
@@ -2064,23 +2062,23 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                   return;
                 }
 
-                NewInstance* new_instance = new NewInstance(inline_klass, state_before, false, true);
-                _memory->new_instance(new_instance);
-                append_split(new_instance);
+                NewInstance* buffer = new NewInstance(inline_klass, state_before, false, true);
+                _memory->new_instance(buffer);
+                append_split(buffer);
 
                 if (inline_klass->is_initialized() && inline_klass->is_empty()) {
                   // Needs an explicit null check because below code does not perform any actual load if there are no fields
                   null_check(obj);
                 }
-                copy_inline_content(inline_klass, obj, field->offset_in_bytes(), new_instance, inline_klass->payload_offset(), state_before);
+                copy_inline_content(inline_klass, obj, field->offset_in_bytes(), buffer, inline_klass->payload_offset(), state_before);
 
-                Instruction* result = new_instance;
+                Instruction* result = buffer;
                 if (!field->is_null_free()) {
                   Value int_zero = append(new Constant(intZero));
                   Value object_null = append(new Constant(objectNull));
                   Value nm_offset = append(new Constant(new LongConstant(offset + inline_klass->null_marker_offset_in_payload())));
                   Value nm = append(new UnsafeGet(T_BOOLEAN, obj, nm_offset, false));
-                  result = append(new IfOp(nm, Instruction::neq, int_zero, new_instance, object_null, state_before, false));
+                  result = append(new IfOp(nm, Instruction::neq, int_zero, buffer, object_null, state_before, false));
                 }
                 apush(result);
               }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -1101,3 +1101,4 @@ void RangeCheckPredicate::check_state() {
 void ProfileInvoke::state_values_do(ValueVisitor* f) {
   if (state() != nullptr) state()->values_do(f);
 }
+

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -163,7 +163,9 @@ bool Instruction::maybe_flat_array() const {
 bool Instruction::maybe_null_free_array() const {
   ciType* type = declared_type();
   if (type != nullptr) {
-    if (type->is_obj_array_klass()) {
+    if (type->is_loaded() && type->is_array_klass() && type->as_array_klass()->is_refined()) {
+      return type->as_array_klass()->is_elem_null_free();
+    } else if (type->is_obj_array_klass()) {
       // Due to array covariance, the runtime type might be a null-free array.
       if (type->as_obj_array_klass()->can_be_inline_array_klass()) {
         return true;
@@ -288,9 +290,7 @@ ciType* NewTypeArray::exact_type() const {
 }
 
 ciType* NewObjectArray::exact_type() const {
-  // TODO 8350865 The refined type should be used here
-  // return ciArrayKlass::make(klass(), false, true, true);
-  return ciArrayKlass::make(klass());
+  return ciObjArrayKlass::make(klass());
 }
 
 ciType* NewMultiArray::exact_type() const {
@@ -1101,4 +1101,3 @@ void RangeCheckPredicate::check_state() {
 void ProfileInvoke::state_values_do(ValueVisitor* f) {
   if (state() != nullptr) state()->values_do(f);
 }
-

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -290,6 +290,7 @@ ciType* NewTypeArray::exact_type() const {
 }
 
 ciType* NewObjectArray::exact_type() const {
+  // Returns the refined type
   return ciObjArrayKlass::make(klass());
 }
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -988,6 +988,7 @@ LEAF(LoadIndexed, AccessIndexed)
   ciType* declared_type() const;
 
   Value buffer() const { return _buffer; }
+  
   void set_buffer(Value buffer) {
     assert(buffer == nullptr || buffer->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must be a NewInstance");
     _buffer = buffer;

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -967,15 +967,15 @@ class DelayedLoadIndexed;
 
 LEAF(LoadIndexed, AccessIndexed)
  private:
-  NullCheck*  _explicit_null_check;              // For explicit null check elimination
-  Value _vt;
+  NullCheck*  _explicit_null_check;  // For explicit null check elimination
+  Value _buffer;                     // Buffer for load from flat arrays
   DelayedLoadIndexed* _delayed;
 
  public:
   // creation
   LoadIndexed(Value array, Value index, Value length, BasicType elt_type, ValueStack* state_before, bool mismatched = false)
   : AccessIndexed(array, index, length, elt_type, state_before, mismatched)
-  , _explicit_null_check(nullptr), _vt(nullptr), _delayed(nullptr) {}
+  , _explicit_null_check(nullptr), _buffer(nullptr), _delayed(nullptr) {}
 
   // accessors
   NullCheck* explicit_null_check() const         { return _explicit_null_check; }
@@ -987,24 +987,25 @@ LEAF(LoadIndexed, AccessIndexed)
   ciType* exact_type() const;
   ciType* declared_type() const;
 
-  Value vt() const { return _vt; }
-  void set_vt(Value vt) {
-    assert(vt == nullptr || vt->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must be a NewInstance");
-    _vt = vt;
+  Value buffer() const { return _buffer; }
+  void set_buffer(Value buffer) {
+    assert(buffer == nullptr || buffer->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must be a NewInstance");
+    _buffer = buffer;
   }
 
   DelayedLoadIndexed* delayed() const { return _delayed; }
   void set_delayed(DelayedLoadIndexed* delayed) { _delayed = delayed; }
 
-  // generic;
   virtual void input_values_do(ValueVisitor* f) {
     AccessIndexed::input_values_do(f);
-    if (_vt != nullptr) {
-      f->visit(&_vt);
-      assert(_vt->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must stay a NewInstance");
+    if (_buffer != nullptr) {
+      f->visit(&_buffer);
+      assert(_buffer->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must stay a NewInstance");
     }
   }
-  HASHING4(LoadIndexed, delayed() == nullptr && !should_profile(), elt_type(), array()->subst(), index()->subst(), vt())
+
+  // generic;
+  HASHING4(LoadIndexed, delayed() == nullptr && !should_profile(), elt_type(), array()->subst(), index()->subst(), buffer())
 };
 
 class DelayedLoadIndexed : public CompilationResourceObj {

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -988,7 +988,7 @@ LEAF(LoadIndexed, AccessIndexed)
   ciType* declared_type() const;
 
   Value buffer() const { return _buffer; }
-  
+
   void set_buffer(Value buffer) {
     assert(buffer == nullptr || buffer->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must be a NewInstance");
     _buffer = buffer;

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -968,7 +968,7 @@ class DelayedLoadIndexed;
 LEAF(LoadIndexed, AccessIndexed)
  private:
   NullCheck*  _explicit_null_check;              // For explicit null check elimination
-  NewInstance* _vt;
+  Value _vt;
   DelayedLoadIndexed* _delayed;
 
  public:
@@ -987,13 +987,23 @@ LEAF(LoadIndexed, AccessIndexed)
   ciType* exact_type() const;
   ciType* declared_type() const;
 
-  NewInstance* vt() const { return _vt; }
-  void set_vt(NewInstance* vt) { _vt = vt; }
+  Value vt() const { return _vt; }
+  void set_vt(Value vt) {
+    assert(vt == nullptr || vt->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must be a NewInstance");
+    _vt = vt;
+  }
 
   DelayedLoadIndexed* delayed() const { return _delayed; }
   void set_delayed(DelayedLoadIndexed* delayed) { _delayed = delayed; }
 
   // generic;
+  virtual void input_values_do(ValueVisitor* f) {
+    AccessIndexed::input_values_do(f);
+    if (_vt != nullptr) {
+      f->visit(&_vt);
+      assert(_vt->as_NewInstance() != nullptr, "LoadIndexed flat array buffer must stay a NewInstance");
+    }
+  }
   HASHING4(LoadIndexed, delayed() == nullptr && !should_profile(), elt_type(), array()->subst(), index()->subst(), vt())
 };
 

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -341,10 +341,9 @@ LIR_OpTypeCheck::LIR_OpTypeCheck(LIR_Code code, LIR_Opr object, LIR_Opr array, L
   }
 }
 
-LIR_OpFlattenedArrayCheck::LIR_OpFlattenedArrayCheck(LIR_Opr array, LIR_Opr value, LIR_Opr tmp, CodeStub* stub)
+LIR_OpFlattenedArrayCheck::LIR_OpFlattenedArrayCheck(LIR_Opr array, LIR_Opr tmp, CodeStub* stub)
   : LIR_Op(lir_flat_array_check, LIR_OprFact::illegalOpr, nullptr)
   , _array(array)
-  , _value(value)
   , _tmp(tmp)
   , _stub(stub) {}
 
@@ -855,7 +854,6 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
       LIR_OpFlattenedArrayCheck* opFlattenedArrayCheck = (LIR_OpFlattenedArrayCheck*)op;
 
       if (opFlattenedArrayCheck->_array->is_valid()) do_input(opFlattenedArrayCheck->_array);
-      if (opFlattenedArrayCheck->_value->is_valid()) do_input(opFlattenedArrayCheck->_value);
       if (opFlattenedArrayCheck->_tmp->is_valid())   do_temp(opFlattenedArrayCheck->_tmp);
 
       do_stub(opFlattenedArrayCheck->_stub);
@@ -1613,8 +1611,8 @@ void LIR_List::null_check(LIR_Opr opr, CodeEmitInfo* info, bool deoptimize_on_nu
   }
 }
 
-void LIR_List::check_flat_array(LIR_Opr array, LIR_Opr value, LIR_Opr tmp, CodeStub* stub) {
-  LIR_OpFlattenedArrayCheck* c = new LIR_OpFlattenedArrayCheck(array, value, tmp, stub);
+void LIR_List::check_flat_array(LIR_Opr array, LIR_Opr tmp, CodeStub* stub) {
+  LIR_OpFlattenedArrayCheck* c = new LIR_OpFlattenedArrayCheck(array, tmp, stub);
   append(c);
 }
 
@@ -2153,7 +2151,6 @@ void LIR_OpTypeCheck::print_instr(outputStream* out) const {
 
 void LIR_OpFlattenedArrayCheck::print_instr(outputStream* out) const {
   array()->print(out);                   out->print(" ");
-  value()->print(out);                   out->print(" ");
   tmp()->print(out);                     out->print(" ");
   if (stub() != nullptr) {
     out->print("[label:" INTPTR_FORMAT "]", p2i(stub()->entry()));

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1578,13 +1578,11 @@ class LIR_OpFlattenedArrayCheck: public LIR_Op {
 
  private:
   LIR_Opr       _array;
-  LIR_Opr       _value;
   LIR_Opr       _tmp;
   CodeStub*     _stub;
 public:
-  LIR_OpFlattenedArrayCheck(LIR_Opr array, LIR_Opr value, LIR_Opr tmp, CodeStub* stub);
+  LIR_OpFlattenedArrayCheck(LIR_Opr array, LIR_Opr tmp, CodeStub* stub);
   LIR_Opr array() const                          { return _array;         }
-  LIR_Opr value() const                          { return _value;         }
   LIR_Opr tmp() const                            { return _tmp;           }
   CodeStub* stub() const                         { return _stub;          }
 
@@ -2429,7 +2427,7 @@ class LIR_List: public CompilationResourceObj {
 
   void instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check, CodeEmitInfo* info_for_patch, ciMethod* profiled_method, int profiled_bci);
   void store_check(LIR_Opr object, LIR_Opr array, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, CodeEmitInfo* info_for_exception, ciMethod* profiled_method, int profiled_bci);
-  void check_flat_array(LIR_Opr array, LIR_Opr value, LIR_Opr tmp, CodeStub* stub);
+  void check_flat_array(LIR_Opr array, LIR_Opr tmp, CodeStub* stub);
   void check_null_free_array(LIR_Opr array, LIR_Opr tmp);
   void substitutability_check(LIR_Opr result, LIR_Opr left, LIR_Opr right, LIR_Opr equal_result, LIR_Opr not_equal_result,
                               ciKlass* left_klass, ciKlass* right_klass, LIR_Opr tmp1, LIR_Opr tmp2,

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1678,7 +1678,7 @@ void LIRGenerator::do_StoreField(StoreField* x) {
       bool is_constant_null = value.is_constant() && value.value()->is_null_obj();
       if (!is_constant_null) {
         LabelObj* L_isNull = new LabelObj();
-        bool needs_null_check = !value.is_constant() || value.value()->is_null_obj();
+        bool needs_null_check = !value.is_constant();
         if (needs_null_check) {
           __ cmp(lir_cond_equal, value.result(), LIR_OprFact::oopConst(nullptr));
           __ branch(lir_cond_equal, L_isNull->label());
@@ -1761,7 +1761,7 @@ void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& r
 }
 
 LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item,
-                                          ciField* field, size_t sub_offset) {
+                                        ciField* field, size_t sub_offset) {
   assert(sub_offset == 0 || field != nullptr, "Sanity check");
 
   // Find the starting address of the source (inside the array)
@@ -1786,11 +1786,12 @@ LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& i
     LIRItem elm_item(elm_resolved_addr, this);
     DecoratorSet decorators = IN_HEAP;
     if (is_load) {
-      access_load_at(decorators, bt, elm_item, LIR_OprFact::intConst(0), payload,
-                     nullptr, nullptr);
+      access_load_at(decorators, bt, elm_item, LIR_OprFact::intConst(0), payload, nullptr, nullptr);
       access_store_at(decorators, bt, obj_item, LIR_OprFact::intConst(elem_klass->payload_offset()), payload,
                       nullptr, nullptr, elem_klass);
+      // Null check is performed in the caller
     } else {
+      // Zero the payload
       LIR_Opr zero = (bt == T_LONG) ? LIR_OprFact::longConst(0) : LIR_OprFact::intConst(0);
       __ move(zero, payload);
 
@@ -1807,6 +1808,7 @@ LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& i
             __ cmp(lir_cond_equal, obj_item.result(), LIR_OprFact::oopConst(nullptr));
             __ branch(lir_cond_equal, L_isNull->label());
           }
+          // Load payload (if not empty) and set null marker.
           if (!elem_klass->is_empty()) {
             access_load_at(decorators, bt, obj_item, LIR_OprFact::intConst(elem_klass->payload_offset()), payload);
           }
@@ -1816,8 +1818,7 @@ LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& i
           }
         }
       }
-      access_store_at(decorators, bt, elm_item, LIR_OprFact::intConst(0), payload,
-                      nullptr, nullptr, elem_klass);
+      access_store_at(decorators, bt, elm_item, LIR_OprFact::intConst(0), payload, nullptr, nullptr, elem_klass);
     }
     return payload;
   }
@@ -2358,20 +2359,21 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
   if (x->buffer() != nullptr) {
     assert(x->array()->is_loaded_flat_array(), "must be");
     // Find the destination address (of the NewInlineTypeInstance).
-    LIRItem obj_item(x->buffer(), this);
-    LIR_Opr payload = access_flat_array(true, array, index, obj_item,
+    LIRItem buffer(x->buffer(), this);
+    LIR_Opr payload = access_flat_array(true, array, index, buffer,
                                         x->delayed() == nullptr ? nullptr : x->delayed()->field(),
                                         x->delayed() == nullptr ? 0 : x->delayed()->offset());
     ciFlatArrayKlass* array_klass = x->array()->declared_type()->as_flat_array_klass();
     if (array_klass->is_elem_null_free()) {
-      set_no_result(x);
+      set_result(x, x->buffer()->operand());
     } else {
+      // Check the null marker and set result to null if it's not set
       ciInlineKlass* elem_klass = array_klass->element_klass()->as_inline_klass();
       BasicType bt = elem_klass->atomic_size_to_basic_type(false);
       assert(payload->is_valid(), "nullable flat array load must return the atomic payload");
       __ logical_and(payload, null_marker_mask(bt, elem_klass->null_marker_offset_in_payload()), payload);
       __ cmp(lir_cond_equal, payload, (bt == T_LONG) ? LIR_OprFact::longConst(0) : LIR_OprFact::intConst(0));
-      __ cmove(lir_cond_equal, LIR_OprFact::oopConst(nullptr), obj_item.result(), rlock_result(x), T_OBJECT);
+      __ cmove(lir_cond_equal, LIR_OprFact::oopConst(nullptr), buffer.result(), rlock_result(x), T_OBJECT);
     }
   } else if (x->delayed() != nullptr) {
     assert(x->array()->is_loaded_flat_array(), "must be");

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1724,7 +1724,7 @@ LIR_Opr LIRGenerator::get_and_load_element_address(LIRItem& array, LIRItem& inde
   LIR_Opr index_op = new_register(T_LONG);
   if (index.result()->is_constant()) {
     jint const_index = index.result()->as_jint();
-    __ move(LIR_OprFact::longConst((jlong)const_index << shift), index_op);
+    __ move(LIR_OprFact::longConst(static_cast<jlong>(const_index) << shift), index_op);
   } else {
     __ convert(Bytecodes::_i2l, index.result(), index_op);
     // Need to shift manually, as LIR_Address can scale only up to 3.

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2354,11 +2354,10 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
   }
 
   Value element = nullptr;
-  if (x->vt() != nullptr) {
+  if (x->buffer() != nullptr) {
     assert(x->array()->is_loaded_flat_array(), "must be");
     // Find the destination address (of the NewInlineTypeInstance).
-    LIRItem obj_item(x->vt(), this);
-
+    LIRItem obj_item(x->buffer(), this);
     LIR_Opr payload = access_flat_array(true, array, index, obj_item,
                                         x->delayed() == nullptr ? nullptr : x->delayed()->field(),
                                         x->delayed() == nullptr ? 0 : x->delayed()->offset());

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -41,7 +41,6 @@
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c1/barrierSetC1.hpp"
 #include "oops/klass.inline.hpp"
-#include "oops/layoutKind.hpp"
 #include "oops/methodCounters.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -1776,7 +1775,7 @@ LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& i
   }
 
   bool null_free = array_klass->is_elem_null_free();
-  bool atomic = LayoutKindHelper::is_atomic_flat(array_klass->layout_kind());
+  bool atomic = array_klass->is_elem_atomic();
   assert(null_free || atomic, "nullable flat arrays must use an atomic layout");
   if (atomic) {
     assert(field == nullptr && sub_offset == 0, "delayed sub-element access is only supported for non-atomic arrays");

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1667,30 +1667,23 @@ void LIRGenerator::do_StoreField(StoreField* x) {
     LIR_Opr zero = (bt == T_LONG) ? LIR_OprFact::longConst(0) : LIR_OprFact::intConst(0);
     __ move(zero, payload);
 
-    if (field->is_null_free()) {
-      if (!x->value()->is_null_free()) {
-        __ null_check(value.result(), new CodeEmitInfo(state_for(x)));
+    bool is_constant_null = value.is_constant() && value.value()->is_null_obj();
+    if (!is_constant_null) {
+      LabelObj* L_isNull = new LabelObj();
+      bool needs_null_check = !value.is_constant();
+      if (needs_null_check) {
+        __ cmp(lir_cond_equal, value.result(), LIR_OprFact::oopConst(nullptr));
+        __ branch(lir_cond_equal, L_isNull->label());
       }
+      // Load payload (if not empty) and set null marker (if not null-free)
       if (!vk->is_empty()) {
         access_load_at(decorators, bt, value, LIR_OprFact::intConst(vk->payload_offset()), payload);
       }
-    } else {
-      bool is_constant_null = value.is_constant() && value.value()->is_null_obj();
-      if (!is_constant_null) {
-        LabelObj* L_isNull = new LabelObj();
-        bool needs_null_check = !value.is_constant();
-        if (needs_null_check) {
-          __ cmp(lir_cond_equal, value.result(), LIR_OprFact::oopConst(nullptr));
-          __ branch(lir_cond_equal, L_isNull->label());
-        }
-        // Load payload (if not empty) and set null marker.
-        if (!vk->is_empty()) {
-          access_load_at(decorators, bt, value, LIR_OprFact::intConst(vk->payload_offset()), payload);
-        }
+      if (!field->is_null_free()) {
         __ logical_or(payload, null_marker_mask(bt, field), payload);
-        if (needs_null_check) {
-          __ branch_destination(L_isNull->label());
-        }
+      }
+      if (needs_null_check) {
+        __ branch_destination(L_isNull->label());
       }
     }
     access_store_at(decorators, bt, object, LIR_OprFact::intConst(x->offset()), payload,

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -41,6 +41,7 @@
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c1/barrierSetC1.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/layoutKind.hpp"
 #include "oops/methodCounters.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -785,6 +786,8 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
   // of the required checks for a fast case can be elided.
   int flags = LIR_OpArrayCopy::all_flags;
 
+  // TODO 8251971 Compare ArrayKlass::properties() of source and destination
+  // array here instead, see also LIR_Assembler::arraycopy_inlinetype_check
   if (!src->is_loaded_flat_array() && !dst->is_loaded_flat_array()) {
     flags &= ~LIR_OpArrayCopy::always_slow_path;
   }
@@ -1542,12 +1545,16 @@ void LIRGenerator::do_CompareAndSwap(Intrinsic* x, ValueType* type) {
   set_result(x, result);
 }
 
-// Returns a int/long value with the null marker bit set
-static LIR_Opr null_marker_mask(BasicType bt, ciField* field) {
-  assert(field->null_marker_offset() != -1, "field does not have null marker");
-  int nm_offset = field->null_marker_offset() - field->offset_in_bytes();
+// Returns an int/long value with the null marker bit set.
+static LIR_Opr null_marker_mask(BasicType bt, int nm_offset) {
+  assert(nm_offset >= 0, "field does not have null marker");
   jlong null_marker = 1ULL << (nm_offset << LogBitsPerByte);
   return (bt == T_LONG) ? LIR_OprFact::longConst(null_marker) : LIR_OprFact::intConst(null_marker);
+}
+
+static LIR_Opr null_marker_mask(BasicType bt, ciField* field) {
+  assert(field->null_marker_offset() != -1, "field does not have null marker");
+  return null_marker_mask(bt, field->null_marker_offset() - field->offset_in_bytes());
 }
 
 // Comment copied form templateTable_i486.cpp
@@ -1661,23 +1668,30 @@ void LIRGenerator::do_StoreField(StoreField* x) {
     LIR_Opr zero = (bt == T_LONG) ? LIR_OprFact::longConst(0) : LIR_OprFact::intConst(0);
     __ move(zero, payload);
 
-    bool is_constant_null = value.is_constant() && value.value()->is_null_obj();
-    if (!is_constant_null) {
-      LabelObj* L_isNull = new LabelObj();
-      bool needs_null_check = !value.is_constant() || value.value()->is_null_obj();
-      if (needs_null_check) {
-        __ cmp(lir_cond_equal, value.result(), LIR_OprFact::oopConst(nullptr));
-        __ branch(lir_cond_equal, L_isNull->label());
+    if (field->is_null_free()) {
+      if (!x->value()->is_null_free()) {
+        __ null_check(value.result(), new CodeEmitInfo(state_for(x)));
       }
-      // Load payload (if not empty) and set null marker (if not null-free)
       if (!vk->is_empty()) {
         access_load_at(decorators, bt, value, LIR_OprFact::intConst(vk->payload_offset()), payload);
       }
-      if (!field->is_null_free()) {
+    } else {
+      bool is_constant_null = value.is_constant() && value.value()->is_null_obj();
+      if (!is_constant_null) {
+        LabelObj* L_isNull = new LabelObj();
+        bool needs_null_check = !value.is_constant() || value.value()->is_null_obj();
+        if (needs_null_check) {
+          __ cmp(lir_cond_equal, value.result(), LIR_OprFact::oopConst(nullptr));
+          __ branch(lir_cond_equal, L_isNull->label());
+        }
+        // Load payload (if not empty) and set null marker.
+        if (!vk->is_empty()) {
+          access_load_at(decorators, bt, value, LIR_OprFact::intConst(vk->payload_offset()), payload);
+        }
         __ logical_or(payload, null_marker_mask(bt, field), payload);
-      }
-      if (needs_null_check) {
-        __ branch_destination(L_isNull->label());
+        if (needs_null_check) {
+          __ branch_destination(L_isNull->label());
+        }
       }
     }
     access_store_at(decorators, bt, object, LIR_OprFact::intConst(x->offset()), payload,
@@ -1717,7 +1731,7 @@ LIR_Opr LIRGenerator::get_and_load_element_address(LIRItem& array, LIRItem& inde
   LIR_Opr index_op = new_register(T_LONG);
   if (index.result()->is_constant()) {
     jint const_index = index.result()->as_jint();
-    __ move(LIR_OprFact::longConst(const_index << shift), index_op);
+    __ move(LIR_OprFact::longConst((jlong)const_index << shift), index_op);
   } else {
     __ convert(Bytecodes::_i2l, index.result(), index_op);
     // Need to shift manually, as LIR_Address can scale only up to 3.
@@ -1746,19 +1760,68 @@ void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& r
                      nullptr, nullptr);
 }
 
-void LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item,
+LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item,
                                           ciField* field, size_t sub_offset) {
   assert(sub_offset == 0 || field != nullptr, "Sanity check");
 
   // Find the starting address of the source (inside the array)
   LIR_Opr elm_op = get_and_load_element_address(array, index);
 
+  ciFlatArrayKlass* array_klass = array.value()->declared_type()->as_flat_array_klass();
   ciInlineKlass* elem_klass = nullptr;
   if (field != nullptr) {
     elem_klass = field->type()->as_inline_klass();
   } else {
-    elem_klass = array.value()->declared_type()->as_flat_array_klass()->element_klass()->as_inline_klass();
+    elem_klass = array_klass->element_klass()->as_inline_klass();
   }
+
+  bool null_free = array_klass->is_elem_null_free();
+  bool atomic = LayoutKindHelper::is_atomic_flat(array_klass->layout_kind());
+  assert(null_free || atomic, "nullable flat arrays must use an atomic layout");
+  if (atomic) {
+    assert(field == nullptr && sub_offset == 0, "delayed sub-element access is only supported for non-atomic arrays");
+    BasicType bt = elem_klass->atomic_size_to_basic_type(null_free);
+    LIR_Opr payload = new_register((bt == T_LONG) ? bt : T_INT);
+    TempResolvedAddress* elm_resolved_addr = new TempResolvedAddress(as_ValueType(bt), elm_op);
+    LIRItem elm_item(elm_resolved_addr, this);
+    DecoratorSet decorators = IN_HEAP;
+    if (is_load) {
+      access_load_at(decorators, bt, elm_item, LIR_OprFact::intConst(0), payload,
+                     nullptr, nullptr);
+      access_store_at(decorators, bt, obj_item, LIR_OprFact::intConst(elem_klass->payload_offset()), payload,
+                      nullptr, nullptr, elem_klass);
+    } else {
+      LIR_Opr zero = (bt == T_LONG) ? LIR_OprFact::longConst(0) : LIR_OprFact::intConst(0);
+      __ move(zero, payload);
+
+      if (null_free) {
+        if (!elem_klass->is_empty()) {
+          access_load_at(decorators, bt, obj_item, LIR_OprFact::intConst(elem_klass->payload_offset()), payload);
+        }
+      } else {
+        bool is_constant_null = obj_item.is_constant() && obj_item.value()->is_null_obj();
+        if (!is_constant_null) {
+          LabelObj* L_isNull = new LabelObj();
+          bool needs_null_check = !obj_item.is_constant();
+          if (needs_null_check) {
+            __ cmp(lir_cond_equal, obj_item.result(), LIR_OprFact::oopConst(nullptr));
+            __ branch(lir_cond_equal, L_isNull->label());
+          }
+          if (!elem_klass->is_empty()) {
+            access_load_at(decorators, bt, obj_item, LIR_OprFact::intConst(elem_klass->payload_offset()), payload);
+          }
+          __ logical_or(payload, null_marker_mask(bt, elem_klass->null_marker_offset_in_payload()), payload);
+          if (needs_null_check) {
+            __ branch_destination(L_isNull->label());
+          }
+        }
+      }
+      access_store_at(decorators, bt, elm_item, LIR_OprFact::intConst(0), payload,
+                      nullptr, nullptr, elem_klass);
+    }
+    return payload;
+  }
+
   for (int i = 0; i < elem_klass->nof_nonstatic_fields(); i++) {
     ciField* inner_field = elem_klass->nonstatic_field_at(i);
     assert(!inner_field->is_flat(), "flat fields must have been expanded");
@@ -1800,6 +1863,7 @@ void LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& inde
                       nullptr, nullptr);
     }
   }
+  return LIR_OprFact::illegalOpr;
 }
 
 void LIRGenerator::check_flat_array(LIR_Opr array, LIR_Opr value, CodeStub* slow_path) {
@@ -1916,12 +1980,15 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
   }
 
   if (is_loaded_flat_array) {
-    // TODO 8350865 This is currently dead code and still assumes that flat arrays are null-free
-    if (!x->value()->is_null_free()) {
+    ciFlatArrayKlass* array_klass = x->array()->declared_type()->as_flat_array_klass();
+    ciInlineKlass* elem_klass = array_klass->element_klass()->as_inline_klass();
+    bool null_free = array_klass->is_elem_null_free();
+    if (null_free && !x->value()->is_null_free()) {
       __ null_check(value.result(), new CodeEmitInfo(range_check_info));
     }
-    // If array element is an empty inline type, no need to copy anything
-    if (!x->array()->declared_type()->as_flat_array_klass()->element_klass()->as_inline_klass()->is_empty()) {
+    // If array element is an empty null-free inline type, no need to copy anything.
+    // Nullable empty arrays still need their null marker updated.
+    if (!elem_klass->is_empty() || !null_free) {
       access_flat_array(false, array, index, value);
     }
   } else {
@@ -1931,9 +1998,11 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
       // Check if we indeed have a flat array
       index.load_item();
       slow_path = new StoreFlattenedArrayStub(array.result(), index.result(), value.result(), state_for(x, x->state_before()));
-      check_flat_array(array.result(), value.result(), slow_path);
+      check_flat_array(array.result(), LIR_OprFact::illegalOpr, slow_path);
       set_in_conditional_code(true);
-    } else if (needs_null_free_array_store_check(x)) {
+    }
+
+    if (needs_null_free_array_store_check(x)) {
       CodeEmitInfo* info = new CodeEmitInfo(range_check_info);
       check_null_free_array(array, value, info);
     }
@@ -2291,10 +2360,20 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
     // Find the destination address (of the NewInlineTypeInstance).
     LIRItem obj_item(x->vt(), this);
 
-    access_flat_array(true, array, index, obj_item,
-                      x->delayed() == nullptr ? nullptr : x->delayed()->field(),
-                      x->delayed() == nullptr ? 0 : x->delayed()->offset());
-    set_no_result(x);
+    LIR_Opr payload = access_flat_array(true, array, index, obj_item,
+                                        x->delayed() == nullptr ? nullptr : x->delayed()->field(),
+                                        x->delayed() == nullptr ? 0 : x->delayed()->offset());
+    ciFlatArrayKlass* array_klass = x->array()->declared_type()->as_flat_array_klass();
+    if (array_klass->is_elem_null_free()) {
+      set_no_result(x);
+    } else {
+      ciInlineKlass* elem_klass = array_klass->element_klass()->as_inline_klass();
+      BasicType bt = elem_klass->atomic_size_to_basic_type(false);
+      assert(payload->is_valid(), "nullable flat array load must return the atomic payload");
+      __ logical_and(payload, null_marker_mask(bt, elem_klass->null_marker_offset_in_payload()), payload);
+      __ cmp(lir_cond_equal, payload, (bt == T_LONG) ? LIR_OprFact::longConst(0) : LIR_OprFact::intConst(0));
+      __ cmove(lir_cond_equal, LIR_OprFact::oopConst(nullptr), obj_item.result(), rlock_result(x), T_OBJECT);
+    }
   } else if (x->delayed() != nullptr) {
     assert(x->array()->is_loaded_flat_array(), "must be");
     LIR_Opr result = rlock_result(x, x->delayed()->field()->type()->basic_type());
@@ -2847,14 +2926,17 @@ ciKlass* LIRGenerator::profile_type(ciMethodData* md, int md_base_offset, int md
   }
 
   if (exact_klass != nullptr && exact_klass->is_obj_array_klass()) {
-    if (exact_klass->can_be_inline_array_klass()) {
-      // Inline type arrays can have additional properties, we need to load the klass
-      // TODO 8350865 Can we do better here and track the properties?
+    ciArrayKlass* exact_array_klass = exact_klass->as_array_klass();
+    if (exact_array_klass->is_refined()) {
+      do_update = ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
+    } else if (exact_klass->can_be_inline_array_klass()) {
+      // Inline type arrays can have additional properties. Load the klass unless
+      // the C1 type already carries refined array properties.
       exact_klass = nullptr;
       do_update = true;
     } else {
       // For a direct pointer comparison, we need the refined array klass pointer
-      exact_klass = ciObjArrayKlass::make(exact_klass->as_array_klass()->element_klass());
+      exact_klass = ciObjArrayKlass::make(exact_array_klass->element_klass());
       do_update = ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
     }
   }

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1704,15 +1704,16 @@ void LIRGenerator::do_StoreField(StoreField* x) {
                   value.result(), info != nullptr ? new CodeEmitInfo(info) : nullptr, info);
 }
 
-// TODO 8350865 Can we find another way to pass an address to access_load_at()?
-class TempResolvedAddress: public Instruction {
+// Wrap an already computed address register as a C1 Instruction so it
+// can be passed as LIRItem into access_load_at() / access_store_at().
+class ComputedAddressValue: public Instruction {
  public:
-  TempResolvedAddress(ValueType* type, LIR_Opr addr) : Instruction(type) {
+  ComputedAddressValue(ValueType* type, LIR_Opr addr) : Instruction(type) {
     set_operand(addr);
   }
   virtual void input_values_do(ValueVisitor*) {}
   virtual void visit(InstructionVisitor* v)   {}
-  virtual const char* name() const  { return "TempResolvedAddress"; }
+  virtual const char* name() const { return "ComputedAddressValue"; }
 };
 
 LIR_Opr LIRGenerator::get_and_load_element_address(LIRItem& array, LIRItem& index) {
@@ -1750,13 +1751,13 @@ void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& r
   LIR_Opr elm_op = get_and_load_element_address(array, index);
 
   BasicType subelt_type = field->type()->basic_type();
-  TempResolvedAddress* elm_resolved_addr = new TempResolvedAddress(as_ValueType(subelt_type), elm_op);
+  ComputedAddressValue* elm_resolved_addr = new ComputedAddressValue(as_ValueType(subelt_type), elm_op);
   LIRItem elm_item(elm_resolved_addr, this);
 
   DecoratorSet decorators = IN_HEAP;
   access_load_at(decorators, subelt_type,
-                     elm_item, LIR_OprFact::longConst(sub_offset), result,
-                     nullptr, nullptr);
+                 elm_item, LIR_OprFact::longConst(sub_offset), result,
+                 nullptr, nullptr);
 }
 
 LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item,
@@ -1781,7 +1782,7 @@ LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& i
     assert(field == nullptr && sub_offset == 0, "delayed sub-element access is only supported for non-atomic arrays");
     BasicType bt = elem_klass->atomic_size_to_basic_type(null_free);
     LIR_Opr payload = new_register((bt == T_LONG) ? bt : T_INT);
-    TempResolvedAddress* elm_resolved_addr = new TempResolvedAddress(as_ValueType(bt), elm_op);
+    ComputedAddressValue* elm_resolved_addr = new ComputedAddressValue(as_ValueType(bt), elm_op);
     LIRItem elm_item(elm_resolved_addr, this);
     DecoratorSet decorators = IN_HEAP;
     if (is_load) {
@@ -1842,7 +1843,7 @@ LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& i
     }
 
     LIR_Opr temp = new_register(reg_type);
-    TempResolvedAddress* elm_resolved_addr = new TempResolvedAddress(as_ValueType(field_type), elm_op);
+    ComputedAddressValue* elm_resolved_addr = new ComputedAddressValue(as_ValueType(field_type), elm_op);
     LIRItem elm_item(elm_resolved_addr, this);
 
     DecoratorSet decorators = IN_HEAP;

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1867,9 +1867,9 @@ LIR_Opr LIRGenerator::access_flat_array(bool is_load, LIRItem& array, LIRItem& i
   return LIR_OprFact::illegalOpr;
 }
 
-void LIRGenerator::check_flat_array(LIR_Opr array, LIR_Opr value, CodeStub* slow_path) {
+void LIRGenerator::check_flat_array(LIR_Opr array, CodeStub* slow_path) {
   LIR_Opr tmp = new_register(T_METADATA);
-  __ check_flat_array(array, value, tmp, slow_path);
+  __ check_flat_array(array, tmp, slow_path);
 }
 
 void LIRGenerator::check_null_free_array(LIRItem& array, LIRItem& value, CodeEmitInfo* info) {
@@ -1999,7 +1999,7 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
       // Check if we indeed have a flat array
       index.load_item();
       slow_path = new StoreFlattenedArrayStub(array.result(), index.result(), value.result(), state_for(x, x->state_before()));
-      check_flat_array(array.result(), LIR_OprFact::illegalOpr, slow_path);
+      check_flat_array(array.result(), slow_path);
       set_in_conditional_code(true);
     }
 
@@ -2392,7 +2392,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
       index.load_item();
       // if we are loading from a flat array, load it using a runtime call
       slow_path = new LoadFlattenedArrayStub(array.result(), index.result(), result, state_for(x, x->state_before()));
-      check_flat_array(array.result(), LIR_OprFact::illegalOpr, slow_path);
+      check_flat_array(array.result(), slow_path);
       set_in_conditional_code(true);
     }
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -275,7 +275,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_vectorizedMismatch(Intrinsic* x);
   void do_blackhole(Intrinsic* x);
 
-  void access_flat_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = nullptr, size_t offset = 0);
+  LIR_Opr access_flat_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = nullptr, size_t offset = 0);
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, size_t sub_offset);
   LIR_Opr get_and_load_element_address(LIRItem& array, LIRItem& index);
   static bool needs_flat_array_store_check(StoreIndexed* x);

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -279,7 +279,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, size_t sub_offset);
   LIR_Opr get_and_load_element_address(LIRItem& array, LIRItem& index);
   static bool needs_flat_array_store_check(StoreIndexed* x);
-  void check_flat_array(LIR_Opr array, LIR_Opr value, CodeStub* slow_path);
+  void check_flat_array(LIR_Opr array, CodeStub* slow_path);
   static bool needs_null_free_array_store_check(StoreIndexed* x);
   void check_null_free_array(LIRItem& array, LIRItem& value,  CodeEmitInfo* info);
   void substitutability_check(IfOp* x, LIRItem& left, LIRItem& right, LIRItem& t_val, LIRItem& f_val);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -450,7 +450,6 @@ JRT_END
 
 JRT_ENTRY(void, Runtime1::new_null_free_array(JavaThread* current, Klass* array_klass, jint length))
   NOT_PRODUCT(_new_null_free_array_slowcase_cnt++;)
-  // TODO 8350865 This is dead code since 8325660 because null-free arrays can only be created via the factory methods that are not yet implemented in C1. Should probably be fixed by 8265122.
 
   // Note: no handle for klass needed since they are not used
   //       anymore after new_objArray() and no GC can happen before.
@@ -535,18 +534,15 @@ JRT_ENTRY(void, Runtime1::load_flat_array(JavaThread* current, flatArrayOopDesc*
   current->set_vm_result_oop(obj);
 JRT_END
 
-JRT_ENTRY(void, Runtime1::store_flat_array(JavaThread* current, arrayOopDesc* array, int index, oopDesc* value))
-  // TOOD 8350865 We can call here with a non-flat array because of LIR_Assembler::emit_opFlattenedArrayCheck
-  if (array->is_flatArray()) {
-    profile_flat_array(current, false, array->is_null_free_array());
-  }
+JRT_ENTRY(void, Runtime1::store_flat_array(JavaThread* current, flatArrayOopDesc* array, int index, oopDesc* value))
+  assert(array->is_flatArray(), "should not be called");
+  profile_flat_array(current, false, array->is_null_free_array());
 
   NOT_PRODUCT(_store_flat_array_slowcase_cnt++;)
   if (value == nullptr && array->is_null_free_array()) {
     SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_NullPointerException());
   } else {
-    // Here we know that we have a flat array
-    oop_cast<flatArrayOop>(array)->obj_at_put(index, value, CHECK);
+    array->obj_at_put(index, value, CHECK);
   }
 JRT_END
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -447,7 +447,7 @@ JRT_ENTRY(void, Runtime1::new_object_array(JavaThread* current, Klass* array_kla
   }
 JRT_END
 
-
+// TODO 8265122 This is currently dead code until the array factory methods are intrinsified
 JRT_ENTRY(void, Runtime1::new_null_free_array(JavaThread* current, Klass* array_klass, jint length))
   NOT_PRODUCT(_new_null_free_array_slowcase_cnt++;)
 

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -104,7 +104,7 @@ public:
   static void new_null_free_array(JavaThread* current, Klass* klass, jint length);
   static void new_multi_array (JavaThread* current, Klass* klass, int rank, jint* dims);
   static void load_flat_array(JavaThread* current, flatArrayOopDesc* array, int index);
-  static void store_flat_array(JavaThread* current, arrayOopDesc* array, int index, oopDesc* value);
+  static void store_flat_array(JavaThread* current, flatArrayOopDesc* array, int index, oopDesc* value);
   static int  substitutability_check(JavaThread* current, oopDesc* left, oopDesc* right);
   static void buffer_inline_args(JavaThread* current, Method* method);
   static void buffer_inline_args_no_receiver(JavaThread* current, Method* method);

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -312,7 +312,7 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
     if (is_reference_type(src_elem, true)) src_elem = T_OBJECT;
     if (is_reference_type(dest_elem, true)) dest_elem = T_OBJECT;
 
-    // TODO 8350865 What about atomicity?
+    // TODO 8251971 What about atomicity?
     if (src_elem != dest_elem || ary_src->is_null_free() != ary_dest->is_null_free() || ary_src->is_flat() != ary_dest->is_flat() || dest_elem == T_VOID) {
       // We don't know if arguments are arrays of the same type
       return false;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5075,7 +5075,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
         } else {
           generate_fair_guard(flat_array_test(refined_klass_node, /* flat = */ false), bailout);
         }
-        // TODO 8350865 This is not correct anymore. Write tests and fix logic similar to arraycopy.
+        // TODO 8251971 This is not correct anymore. Write tests and fix logic similar to arraycopy.
       } else if (UseArrayFlattening && (orig_t == nullptr || !orig_t->is_not_flat()) &&
                  // If dest is flat, src must be flat as well (guaranteed by src <: dest check if validated).
                  ((!tklass->is_flat() && tklass->can_be_inline_array()) || !can_validate)) {
@@ -6646,7 +6646,7 @@ bool LibraryCallKit::inline_arraycopy() {
       slow_region->add_req(not_subtype_ctrl);
     }
 
-    // TODO 8350865 Improve this. What about atomicity? Make sure this is always folded for type arrays.
+    // TODO 8251971 Improve this. What about atomicity? Make sure this is always folded for type arrays.
     // If destination is null-restricted, source must be null-restricted as well: src_null_restricted || !dst_null_restricted
     Node* src_klass = load_object_klass(src);
     Node* adr_prop_src = basic_plus_adr(top(), src_klass, in_bytes(ArrayKlass::properties_offset()));
@@ -6669,7 +6669,7 @@ bool LibraryCallKit::inline_arraycopy() {
     Node* tst = _gvn.transform(new BoolNode(chk, BoolTest::ne));
     generate_fair_guard(tst, slow_region);
 
-    // TODO 8350865 This is too strong
+    // TODO 8251971 This is too strong
     generate_fair_guard(flat_array_test(src), slow_region);
     generate_fair_guard(flat_array_test(dest), slow_region);
 

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1598,7 +1598,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     // (9) each element of an oop array must be assignable
     // The generate_arraycopy subroutine checks this.
 
-    // TODO 8350865 This is too strong
+    // TODO 8251971 This is too strong
     // We need to be careful here because 'adjust_for_flat_array' will adjust offsets/length etc. which then does not work anymore for the slow call to SharedRuntime::slow_arraycopy_C.
     assert(top_src->is_flat() == top_dest->is_flat(), "must have bailed out before");
     if (!flat_and_same_nullness) {


### PR DESCRIPTION
This patch addresses the C1 parts of [JDK-8350865](https://bugs.openjdk.org/browse/JDK-8350865): [lworld] Follow-up work from adding support for nullable, flat, atomic arrays / fields. Comments in-line with the changes.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383628](https://bugs.openjdk.org/browse/JDK-8383628): [lworld] C1 parts of JDK-8350865 (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2380/head:pull/2380` \
`$ git checkout pull/2380`

Update a local copy of the PR: \
`$ git checkout pull/2380` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2380`

View PR using the GUI difftool: \
`$ git pr show -t 2380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2380.diff">https://git.openjdk.org/valhalla/pull/2380.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2380#issuecomment-4368663314)
</details>
