### PR TITLE
8380059: [lworld] zero: java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java failed with SIGSEGV in InterpreterRuntime::write_flat_field

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010, 2011 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -582,6 +582,12 @@ int ZeroInterpreter::getter_entry(Method* method, intptr_t UNUSED, TRAPS) {
     return normal_entry(method, 0, THREAD);
   }
 
+  // Flattened entries require handling beyond a direct field load.
+  // Bail to slow path.
+  if (entry->is_flat()) {
+    return normal_entry(method, 0, THREAD);
+  }
+
   ZeroStack* stack = thread->zero_stack();
   intptr_t* topOfStack = stack->sp();
 
@@ -670,6 +676,12 @@ int ZeroInterpreter::setter_entry(Method* method, intptr_t UNUSED, TRAPS) {
   ConstantPoolCache* cache = method->constants()->cache();
   ResolvedFieldEntry* entry = cache->resolved_field_entry_at(index);
   if (!entry->is_resolved(Bytecodes::_putfield)) {
+    return normal_entry(method, 0, THREAD);
+  }
+
+  // Flattened entries require handling beyond a direct field store.
+  // Bail to slow path.
+  if (entry->is_flat()) {
     return normal_entry(method, 0, THREAD);
   }
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatFieldAccessorMethods.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatFieldAccessorMethods.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test FlatFieldAccessorMethods
+ * @bug 8380059
+ * @summary Test trivial getter and setter methods for flattened fields
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @enablePreview
+ * @compile FlatFieldAccessorMethods.java
+ * @run main runtime.valhalla.inlinetypes.FlatFieldAccessorMethods
+ */
+
+package runtime.valhalla.inlinetypes;
+
+import java.lang.reflect.Field;
+
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.Asserts;
+
+public class FlatFieldAccessorMethods {
+    static final Unsafe U = Unsafe.getUnsafe();
+
+    static class Holder {
+        Boolean value;
+
+        Holder(Boolean value) {
+            this.value = value;
+        }
+
+        Boolean getValue() {
+            return value;
+        }
+
+        void setValue(Boolean value) {
+            this.value = value;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        assertFlatField();
+        testGetterMaterializesFlatField();
+        testSetterStoresFlatFieldPayload();
+        testGetterResultCanBeStoredThroughSetter();
+    }
+
+    static void assertFlatField() throws ReflectiveOperationException {
+        Field value = Holder.class.getDeclaredField("value");
+        Asserts.assertTrue(U.isFlatField(value), "Holder.value should be flat");
+        Asserts.assertTrue(U.hasNullMarker(value), "Holder.value should be nullable flat");
+    }
+
+    static void testGetterMaterializesFlatField() {
+        Holder holder = new Holder(Boolean.TRUE);
+
+        holder.getValue(); // Resolve the field entry.
+        assertBoolean(holder.getValue(), true, "getter result");
+    }
+
+    static void testSetterStoresFlatFieldPayload() {
+        Holder holder = new Holder(Boolean.FALSE);
+
+        holder.setValue(Boolean.TRUE); // Resolve the field entry.
+        holder.setValue(Boolean.FALSE);
+
+        assertBoolean(holder.value, false, "direct field read after setter");
+        assertBoolean(holder.getValue(), false, "getter result after setter");
+    }
+
+    static void testGetterResultCanBeStoredThroughSetter() {
+        Holder source = new Holder(Boolean.TRUE);
+        Holder target = new Holder(Boolean.FALSE);
+
+        source.getValue(); // Resolve the getter field entry.
+        target.setValue(Boolean.FALSE); // Resolve the setter field entry.
+        target.setValue(source.getValue());
+
+        assertBoolean(target.value, true, "direct field read after getter-to-setter");
+        assertBoolean(target.getValue(), true, "getter result after getter-to-setter");
+    }
+
+    static void assertBoolean(Boolean value, boolean expected, String message) {
+        Asserts.assertNotNull(value, message);
+        Asserts.assertEquals(value.booleanValue(), expected, message);
+    }
+}

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
@@ -28,8 +28,6 @@
  * @library /test/lib
  * @requires jdk.foreign.linker != "UNSUPPORTED"
  * @requires !vm.musl
- * @comment Disable test for the zero VM config due to 8380059.
- * @requires vm.flavor != "zero"
  *
  * @enablePreview
  * @build TestEnableNativeAccessJarManifest


### PR DESCRIPTION
Hi,

The `zero` interpreter has fast paths for basic getters and setters, but these fail to take into account how flattened fields work. This causes flattened fields to be copied onto the stack directly, instead of wrapped in an oop (for getters), and flattened fields to be transformed into oops (for setters). Instead of adapting the fast paths, we bail to the slow path.

To convince you, this is `getter_entry`:

```c++
    switch (entry->tos_state()) {
      // SNIP!
      case atos: SET_STACK_OBJECT(object->obj_field(offset),    0); break;
```

and this is the basic bytecode dispatch (slow path):

```c++
switch (tos_type) {
  // SNIP!
case atos:
                oop val;
                if (entry->is_flat()) {
                  CALL_VM(InterpreterRuntime::read_flat_field(THREAD, obj, entry), handle_exception);
                  val = THREAD->vm_result_oop();
                  THREAD->set_vm_result_oop(nullptr);
                } else {
                  val = obj->obj_field(field_offset);
                }

```

I added a test in order to coax the getter/setter pattern optimization to run consistently and re-ran the previously disabled test along with the new one on linux-x64-zero, and they both pass. Running the new test with lworld -Xint linux-x64-zero crashes similarly to the reported bug.

## Everything below this header is bonus info for the curious

We fail within `init` of `TestSuite` which has a flattened field:

```
 - private value 'skipFailedInvocationCounts' 'Ljava/lang/Boolean;' @12  Flat inline type field 'java/lang/Boolean':
   - private final value 'value' 'Z' @12  false (0x00)
   - [null_marker] @13 Field marked as non-null
 ```

and in `SuiteRunner.java:183` we can see this:

```java
    skipFailedInvocationCounts = suite.skipFailedInvocationCounts(); // (suite has type XmlSuite)
```

and `XmlSuite` has the following getter

```java
  public Boolean skipFailedInvocationCounts() {
    return m_skipFailedInvocationCounts;
  }
```

This is probably triggering the buggy zero code.

Just some more discovery stuff:

Let's look at `si_addr` which is `0x0000000001000108`. Alright, we're running with compressed klass pointers but without `UseCompactObjectHeaders`, so when doing the `write_flat_field` we finally reach `return CompressedKlassPointers::decode_not_null(_compressed_klass);` and `_compressed_klass` has offset 8. So, the actual "oop" is at `0x1000100`. OK, I dunno, that could be a flattened Boolean I guess?

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8380059](https://bugs.openjdk.org/browse/JDK-8380059): [lworld] zero: java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java failed with SIGSEGV in InterpreterRuntime::write_flat_field (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2382/head:pull/2382` \
`$ git checkout pull/2382`

Update a local copy of the PR: \
`$ git checkout pull/2382` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2382`

View PR using the GUI difftool: \
`$ git pr show -t 2382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2382.diff">https://git.openjdk.org/valhalla/pull/2382.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2382#issuecomment-4386456607)
</details>
