### PR TITLE
8384054: [lworld] Cleanup typos and spellings in hotspot

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -469,7 +469,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   assert(result->is_illegal() || !result->is_single_cpu() || result->as_register() == r0, "word returns are in r0,");
 
   if (InlineTypeReturnedAsFields) {
-    // Check if we are returning an non-null inline type and load its fields into registers
+    // Check if we are returning a non-null inline type and load its fields into registers
     ciType* return_type = compilation()->method()->return_type();
     if (return_type->is_inlinetype()) {
       ciInlineKlass* vk = return_type->as_inline_klass();
@@ -493,7 +493,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
       __ b(skip);
       __ bind(not_null);
 
-      // Check if we are returning an non-null inline type and load its fields into registers
+      // Check if we are returning a non-null inline type and load its fields into registers
       __ test_oop_is_not_inline_type(r0, rscratch2, skip, /* can_be_null= */ false);
 
       // Load fields from a buffered value with an inline class specific handler
@@ -1604,7 +1604,7 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   ciKlass* left_klass = op->left_klass();
   ciKlass* right_klass = op->right_klass();
 
-  // (2) Inline type check -- if either of the operands is not a inline type,
+  // (2) Inline type check -- if either of the operands is not an inline type,
   //     they are not substitutable. We do this only if we are not sure that the
   //     operands are inline type
   if ((left_klass == nullptr || right_klass == nullptr) ||// The klass is still unloaded, or came from a Phi node.

--- a/src/hotspot/cpu/aarch64/gc/g1/g1_aarch64.ad
+++ b/src/hotspot/cpu/aarch64/gc/g1/g1_aarch64.ad
@@ -74,7 +74,7 @@ static void write_barrier_post(MacroAssembler* masm,
 %}
 
 // TODO 8350865 (same applies to g1StoreLSpecialTwoOops)
-// - Do no set/overwrite barrier data here, also handle G1C2BarrierPostNotNull
+// - Do not set/overwrite barrier data here, also handle G1C2BarrierPostNotNull
 // - Move this into the .m4?
 instruct g1StoreLSpecialOneOopOff0(indirect mem, iRegLNoSp src, immI0 off, iRegPNoSp tmp1, iRegPNoSp tmp2, iRegPNoSp tmp3, rFlagsReg cr)
 %{

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -711,7 +711,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     b(skip);
     bind(not_null);
 
-    // Check if we are returning an non-null inline type and load its fields into registers
+    // Check if we are returning a non-null inline type and load its fields into registers
     test_oop_is_not_inline_type(r0, rscratch2, skip, /* can_be_null= */ false);
 
     // Load fields from a buffered value with an inline class specific handler

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -476,7 +476,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   #ifndef _LP64
      Unimplemented();
   #endif
-    // Check if we are returning an non-null inline type and load its fields into registers
+    // Check if we are returning a non-null inline type and load its fields into registers
     ciType* return_type = compilation()->method()->return_type();
     if (return_type->is_inlinetype()) {
       ciInlineKlass* vk = return_type->as_inline_klass();
@@ -499,7 +499,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
       __ jmp(skip);
       __ bind(not_null);
 
-      // Check if we are returning an non-null inline type and load its fields into registers
+      // Check if we are returning a non-null inline type and load its fields into registers
       __ test_oop_is_not_inline_type(rax, rscratch1, skip, /* can_be_null= */ false);
 
       // Load fields from a buffered value with an inline class specific handler
@@ -1602,7 +1602,7 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   ciKlass* left_klass = op->left_klass();
   ciKlass* right_klass = op->right_klass();
 
-  // (2) Inline type check -- if either of the operands is not a inline type,
+  // (2) Inline type check -- if either of the operands is not an inline type,
   //     they are not substitutable. We do this only if we are not sure that the
   //     operands are inline type
   if ((left_klass == nullptr || right_klass == nullptr) ||// The klass is still unloaded, or came from a Phi node.

--- a/src/hotspot/cpu/x86/gc/g1/g1_x86_64.ad
+++ b/src/hotspot/cpu/x86/gc/g1/g1_x86_64.ad
@@ -100,7 +100,7 @@ instruct g1StoreP(memory mem, any_RegP src, rRegP tmp1, rRegP tmp2, rRegP tmp3, 
 %}
 
 // TODO 8350865 (same applies to g1StoreLSpecialTwoOops)
-// - Do no set/overwrite barrier data here, also handle G1C2BarrierPostNotNull
+// - Do not set/overwrite barrier data here, also handle G1C2BarrierPostNotNull
 instruct g1StoreLSpecialOneOopOff0(memory mem, rRegL src, immI_0 off, rRegP tmp1, rRegP tmp2, rRegP tmp3, rFlagsReg cr)
 %{
   predicate(UseG1GC);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1071,7 +1071,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     jmp(skip);
     bind(not_null);
 
-    // Check if we are returning an non-null inline type and load its fields into registers
+    // Check if we are returning a non-null inline type and load its fields into registers
     test_oop_is_not_inline_type(rax, rscratch1, skip, /* can_be_null= */ false);
 
 #ifndef _LP64

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -296,7 +296,7 @@ class GraphBuilder {
   void throw_op(int bci);
 
   // inline types
-  void copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before, ciField* encloding_field = nullptr);
+  void copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before, ciField* enclosing_field = nullptr);
 
   // stack/code manipulation helpers
   Instruction* append_with_bci(Instruction* instr, int bci);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -238,7 +238,7 @@ JRT_BLOCK_ENTRY(void, InterpreterRuntime::read_flat_field(JavaThread* current, o
 
   FlatFieldPayload payload(instanceOop(obj), entry);
   if (payload.is_payload_null()) {
-    // If the payload is null return before entring the JRT_BLOCK.
+    // If the payload is null return before entering the JRT_BLOCK.
     current->set_vm_result_oop(nullptr);
     return;
   }

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -184,7 +184,7 @@ size_t FlatArrayKlass::oop_size(oop obj) const {
   // because size_given_klass() calls oop_size() on objects that might be
   // concurrently forwarded, which would overwrite the Klass*.
   // Also, why we need to pass this layout_helper() to flatArrayOop::object_size.
-  assert(UseCompactObjectHeaders || obj->is_flatArray(),"must be an flat array");
+  assert(UseCompactObjectHeaders || obj->is_flatArray(),"must be a flat array");
   flatArrayOop array = flatArrayOop(obj);
   return array->object_size(layout_helper());
 }
@@ -327,7 +327,7 @@ void FlatArrayKlass::copy_array(arrayOop s, int src_pos,
       }
     } else {
       // flatArray-to-refArray
-      assert(dk->is_refArray_klass(), "Expected objArray here");
+      assert(dk->is_refArray_klass(), "Expected refArray here");
 
       // Need to allocate each new src elem payload -> dst oop
       refArrayHandle dh(THREAD, (refArrayOop)d);
@@ -355,7 +355,7 @@ bool FlatArrayKlass::can_be_primary_super_slow() const {
 }
 
 u2 FlatArrayKlass::compute_modifier_flags() const {
-  // The modifier for an flatArray is the same as its element
+  // The modifier for a flatArray is the same as its element
   // With the addition of ACC_IDENTITY
   u2 element_flags = element_klass()->compute_modifier_flags();
 

--- a/src/hotspot/share/oops/refArrayKlass.cpp
+++ b/src/hotspot/share/oops/refArrayKlass.cpp
@@ -225,7 +225,7 @@ void RefArrayKlass::copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos,
     THROW_MSG(vmSymbols::java_lang_ArrayStoreException(), ss.as_string());
   }
 
-  // Check is all offsets and lengths are non negative
+  // Check if all offsets and lengths are non negative
   if (src_pos < 0 || dst_pos < 0 || length < 0) {
     // Pass specific exception reason.
     ResourceMark rm(THREAD);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3526,7 +3526,7 @@ JVM_ENTRY(jobject, JVM_InvokeMethod(JNIEnv *env, jobject method, jobject obj, jo
     method_handle = Handle(THREAD, JNIHandles::resolve(method));
     Handle receiver(THREAD, JNIHandles::resolve(obj));
     objArrayHandle args(THREAD, (objArrayOop)JNIHandles::resolve(args0));
-    assert(args() == nullptr || !args->is_flatArray(), "args are never flat or are they???");
+    assert(args() == nullptr || !args->is_flatArray(), "args are never flat");
 
     oop result = Reflection::invoke_method(method_handle(), receiver, args, CHECK_NULL);
     jobject res = JNIHandles::make_local(THREAD, result);
@@ -3548,7 +3548,7 @@ JVM_END
 
 JVM_ENTRY(jobject, JVM_NewInstanceFromConstructor(JNIEnv *env, jobject c, jobjectArray args0))
   objArrayHandle args(THREAD, (objArrayOop)JNIHandles::resolve(args0));
-  assert(args() == nullptr || !args->is_flatArray(), "args are never flat or are they???");
+  assert(args() == nullptr || !args->is_flatArray(), "args are never flat");
   oop constructor_mirror = JNIHandles::resolve(c);
   oop result = Reflection::invoke_constructor(constructor_mirror, args, CHECK_NULL);
   jobject res = JNIHandles::make_local(THREAD, result);

--- a/src/hotspot/share/prims/jvmtiTagMap.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.hpp
@@ -61,7 +61,7 @@ class JvmtiTagMap :  public CHeapObj<mtServiceability> {
   void convert_flat_object_entries();
 
  public:
-  // for inernal use
+  // for internal use
   jlong find(const JvmtiHeapwalkObject& obj) const;
   void add(const JvmtiHeapwalkObject& obj, jlong tag);
   void remove(const JvmtiHeapwalkObject& obj);

--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -85,7 +85,7 @@ public:
 // Value objects: keep just one tag for all equal value objects including heap allocated value objects.
 // We have to keep a strong reference to each unique value object with a non-zero tag.
 // During heap walking flattened value object tags stored in separate JvmtiFlatTagMapTable,
-// converted to standard strong entries in JvmtiTagMapTable outside of sefepoint.
+// converted to standard strong entries in JvmtiTagMapTable outside of safepoint.
 // All equal value objects should have the same tag.
 // Keep value objects alive (1 copy for each "value") until their tags are removed.
 

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -336,7 +336,7 @@ public:
 
 class PrintClassLayoutDCmd : public DCmdWithParser {
 protected:
-  DCmdArgument<char*> _classname; // lass name whose layout should be printed.
+  DCmdArgument<char*> _classname; // Class name whose layout should be printed.
 public:
   PrintClassLayoutDCmd(outputStream* output, bool heap);
   static const char* name() {

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -963,7 +963,7 @@ public:
   }
 };
 
-// Describes flat object (flatted field or element of flat array) in the holder oop
+// Describes flat object (flat field or element of flat array) in the holder oop
 class DumperFlatObject: public CHeapObj<mtServiceability> {
   friend class DumperFlatObjectList;
 private:


### PR DESCRIPTION
Trivial fix of misspelled words and incorrect indefinite articles. There are probably more.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384054](https://bugs.openjdk.org/browse/JDK-8384054): [lworld] Cleanup typos and spellings in hotspot (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2399/head:pull/2399` \
`$ git checkout pull/2399`

Update a local copy of the PR: \
`$ git checkout pull/2399` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2399`

View PR using the GUI difftool: \
`$ git pr show -t 2399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2399.diff">https://git.openjdk.org/valhalla/pull/2399.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2399#issuecomment-4394422909)
</details>
