### PR TITLE
8383991: [lworld] C2: assert(InlineUnsafeOps || StressReflectiveCode) failed: indeterminate pointers come only from unsafe ops

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1408,7 +1408,7 @@ const TypePtr *Compile::flatten_alias_type( const TypePtr *tj ) const {
 
   // Process weird unsafe references.
   if (offset == Type::OffsetBot && (tj->isa_instptr() /*|| tj->isa_klassptr()*/)) {
-    assert(InlineUnsafeOps || StressReflectiveCode, "indeterminate pointers come only from unsafe ops");
+    assert(InlineUnsafeOps || StressReflectiveCode || UseAcmpFastPath, "indeterminate pointers come only from unsafe ops");
     assert(!is_known_inst, "scalarizable allocation should not have unsafe references");
     tj = TypeOopPtr::BOTTOM;
     ptr = tj->ptr();

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3616,6 +3616,7 @@ jint Arguments::apply_ergo() {
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseNullableAtomicValueFlattening);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseNullFreeAtomicValueFlattening);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseNullableNonAtomicValueFlattening);
+    DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseAcmpFastPath);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(PrintInlineLayout);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(PrintFlatArrayLayout);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(IgnoreAssertUnsetFields);


### PR DESCRIPTION
[JDK-8381472](https://bugs.openjdk.org/browse/JDK-8381472) added a new fast path for acmp that emits "unsafe" loads:
https://github.com/openjdk/valhalla/blob/46dafa35ea274abed90c4c1475fbbff69bb14d6b/src/hotspot/share/opto/parse2.cpp#L2331-L2334

Although those loads are marked as unsafe themselves, they are still emitted even if `InlineUnsafeOps` is false. The assert in `Compile::flatten_alias_type` needs to be adjusted to account for this. Not adding a regression test because this easily reproduces with an existing test (in higher tiers).

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383991](https://bugs.openjdk.org/browse/JDK-8383991): [lworld] C2: assert(InlineUnsafeOps || StressReflectiveCode) failed: indeterminate pointers come only from unsafe ops (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2407/head:pull/2407` \
`$ git checkout pull/2407`

Update a local copy of the PR: \
`$ git checkout pull/2407` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2407`

View PR using the GUI difftool: \
`$ git pr show -t 2407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2407.diff">https://git.openjdk.org/valhalla/pull/2407.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2407#issuecomment-4395572965)
</details>
