### PR TITLE
8384053: [lworld] Missing comma in SetupJavaCompliation for Preview Classes

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -159,7 +159,7 @@ ifneq ($(COMPILER), bootjdk)
         HEADERS := $(SUPPORT_OUTPUTDIR)/headers, \
         DISABLED_WARNINGS := $(DISABLED_WARNINGS_java) preview, \
         EXCLUDES := $(EXCLUDES), \
-        EXCLUDE_FILES := $(EXCLUDE_FILES) \
+        EXCLUDE_FILES := $(EXCLUDE_FILES), \
         KEEP_ALL_TRANSLATIONS := $(KEEP_ALL_TRANSLATIONS), \
         DEPENDS := $($(MODULE)), \
         JAVAC_FLAGS := \


### PR DESCRIPTION
When doing `# Setup compilation for preview classes in the module` a comma is missing after `EXCLUDE_FILES`. So instead of setting `<module>-preview_KEEP_ALL_TRANSLATIONS := value` it is added as to the `<module>-preview_EXCLUDE_FILES` variable.

```
<module>-preview_EXCLUDE_FILES := $(EXCLUDE_FILES) KEEP_ALL_TRANSLATIONS := $(KEEP_ALL_TRANSLATIONS)
```

Instead of 
```
<module>-preview_EXCLUDE_FILES := $(EXCLUDE_FILES) 
<module>-preview_KEEP_ALL_TRANSLATIONS := $(KEEP_ALL_TRANSLATIONS)
```

The only usage of this variable set to true is in `jdk.localedata`, which is probably why it went unnoticed. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384053](https://bugs.openjdk.org/browse/JDK-8384053): [lworld] Missing comma in SetupJavaCompliation for Preview Classes (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2398/head:pull/2398` \
`$ git checkout pull/2398`

Update a local copy of the PR: \
`$ git checkout pull/2398` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2398`

View PR using the GUI difftool: \
`$ git pr show -t 2398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2398.diff">https://git.openjdk.org/valhalla/pull/2398.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2398#issuecomment-4394373771)
</details>
