### PR TITLE
8384064: [lworld] DEBUG_CDS_ARCHIVE does not work

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -162,7 +162,7 @@ define CreateCDSArchive
   endif
 
   ifeq ($(DEBUG_CDS_ARCHIVE), true)
-    $1_$2_CDS_DUMP_FLAGS += -Xlog:aot+map*=trace:file=$$(JDK_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE).cdsmap:none:filesize=0
+    $1_$2_$3_CDS_DUMP_FLAGS += -Xlog:aot+map*=trace:file=$$(JDK_IMAGE_DIR)/$$($1_$2_$3_CDS_ARCHIVE).cdsmap:none:filesize=0
   endif
 
   $$(eval $$(call SetupExecute, $1_$2_$3_gen_cds_archive_jdk, \


### PR DESCRIPTION
`DEBUG_CDS_ARCHIVE` is used add logging to the archive build step generation. But because it is missing one nesting level it does nothing.

Should be prefixed with `$1_$2_$3_` not just `$1_$2_`

Build.log with `DEBUG_CDS_ARCHIVE=true`:
* Without patch 
```log
Creating CDS archive for jdk image for server
Using CDS flags for server: -Xmx128M -Xms128M -XX:+UseG1GC
```
* With patch 
```log
Creating CDS archive for jdk image for server
Using CDS flags for server: -Xmx128M -Xms128M -XX:+UseG1GC -Xlog:aot+map*=trace:file=/scratch/aboldtch/zgc-worktrees/valhalla_review/build/linux-x64-debug/images/jdk/lib/server/classes.jsa.cdsmap:none:filesize=0
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384064](https://bugs.openjdk.org/browse/JDK-8384064): [lworld] DEBUG_CDS_ARCHIVE does not work (**Bug** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2403/head:pull/2403` \
`$ git checkout pull/2403`

Update a local copy of the PR: \
`$ git checkout pull/2403` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2403`

View PR using the GUI difftool: \
`$ git pr show -t 2403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2403.diff">https://git.openjdk.org/valhalla/pull/2403.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2403#issuecomment-4394695296)
</details>
