### PR TITLE
8383814: [lworld] many compiler/valhalla/inlinetypes/TestAcmpFastPath.java sub-tests fail with C1

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1160,7 +1160,7 @@ bool WhiteBox::compile_method(Method* method, int comp_level, int bci, JavaThrea
   } else if (mh->lookup_osr_nmethod_for(bci, comp_level, false) != nullptr) {
     return true;
   }
-  tty->print("WB error: failed to %s compile at level %d method ", is_blocking ? "blocking" : "", comp_level);
+  tty->print("WB error: failed to %s compile at level %d method", is_blocking ? " blocking" : "", comp_level);
   mh->print_short_name(tty);
   tty->cr();
   if (is_blocking && is_queued) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpFastPath.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpFastPath.java
@@ -193,9 +193,6 @@ public class TestAcmpFastPath {
         scenario.addFlags();
         InlineTypes.getFramework()
                 .addScenarios(scenario)
-                .addHelperClasses(MyValueClass1.class,
-                        MyValueClass2.class,
-                        MyValueClass2Inline.class)
                 .start();
     }
 


### PR DESCRIPTION
It's actually https://bugs.openjdk.org/browse/JDK-8376254, but I take this opportunity to remove the actually useless problematic class. I've also fixed a spacing detail.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383814](https://bugs.openjdk.org/browse/JDK-8383814): [lworld] many compiler/valhalla/inlinetypes/TestAcmpFastPath.java sub-tests fail with C1 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2387/head:pull/2387` \
`$ git checkout pull/2387`

Update a local copy of the PR: \
`$ git checkout pull/2387` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2387`

View PR using the GUI difftool: \
`$ git pr show -t 2387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2387.diff">https://git.openjdk.org/valhalla/pull/2387.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2387#issuecomment-4378820477)
</details>
