### PR TITLE
8384079: [lworld] extended_sig may be left as a dangling pointer

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -289,6 +289,7 @@ void InlineKlass::initialize_calling_convention(TRAPS) {
     }
     if (!can_be_returned_as_fields() && !can_be_passed_as_fields()) {
       MetadataFactory::free_array<SigEntry>(class_loader_data(), extended_sig);
+      set_extended_sig(nullptr);
       assert(return_regs() == nullptr, "sanity");
     }
   }


### PR DESCRIPTION
InlineKlass::initialize_calling_convention has a path which frees the array after having called `set_extended_sig` without clearing the pointer. This can cause a double free.

Looked at other uses of this, and it seems like all other uses of `extended_sig` are explicitly or implicitly guarded from reading it incorrectly.

`InlineKlass::deallocate_contents` will however cause problems.

By clearing it once it is freed we both remove the use after free and double free, and will have a nullptr crash incase there is an incorrect use that pops up later.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384079](https://bugs.openjdk.org/browse/JDK-8384079): [lworld] extended_sig may be left as a dangling pointer (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2408/head:pull/2408` \
`$ git checkout pull/2408`

Update a local copy of the PR: \
`$ git checkout pull/2408` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2408`

View PR using the GUI difftool: \
`$ git pr show -t 2408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2408.diff">https://git.openjdk.org/valhalla/pull/2408.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2408#issuecomment-4395707116)
</details>
