### PR TITLE
8384063: [lworld] src.zip missing preview java classes

### DIFF
--- a/make/ZipSource.gmk
+++ b/make/ZipSource.gmk
@@ -94,7 +94,7 @@ $(foreach m, $(ALL_MODULES), \
 # an extra rule to associate the symbolic link and the parent directory.
 #
 $(foreach m, $(ALL_MODULES), \
-  $(foreach d, $(call FindModuleValueClassSrcDirs, $m), \
+  $(foreach d, $(call FindModulePreviewSrcDirs, $m), \
     $(eval $d_TARGET := $(SRC_ZIP_WORK_DIR)/$(patsubst $(SUPPORT_OUTPUTDIR)/%,%,$d)/$m) \
     $(if $(SRC_GENERATED), , \
       $(eval $$($d_TARGET)/META-INF/preview: $d ; \


### PR DESCRIPTION
[JDK-8369922](https://bugs.openjdk.org/browse/JDK-8369922) added the preview classes sources to src.zip.
[JDK-8378767](https://bugs.openjdk.org/browse/JDK-8378767) then renamed the make function names but forgot to update the preview classes source usage. So it called an undefined function and did nothing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384063](https://bugs.openjdk.org/browse/JDK-8384063): [lworld] src.zip missing preview java classes (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2402/head:pull/2402` \
`$ git checkout pull/2402`

Update a local copy of the PR: \
`$ git checkout pull/2402` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2402`

View PR using the GUI difftool: \
`$ git pr show -t 2402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2402.diff">https://git.openjdk.org/valhalla/pull/2402.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2402#issuecomment-4394667848)
</details>
