### PR TITLE
8384081: [lworld] JVM_IHashCode caches hash after pending exception

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -327,16 +327,8 @@ JRT_ENTRY(jboolean, InterpreterRuntime::is_substitutable(JavaThread* current, oo
   methodHandle method(current, Universe::is_substitutable_method());
   method->method_holder()->initialize(CHECK_false); // Ensure class ValueObjectMethods is initialized
   JavaCalls::call(&result, method, &args, THREAD);
-  if (HAS_PENDING_EXCEPTION) {
-    // Something really bad happened because isSubstitutable() should not throw exceptions
-    // If it is an error, just let it propagate
-    // If it is an exception, wrap it into an InternalError
-    if (!PENDING_EXCEPTION->is_a(vmClasses::Error_klass())) {
-      Handle e(THREAD, PENDING_EXCEPTION);
-      CLEAR_PENDING_EXCEPTION;
-      THROW_MSG_CAUSE_(vmSymbols::java_lang_InternalError(), "Internal error in substitutability test", e, false);
-    }
-  }
+  Exceptions::wrap_exception_in_internal_error("Internal error in substitutability test", CHECK_false);
+
   return result.get_jboolean();
 JRT_END
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -831,13 +831,8 @@ JVM_ENTRY(jint, JVM_IHashCode(JNIEnv* env, jobject handle))
     args.push_oop(ho);
     methodHandle method(THREAD, Universe::value_object_hash_code_method());
     JavaCalls::call(&result, method, &args, THREAD);
-    if (HAS_PENDING_EXCEPTION) {
-      if (!PENDING_EXCEPTION->is_a(vmClasses::Error_klass())) {
-        Handle e(THREAD, PENDING_EXCEPTION);
-        CLEAR_PENDING_EXCEPTION;
-        THROW_MSG_CAUSE_(vmSymbols::java_lang_InternalError(), "Internal error in hashCode", e, false);
-      }
-    }
+    Exceptions::wrap_exception_in_internal_error("Internal error in hashCode", CHECK_0);
+
     const intptr_t identity_hash = result.get_jint();
 
     // We now have to set the hash via CAS. It's possible that this will race

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -308,16 +308,8 @@ bool JNIHandles::is_same_object(jobject handle1, jobject handle2) {
       args.push_oop(hb);
       methodHandle method(THREAD, Universe::is_substitutable_method());
       JavaCalls::call(&result, method, &args, THREAD);
-      if (HAS_PENDING_EXCEPTION) {
-        // Something really bad happened because isSubstitutable() should not throw exceptions
-        // If it is an error, just let it propagate
-        // If it is an exception, wrap it into an InternalError
-        if (!PENDING_EXCEPTION->is_a(vmClasses::Error_klass())) {
-          Handle e(THREAD, PENDING_EXCEPTION);
-          CLEAR_PENDING_EXCEPTION;
-          THROW_MSG_CAUSE_(vmSymbols::java_lang_InternalError(), "Internal error in substitutability test", e, false);
-        }
-      }
+      Exceptions::wrap_exception_in_internal_error("Internal error in substitutability test", CHECK_false);
+
       ret = result.get_jboolean();
     }
   }

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -476,8 +476,8 @@ Handle Exceptions::new_exception(JavaThread* thread, Symbol* name,
 }
 
 void Exceptions::wrap_exception_in_internal_error(const char* message, JavaThread* THREAD) {
-  // If there is a pending exception and that is not an internal error,
-  // clear it and wrap it in an internal error instead.
+  // If there is a pending exception that is not an Error, clear it and wrap it
+  // in an InternalError instead.
   if (THREAD->has_pending_exception()) {
     oop exception = THREAD->pending_exception();
     if (!exception->is_a(vmClasses::Error_klass())) {

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -475,6 +475,19 @@ Handle Exceptions::new_exception(JavaThread* thread, Symbol* name,
                                    to_utf8_safe);
 }
 
+void Exceptions::wrap_exception_in_internal_error(const char* message, JavaThread* THREAD) {
+  // If there is a pending exception and that is not an internal error,
+  // clear it and wrap it in an internal error instead.
+  if (THREAD->has_pending_exception()) {
+    oop exception = THREAD->pending_exception();
+    if (!exception->is_a(vmClasses::Error_klass())) {
+      Handle e(THREAD, exception);
+      THREAD->clear_pending_exception();
+      THROW_MSG_CAUSE(vmSymbols::java_lang_InternalError(), message, e);
+    }
+  }
+}
+
 // invokedynamic uses wrap_dynamic_exception for:
 //    - bootstrap method resolution
 //    - post call to MethodHandleNatives::linkCallSite

--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -182,6 +182,8 @@ class Exceptions {
 
   static void throw_stack_overflow_exception(JavaThread* thread, const char* file, int line, const methodHandle& method);
 
+  static void wrap_exception_in_internal_error(const char* message, JavaThread* thread);
+
   static void wrap_dynamic_exception(bool is_indy, JavaThread* thread);
 
   // Exception counting of interesting exceptions that may have caused a

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HashOverflowTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HashOverflowTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Tests that JVM_IHashCode does not cache when a SOE occurs.
+ * @comment This test runs with the interpreter such that the value is always
+ *          buffered, meaning that the identity hash code computed will be
+ *          saved in the markWord.
+ * @enablePreview
+ * @compile HashOverflowTest.java
+ * @run main/othervm -Xint -Xss256K
+ *                   runtime.valhalla.inlinetypes.HashOverflowTest
+ */
+
+package runtime.valhalla.inlinetypes;
+
+public class HashOverflowTest {
+    private static final int N_ELEMS = 1000;
+
+    public static void main(String[] args) {
+        Cons list = makeLargeDataStructure();
+        try {
+            System.identityHashCode(list);
+            throw new RuntimeException("expected to stack overflow when computing identity hash");
+        } catch (StackOverflowError expected) {
+            // Expected, continue execution.
+        }
+        try {
+            System.identityHashCode(list);
+            throw new RuntimeException("expected subsequent identity hash calls to also overflow");
+        } catch (StackOverflowError expected) {
+            // Expected, test passes!
+        }
+    }
+
+    private static Cons makeLargeDataStructure() {
+        Cons prev = new Cons(N_ELEMS - 1, null);
+        for (int i = N_ELEMS - 2; i >= 0; i--) {
+            Cons curr = new Cons(i, prev);
+            prev = curr;
+        }
+        return prev;
+    }
+
+    public static value record Cons(int x, Cons y) {}
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HashOverflowTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HashOverflowTest.java
@@ -28,6 +28,7 @@
  *          buffered, meaning that the identity hash code computed will be
  *          saved in the markWord.
  * @enablePreview
+ * @requires vm.flagless
  * @compile HashOverflowTest.java
  * @run main/othervm -Xint -Xss256K
  *                   runtime.valhalla.inlinetypes.HashOverflowTest


### PR DESCRIPTION
Hello,

This PR fixes an issue in `JVM_IHashCode` where we don't handle an exception occurring in the Java call to `ValueObjectMethods.valueObjectHashCode`. If an exception is thrown, we still proceed to install the (bad) hashcode that is based on a return value which is garbage data.

To fix this, we should make sure to return if there is a pending exception.

@xmas92 came up with a smart approach to encapsulate the behavior of wrapping an exception in an internal error into a separate helper, which is implemented in this PR as well. I've adapted other similar places where we wrap exceptions like this as well. These use-cases are all Valhalla-specific, so makes sense to change here IMO.

Testing:
* Running Oracle's tier1-4
* Test reproducer that fails before (installing a bad hashcode), and succeeds with the changes in this PR (never installs a bad hashcode).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384081](https://bugs.openjdk.org/browse/JDK-8384081): [lworld] JVM_IHashCode caches hash after pending exception (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)


### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`
 * Paul Hübner `<phubner@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2410/head:pull/2410` \
`$ git checkout pull/2410`

Update a local copy of the PR: \
`$ git checkout pull/2410` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2410`

View PR using the GUI difftool: \
`$ git pr show -t 2410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2410.diff">https://git.openjdk.org/valhalla/pull/2410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2410#issuecomment-4398112046)
</details>
