### PR TITLE
8383986: [lworld] ArchiveFlatArrayTest.java is not correctly testing all cases

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedArrayLayoutsApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedArrayLayoutsApp.java
@@ -117,7 +117,7 @@ public class ArchivedArrayLayoutsApp {
             Point[] runtimeArray = new Point[3];
             runtimeArray[0] = new Point(0, 1);
             runtimeArray[1] = new Point(1, 0);
-            runtimeArray[2] = new Point(1, 2);
+            runtimeArray[2] = new Point(1, 1);
 
             checkArray(archivedObjects.pointArray, runtimeArray);
             checkArray(archivedObjects.nullRestrictedArray, runtimeArray);

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedFlatArrayApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedFlatArrayApp.java
@@ -89,7 +89,7 @@ public class ArchivedFlatArrayApp {
             throw new RuntimeException("Integer array should be flat");
         }
 
-        if (!ValueClass.isFlatArray(archivedObjects.intArray)) {
+        if (!ValueClass.isFlatArray(archivedObjects.charPairArray)) {
             throw new RuntimeException("CharPair array should be flat");
         }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java
@@ -70,6 +70,6 @@ public class ArchivedFlatArrayTest {
 
     public static void main(String[] args) throws Exception {
         test(mainClass, TestCommon.list(mainClass, "ArchivedFlatArrayApp$ArchivedData", "ArchivedFlatArrayApp$CharPair"));
-        test(mainClass, TestCommon.list(mainClass2, "ArchivedArrayLayoutsApp$ArchivedData", "ArchivedArrayLayoutsApp$Point"));
+        test(mainClass2, TestCommon.list(mainClass2, "ArchivedArrayLayoutsApp$ArchivedData", "ArchivedArrayLayoutsApp$Point"));
     }
 }


### PR DESCRIPTION
This patch corrects mistakes left in ArchiveFlatArrayTest.java which prevented all the intended cases from being tested. Verified with tier 1-5 tests.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383986](https://bugs.openjdk.org/browse/JDK-8383986): [lworld] ArchiveFlatArrayTest.java is not correctly testing all cases (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2395/head:pull/2395` \
`$ git checkout pull/2395`

Update a local copy of the PR: \
`$ git checkout pull/2395` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2395`

View PR using the GUI difftool: \
`$ git pr show -t 2395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2395.diff">https://git.openjdk.org/valhalla/pull/2395.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2395#issuecomment-4391089138)
</details>
