### PR TITLE
8383998: [lworld] compiler/vectorization/TestVectorsNotSavedAtSafepoint.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,6 +25,7 @@
 /**
  * @test
  * @bug 8193518 8249608
+ * @requires vm.compMode != "Xcomp"
  * @summary C2: Vector registers are sometimes corrupted at safepoint
  * @run main/othervm -XX:-BackgroundCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCountedLoopSafepoints -XX:LoopStripMiningIter=2 -XX:-TieredCompilation TestVectorsNotSavedAtSafepoint test1
  * @run main/othervm -XX:-BackgroundCompilation TestVectorsNotSavedAtSafepoint test2


### PR DESCRIPTION
The test is already quite slow in mainline because of the daemon `GarbageProducerThread` which triggers massive GC activity. With `--enable-preview` the jimage paths, including preview directory processing in `src/java.base/share/classes/jdk/internal/jimage/ImageReader.java`, are all C2 compiled due to `-Xcomp` and while that happens, the daemon thread keeps issuing synchronous explicit GCs accumulating ~223 extra Full GCs and ~15.6s extra Full-GC pause times.

While this overhead of `jimage` is a more general issue, there's no real benefit in running this particular test with `-Xcomp` (even without Valhalla). So let's exclude it.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383998](https://bugs.openjdk.org/browse/JDK-8383998): [lworld] compiler/vectorization/TestVectorsNotSavedAtSafepoint.java timed out (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2415/head:pull/2415` \
`$ git checkout pull/2415`

Update a local copy of the PR: \
`$ git checkout pull/2415` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2415`

View PR using the GUI difftool: \
`$ git pr show -t 2415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2415.diff">https://git.openjdk.org/valhalla/pull/2415.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2415#issuecomment-4405401470)
</details>
