### PR TITLE
8383626: [lworld] Remove Objects.isValueObject method

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -199,7 +199,7 @@ public final class Objects {
     * @param obj an object or {@code null}
     * @since Valhalla
     */
-   @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
+   @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
 //    @IntrinsicCandidate
     public static boolean hasIdentity(Object obj) {
         return (obj == null) ? false : !obj.getClass().isValue();
@@ -215,7 +215,7 @@ public final class Objects {
      * @throws IdentityException if {@code obj} is not an identity object
      * @since Valhalla
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     @ForceInline
     public static <T> T requireIdentity(T obj) {
         Objects.requireNonNull(obj);

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -200,19 +200,6 @@ public final class Objects {
         return (obj == null) ? false : obj.getClass().isIdentity();
     }
 
-   /**
-    * {@return {@code true} if the object is a non-null reference
-    * to a {@linkplain Class#isValue() value object}, otherwise {@code false}}
-    *
-    * @param obj an object or {@code null}
-    * @since Valhalla
-    */
-   @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
-//    @IntrinsicCandidate
-    public static boolean isValueObject(Object obj) {
-        return (obj == null) ? false : obj.getClass().isValue();
-    }
-
     /**
      * Checks that the specified object reference is an identity object.
      *

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -179,13 +179,18 @@ public final class Objects {
     }
 
    /**
-    * {@return {@code true} if the object is a non-null reference
-    * to an {@linkplain Class#isIdentity() identity object}, otherwise {@code false}}
+    * {@return {@code true} if the input is a non-null reference
+    * to an object with identity, and {@code false} otherwise}
+    *
+    * <p>If the object is an instance of a concrete {@linkplain Class#isValue()
+    * value class}, it does not have identity and the result will be
+    * {@code false}. All other objects, including arrays, are identity objects
+    * and the result will be {@code true}.
     *
     * @apiNote
     * If the parameter is {@code null}, there is no object
-    * and hence no class to check for identity; the return is {@code false}.
-    * To test for a {@linkplain Class#isValue() value object} use:
+    * and hence no identity; the result is {@code false}.
+    * To test for a value object use:
     * {@snippet type="java" :
     *     if (obj != null && !Objects.hasIdentity(obj)) {
     *         // obj is a non-null value object
@@ -197,7 +202,7 @@ public final class Objects {
    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 //    @IntrinsicCandidate
     public static boolean hasIdentity(Object obj) {
-        return (obj == null) ? false : obj.getClass().isIdentity();
+        return (obj == null) ? false : !obj.getClass().isValue();
     }
 
     /**
@@ -210,7 +215,7 @@ public final class Objects {
      * @throws IdentityException if {@code obj} is not an identity object
      * @since Valhalla
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     @ForceInline
     public static <T> T requireIdentity(T obj) {
         Objects.requireNonNull(obj);

--- a/src/java.base/share/classes/java/util/WeakHashMap.java
+++ b/src/java.base/share/classes/java/util/WeakHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,8 +125,9 @@ import java.util.function.Consumer;
  * @apiNote
  * <div class="preview-block">
  *      <div class="preview-comment">
- *          Objects that are {@linkplain Class#isValue() value objects} do not have identity
- *          and can not be used as keys in a {@code WeakHashMap}. {@linkplain java.lang.ref.Reference References}
+ *          Objects that are {@linkplain java.util.Objects#hasIdentity value objects}
+ *          do not have identity and can not be used as keys in a
+ *          {@code WeakHashMap}. {@linkplain java.lang.ref.Reference References}
  *          such as {@linkplain WeakReference WeakReference} used by {@code WeakhashMap}
  *          to hold the key cannot refer to a value object.
  *          Methods such as {@linkplain #get get} or {@linkplain #containsKey containsKey}
@@ -475,7 +476,7 @@ public class WeakHashMap<@jdk.internal.RequiresIdentity K,V>
      *         (A {@code null} return can also indicate that the map
      *         previously associated {@code null} with {@code key}.)
      * @throws IdentityException if {@code key} is a {@link
-     *         java.util.Objects#isValueObject(Object) value object}
+     *         java.util.Objects#hasIdentity(Object) value object}
      */
     public V put(@jdk.internal.RequiresIdentity K key, V value) {
         Object k = maskNull(key);
@@ -567,9 +568,11 @@ public class WeakHashMap<@jdk.internal.RequiresIdentity K,V>
      * These mappings will replace any mappings that this map had for any
      * of the keys currently in the specified map.
      *
-     * @apiNote If the specified map contains keys that are {@linkplain Objects#isValueObject value objects}
-     * an {@linkplain IdentityException} is thrown when the first value object key is encountered.
-     * Zero or more mappings may have already been copied to this map.
+     * @apiNote If the specified map contains keys that are
+     * {@linkplain java.util.Objects#hasIdentity value objects},
+     * an {@linkplain IdentityException} is thrown when the first value object
+     * key is encountered. Zero or more mappings may have already been copied to
+     * this map.
      *
      * @param m mappings to be stored in this map.
      * @throws  NullPointerException if the specified map is null.

--- a/test/jdk/valhalla/valuetypes/ValueObjectMethodsTest.java
+++ b/test/jdk/valhalla/valuetypes/ValueObjectMethodsTest.java
@@ -176,7 +176,6 @@ public class ValueObjectMethodsTest {
     @Test
     public void identityTestNull() {
         assertFalse(Objects.hasIdentity(null), "Objects.hasIdentity(null)");
-        assertFalse(Objects.isValueObject(null), "Objects.isValueObject(null)");
     }
 
     static Stream<Arguments> equalsTests() {


### PR DESCRIPTION
Eliminate the extra method, and update documentation to reflect the change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383626](https://bugs.openjdk.org/browse/JDK-8383626): [lworld] Remove Objects.isValueObject method (**Bug** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2381/head:pull/2381` \
`$ git checkout pull/2381`

Update a local copy of the PR: \
`$ git checkout pull/2381` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2381`

View PR using the GUI difftool: \
`$ git pr show -t 2381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2381.diff">https://git.openjdk.org/valhalla/pull/2381.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2381#issuecomment-4362091643)
</details>
