### PR TITLE
8384066: [lworld] TestDeadAllocationRemoval.java is ignored by jtreg

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadAllocationRemoval.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadAllocationRemoval.java
@@ -22,13 +22,13 @@
  */
 
 /**
- * @TestDeadAllocRem
+ * @test
  * @bug 8230397
  * @summary TestDeadAllocRem removal of an already dead AllocateNode with not-yet removed proj outputs.
  * @enablePreview
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
- * @run main/othervm -Xbatch compiler.valhalla.inlinetypes.TestDeadAllocRemDeadAllocationRemoval
+ * @run main/othervm -Xbatch compiler.valhalla.inlinetypes.TestDeadAllocationRemoval
  */
 
 package compiler.valhalla.inlinetypes;


### PR DESCRIPTION
TestDeadAllocationRemoval.java is missing the `@test` annotation in its comment and is ignored by jtreg. The test also refers to a nonexistent class, why is probably an uncaught typo caused by the test not actually being ran.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384066](https://bugs.openjdk.org/browse/JDK-8384066): [lworld] TestDeadAllocationRemoval.java is ignored by jtreg (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2404/head:pull/2404` \
`$ git checkout pull/2404`

Update a local copy of the PR: \
`$ git checkout pull/2404` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2404`

View PR using the GUI difftool: \
`$ git pr show -t 2404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2404.diff">https://git.openjdk.org/valhalla/pull/2404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2404#issuecomment-4394738494)
</details>
