### PR TITLE
8380075: [lworld] Update JVMTI spec to clarify that ObjectFree events are not sent for value objects

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5888,8 +5888,8 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              If the frame's method is a value object constructor and
-              the requested local is the "<code>this</code>" object, the
+              When preview features are enabled, the frame's method is a non-identity object
+              constructor and the requested local is the "<code>this</code>" object, the
               value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
@@ -5944,8 +5944,8 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              If the frame's method is a value object constructor, the 
-              value_ptr is set to a snapshot of the "<code>this</code>" object.
+              When preview features are enabled and the frame's method is a non-identity object
+              constructor, the value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
       </parameters>
@@ -14137,6 +14137,7 @@ myInit() {
       must not use <jvmti/> functions except those which
       specifically allow such use (see the raw monitor, memory management,
       and environment local storage functions).
+      When preview features are enabled, this event supports identity object allocations only.
     </description>
     <origin>new</origin>
     <capabilities>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5948,7 +5948,7 @@ class C2 extends C1 implements I2 {
               On return, points to the variable's value.
               When preview features are enabled, and the local instance is a value
               object under construction, the value_ptr is set to a snapshot
-              of the"<code>this</code>" object that represents the value
+              of the "<code>this</code>" object that represents the value
               object's state at the point the snapshot is taken.
             </description>
         </param>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5888,9 +5888,11 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled, the frame's method is a value class
-              constructor and the requested local is a "<code>this</code>" value object,
-              the value_ptr is set to a snapshot of the "<code>this</code>" object.
+              When preview features are enabled, if the requested local is the
+              "<code>this</code>" object, and "<code>this</code>" is a value
+              object under construction, the value_ptr is set to a snapshot
+              of the"<code>this</code>" object that represents the value
+              object's state at the point the snapshot is taken.
             </description>
         </param>
       </parameters>
@@ -5944,9 +5946,10 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled, the frame's method is a value class
-              constructor and the local instance is a value object,
-              the value_ptr is set to a snapshot of the "<code>this</code>" object.
+              When preview features are enabled, and the local instance is a value
+              object under construction, the value_ptr is set to a snapshot
+              of the"<code>this</code>" object that represents the value
+              object's state at the point the snapshot is taken.
             </description>
         </param>
       </parameters>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5888,9 +5888,9 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled, the frame's method is an object
-              constructor and the requested local is a "<code>this</code>" value object, the
-              value_ptr is set to a snapshot of the "<code>this</code>" object.
+              When preview features are enabled, the frame's method is a value class
+              constructor and the requested local is a "<code>this</code>" value object,
+              the value_ptr is set to a snapshot of the object.
             </description>
         </param>
       </parameters>
@@ -5944,9 +5944,9 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled, the frame's method is an object
-              constructor and the requested instance is a value object, the
-              value_ptr is set to a snapshot of the "<code>this</code>" object.
+              When preview features are enabled, the frame's method is a value class
+              constructor and the local instance is a value object,
+              the value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
       </parameters>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5890,7 +5890,7 @@ class C2 extends C1 implements I2 {
               On return, points to the variable's value.
               When preview features are enabled, the frame's method is a value class
               constructor and the requested local is a "<code>this</code>" value object,
-              the value_ptr is set to a snapshot of the object.
+              the value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
       </parameters>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5891,7 +5891,7 @@ class C2 extends C1 implements I2 {
               When preview features are enabled, if the requested local is the
               "<code>this</code>" object, and "<code>this</code>" is a value
               object under construction, the value_ptr is set to a snapshot
-              of the"<code>this</code>" object that represents the value
+              of the "<code>this</code>" object that represents the value
               object's state at the point the snapshot is taken.
             </description>
         </param>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5888,8 +5888,8 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled, the frame's method is a value object
-              constructor and the requested local is the "<code>this</code>" object, the
+              When preview features are enabled, the frame's method is an object
+              constructor and the requested local is a "<code>this</code>" value object, the
               value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
@@ -5944,8 +5944,9 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled and the frame's method is a value object
-              constructor, the value_ptr is set to a snapshot of the "<code>this</code>" object.
+              When preview features are enabled, the frame's method is an object
+              constructor and the requested instance is a value object, the
+              value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
       </parameters>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5888,7 +5888,7 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled, the frame's method is a non-identity object
+              When preview features are enabled, the frame's method is a value object
               constructor and the requested local is the "<code>this</code>" object, the
               value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
@@ -5944,7 +5944,7 @@ class C2 extends C1 implements I2 {
           <outptr><jobject/></outptr>
             <description>
               On return, points to the variable's value.
-              When preview features are enabled and the frame's method is a non-identity object
+              When preview features are enabled and the frame's method is a value object
               constructor, the value_ptr is set to a snapshot of the "<code>this</code>" object.
             </description>
         </param>
@@ -14137,7 +14137,7 @@ myInit() {
       must not use <jvmti/> functions except those which
       specifically allow such use (see the raw monitor, memory management,
       and environment local storage functions).
-      When preview features are enabled, this event supports identity object allocations only.
+      When preview features are enabled, this event does not supports value object allocations.
     </description>
     <origin>new</origin>
     <capabilities>


### PR DESCRIPTION
This update address two enhancements:
 - [8380075](https://bugs.openjdk.org/browse/JDK-8380075) [lworld] Update JVMTI spec to clarify that ObjectFree events are not sent for value objects
 - [8384049](https://bugs.openjdk.org/browse/JDK-8384049) [lworld] Minor GetLocalObject/GetLocalInstance spec wording update

The first one adds an `ObjectFree` event spec clarification that only identity objects are supported by this event.
The second one just slightly reformulates previously added spec clarifications for the JVMTI  `GetLocalObject` and `GetLocalInstance` functions, underlying that they work only when preview features are enabled.

The `ObjectFree` implementation does not need any matching update. Strong references are used for value objects instead of weak references in the `JvmtiTagMap`, so the value objects are kept alive while they are listed in the `JvmtiTagMap`. This means there are no `ObjectFree` events can be generated for value objects.

Testing:
 - No testing is needed for pure spec wording changes


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issues
 * [JDK-8380075](https://bugs.openjdk.org/browse/JDK-8380075): [lworld] Update JVMTI spec to clarify that ObjectFree events are not sent for value objects (**Enhancement** - P4)
 * [JDK-8384049](https://bugs.openjdk.org/browse/JDK-8384049): [lworld] Minor GetLocalObject/GetLocalInstance spec wording update (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2412/head:pull/2412` \
`$ git checkout pull/2412`

Update a local copy of the PR: \
`$ git checkout pull/2412` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2412`

View PR using the GUI difftool: \
`$ git pr show -t 2412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2412.diff">https://git.openjdk.org/valhalla/pull/2412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2412#issuecomment-4402005146)
</details>
