### PR TITLE
[type-classes] Fix regression in type-class mediated shift operation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Operators.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Operators.java
@@ -590,8 +590,8 @@ public class Operators {
 
         @Override
         public boolean test(Env<AttrContext> env, Type arg1, Type arg2) {
-            if (types.unboxedTypeOrType(arg1).isPrimitive() || arg1.isErroneous() ||
-                    types.unboxedTypeOrType(arg2).isPrimitive() || arg2.isErroneous()) {
+            if (types.unboxedTypeOrType(arg1).isPrimitive() ||
+                    arg1.isErroneous() || arg2.isErroneous()) {
                 return false;
             }
             Type witnessType = witnessType(typeClassFunc.apply(syms), arg1);

--- a/test/langtools/tools/javac/typeClasses/TypeClassesOperatorResolutionTest.java
+++ b/test/langtools/tools/javac/typeClasses/TypeClassesOperatorResolutionTest.java
@@ -297,7 +297,6 @@ public class TypeClassesOperatorResolutionTest {
         assertEquals(eR, numBox(-1));
     }
 
-    @Test
     static NumBox testStackmapUnary(NumBox e1, boolean cond) {
         NumBox eR = null;
         if (cond) {


### PR DESCRIPTION
The fix for https://github.com/openjdk/valhalla/pull/1981 introduced a regression in type-class mediated attribution of shift operators.
The test for such operators should only check for reference-ness of the first operand (the one that might potentially be a type class).
Shift operators are "weird" in that they are not symmetric -- first operand is T, second operand is `int` -- and that leads to issue.
The code before https://github.com/openjdk/valhalla/pull/1981 took this into account, but unfortunately the workaround was reverted by accident.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2388/head:pull/2388` \
`$ git checkout pull/2388`

Update a local copy of the PR: \
`$ git checkout pull/2388` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2388`

View PR using the GUI difftool: \
`$ git pr show -t 2388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2388.diff">https://git.openjdk.org/valhalla/pull/2388.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2388#issuecomment-4380788579)
</details>
