### PR TITLE
8383771: [lworld] jdk/javadoc/doccheck/checks/jdkCheckLinks.java fails after JDK-8383141

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -171,7 +171,7 @@ public enum Modifier {
     /**
      * The modifier {@code value}
      *
-     * @jls value-objects-9.1.1.5 {@code value} Classes
+     * @jls value-objects-8.1.1.5 {@code value} Classes
      * @since Valhalla
      */
     @PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)


### PR DESCRIPTION
A trivial typo fix to allow jdk/javadoc/doccheck/checks/jdkCheckLinks.java to pass.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383771](https://bugs.openjdk.org/browse/JDK-8383771): [lworld] jdk/javadoc/doccheck/checks/jdkCheckLinks.java fails after JDK-8383141 (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2392/head:pull/2392` \
`$ git checkout pull/2392`

Update a local copy of the PR: \
`$ git checkout pull/2392` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2392`

View PR using the GUI difftool: \
`$ git pr show -t 2392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2392.diff">https://git.openjdk.org/valhalla/pull/2392.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2392#issuecomment-4383683859)
</details>
