### PR TITLE
8383658: [lworld] Add value class test coverage to java.util.Collections

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -174,7 +174,8 @@ jdk_util = \
 
 valhalla_adopted = \
     java/util/Collections/AddAll.java \
-    java/util/Arrays
+    java/util/Arrays \
+    java/util/Collections
 
 # All util components not part of some other util category
 jdk_util_other = \

--- a/test/jdk/java/util/Collections/AddAll.java
+++ b/test/jdk/java/util/Collections/AddAll.java
@@ -28,10 +28,9 @@
  * @author  Josh Bloch
  * @key randomness
  * @library /test/lib
- * @run main AddAll
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,10 +50,10 @@ public class AddAll {
         test(new HashSet<Integer>());
         test(new LinkedHashSet<Integer>());
 
-        testTuple(new ArrayList<Tuple>());
-        testTuple(new LinkedList<Tuple>());
-        testTuple(new HashSet<Tuple>());
-        testTuple(new LinkedHashSet<Tuple>());
+        testTuple(new ArrayList<VClass>());
+        testTuple(new LinkedList<VClass>());
+        testTuple(new HashSet<VClass>());
+        testTuple(new LinkedHashSet<VClass>());
     }
 
     private static Random rnd = new Random();
@@ -84,7 +83,7 @@ public class AddAll {
         return result;
     }
 
-    static void testTuple(Collection<Tuple> c) {
+    static void testTuple(Collection<VClass> c) {
         int x = 0;
         for (int i = 0; i < N; i++) {
             int rangeLen = rnd.nextInt(10);
@@ -97,15 +96,15 @@ public class AddAll {
             if (!c.equals(Arrays.asList(rangeTuple(0, x))))
                 throw new RuntimeException(x + ": " + c);
         } else {
-            if (!c.equals(new HashSet<Tuple>(Arrays.asList(rangeTuple(0, x)))))
+            if (!c.equals(new HashSet<VClass>(Arrays.asList(rangeTuple(0, x)))))
                 throw new RuntimeException(x + ": " + c);
         }
     }
 
-    private static Tuple[] rangeTuple(int from, int to) {
-        Tuple[] result = new Tuple[to - from];
+    private static VClass[] rangeTuple(int from, int to) {
+        VClass[] result = new VClass[to - from];
         for (int i = from, j = 0; i < to; i++, j++)
-            result[j] = new Tuple(i, i);
+            result[j] = new VClass(i, new int[] { i });
         return result;
     }
 }

--- a/test/jdk/java/util/Collections/AddAll.java
+++ b/test/jdk/java/util/Collections/AddAll.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Random;
 
 public class AddAll {
-    static final int N = 10;
+    static final int N = 100;
     public static void main(String[] args) {
         test(new ArrayList<Integer>());
         test(new LinkedList<Integer>());

--- a/test/jdk/java/util/Collections/AddAll.java
+++ b/test/jdk/java/util/Collections/AddAll.java
@@ -31,7 +31,7 @@
  * @run main AddAll
  */
 
-import jdk.test.lib.valueclass.AsValueClass;
+import jdk.test.lib.valueclass.Tuple;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,23 +44,20 @@ import java.util.List;
 import java.util.Random;
 
 public class AddAll {
-    static final int N = 100;
+    static final int N = 10;
     public static void main(String[] args) {
         test(new ArrayList<Integer>());
         test(new LinkedList<Integer>());
         test(new HashSet<Integer>());
         test(new LinkedHashSet<Integer>());
-        testPoint(new ArrayList<Point>());
+
+        testTuple(new ArrayList<Tuple>());
+        testTuple(new LinkedList<Tuple>());
+        testTuple(new HashSet<Tuple>());
+        testTuple(new LinkedHashSet<Tuple>());
     }
 
     private static Random rnd = new Random();
-
-    @AsValueClass
-    static class Point {
-        int x;
-        int y;
-        Point(int x, int y) { this.x = x; this.y = y; }
-    }
 
     static void test(Collection<Integer> c) {
         int x = 0;
@@ -87,21 +84,28 @@ public class AddAll {
         return result;
     }
 
-    static void testPoint(Collection<Point> c) {
+    static void testTuple(Collection<Tuple> c) {
         int x = 0;
         for (int i = 0; i < N; i++) {
             int rangeLen = rnd.nextInt(10);
-            if (Collections.addAll(c, rangePoint(x, x + rangeLen)) !=
+            if (Collections.addAll(c, rangeTuple(x, x + rangeLen)) !=
                     (rangeLen != 0))
                 throw new RuntimeException("" + rangeLen);
             x += rangeLen;
         }
+        if (c instanceof List) {
+            if (!c.equals(Arrays.asList(rangeTuple(0, x))))
+                throw new RuntimeException(x + ": " + c);
+        } else {
+            if (!c.equals(new HashSet<Tuple>(Arrays.asList(rangeTuple(0, x)))))
+                throw new RuntimeException(x + ": " + c);
+        }
     }
 
-    private static Point[] rangePoint(int from, int to) {
-        Point[] result = new Point[to - from];
+    private static Tuple[] rangeTuple(int from, int to) {
+        Tuple[] result = new Tuple[to - from];
         for (int i = from, j = 0; i < to; i++, j++)
-            result[j] = new Point(i, i);
+            result[j] = new Tuple(i, i);
         return result;
     }
 }

--- a/test/jdk/java/util/Collections/AsLifoQueue.java
+++ b/test/jdk/java/util/Collections/AsLifoQueue.java
@@ -27,10 +27,9 @@
  * @summary Basic tests for asLifoQueue
  * @author  Martin Buchholz
  * @library /test/lib
- * @run main AsLifoQueue
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -77,13 +76,13 @@ public class AsLifoQueue {
         THROWS(NullPointerException.class, () -> Collections.asLifoQueue(null));
 
         try {
-            Deque<Tuple> deq = new ArrayDeque<>();
-            Queue<Tuple> q = Collections.asLifoQueue(deq);
-            check(q.add(new Tuple(1, 1)));
-            check(q.add(new Tuple(2, 2)));
-            equal(q.peek(), new Tuple(2, 2));
-            equal(q.remove(), new Tuple(2, 2));
-            equal(q.poll(), new Tuple(1, 1));
+            Deque<VClass> deq = new ArrayDeque<>();
+            Queue<VClass> q = Collections.asLifoQueue(deq);
+            check(q.add(new VClass(1, new int[] { 1 })));
+            check(q.add(new VClass(2, new int[] { 2 })));
+            equal(q.peek(), new VClass(2, new int[] { 2 }));
+            equal(q.remove(), new VClass(2, new int[] { 2 }));
+            equal(q.poll(), new VClass(1, new int[] { 1 }));
             check(q.isEmpty());
         } catch (Throwable t) { unexpected(t); }
     }

--- a/test/jdk/java/util/Collections/AsLifoQueue.java
+++ b/test/jdk/java/util/Collections/AsLifoQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug     6301085 6192552 6365601
  * @summary Basic tests for asLifoQueue
  * @author  Martin Buchholz
+ * @library /test/lib
+ * @run main AsLifoQueue
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -72,6 +75,17 @@ public class AsLifoQueue {
         } catch (Throwable t) { unexpected(t); }
 
         THROWS(NullPointerException.class, () -> Collections.asLifoQueue(null));
+
+        try {
+            Deque<Tuple> deq = new ArrayDeque<>();
+            Queue<Tuple> q = Collections.asLifoQueue(deq);
+            check(q.add(new Tuple(1, 1)));
+            check(q.add(new Tuple(2, 2)));
+            equal(q.peek(), new Tuple(2, 2));
+            equal(q.remove(), new Tuple(2, 2));
+            equal(q.poll(), new Tuple(1, 1));
+            check(q.isEmpty());
+        } catch (Throwable t) { unexpected(t); }
     }
 
     //--------------------- Infrastructure ---------------------------

--- a/test/jdk/java/util/Collections/BigBinarySearch.java
+++ b/test/jdk/java/util/Collections/BigBinarySearch.java
@@ -27,10 +27,9 @@
  * @summary binarySearch of Collections larger than 1<<30
  * @author Martin Buchholz
  * @library /test/lib
- * @run main BigBinarySearch
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.AbstractList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -41,11 +40,11 @@ import java.util.RandomAccess;
 
 public class BigBinarySearch {
 
-    static class SparseTupleList extends AbstractList<Tuple> implements RandomAccess {
-        final Map<Integer, Tuple> m = new HashMap<>();
-        public Tuple get(int i) { return m.getOrDefault(i, new Tuple(0, 0)); }
+    static class SparseTupleList extends AbstractList<VClass> implements RandomAccess {
+        final Map<Integer, VClass> m = new HashMap<>();
+        public VClass get(int i) { return m.getOrDefault(i, new VClass(0, new int[] { 0 })); }
         public int size() { return Collections.max(m.keySet()) + 1; }
-        public Tuple set(int i, Tuple v) { return m.put(i, v); }
+        public VClass set(int i, VClass v) { return m.put(i, v); }
     }
 
     // Allows creation of very "big" collections without using too
@@ -115,11 +114,11 @@ public class BigBinarySearch {
 
         System.out.println("binarySearch(SparseTupleList, Tuple)");
         SparseTupleList vl = new SparseTupleList();
-        vl.set(0, new Tuple(0, 0));
-        vl.set(1, new Tuple(1, 1));
-        vl.set(n - 2, new Tuple(n - 2, n - 2));
-        vl.set(n - 1, new Tuple(n - 1, n - 1));
-        equal(n - 1, Collections.binarySearch(vl, new Tuple(n - 1, n - 1)));
+        vl.set(0, new VClass(0, new int[] { 0 }));
+        vl.set(1, new VClass(1, new int[] { 1 }));
+        vl.set(n - 2, new VClass(n - 2, new int[] { n - 2 }));
+        vl.set(n - 1, new VClass(n - 1, new int[] { n - 1 }));
+        equal(n - 1, Collections.binarySearch(vl, new VClass(n - 1, new int[] { n - 1 })));
     }
 
     //--------------------- Infrastructure ---------------------------

--- a/test/jdk/java/util/Collections/BigBinarySearch.java
+++ b/test/jdk/java/util/Collections/BigBinarySearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug 5045582
  * @summary binarySearch of Collections larger than 1<<30
  * @author Martin Buchholz
+ * @library /test/lib
+ * @run main BigBinarySearch
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.AbstractList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -37,6 +40,13 @@ import java.util.Map;
 import java.util.RandomAccess;
 
 public class BigBinarySearch {
+
+    static class SparseTupleList extends AbstractList<Tuple> implements RandomAccess {
+        final Map<Integer, Tuple> m = new HashMap<>();
+        public Tuple get(int i) { return m.getOrDefault(i, new Tuple(0, 0)); }
+        public int size() { return Collections.max(m.keySet()) + 1; }
+        public Tuple set(int i, Tuple v) { return m.put(i, v); }
+    }
 
     // Allows creation of very "big" collections without using too
     // many real resources
@@ -102,6 +112,14 @@ public class BigBinarySearch {
             big.set(i, - big.get(i));
         for (int i : ints)
             checkBinarySearch(big, i, reverse);
+
+        System.out.println("binarySearch(SparseTupleList, Tuple)");
+        SparseTupleList vl = new SparseTupleList();
+        vl.set(0, new Tuple(0, 0));
+        vl.set(1, new Tuple(1, 1));
+        vl.set(n - 2, new Tuple(n - 2, n - 2));
+        vl.set(n - 1, new Tuple(n - 1, n - 1));
+        equal(n - 1, Collections.binarySearch(vl, new Tuple(n - 1, n - 1)));
     }
 
     //--------------------- Infrastructure ---------------------------

--- a/test/jdk/java/util/Collections/BinarySearchNullComparator.java
+++ b/test/jdk/java/util/Collections/BinarySearchNullComparator.java
@@ -26,10 +26,9 @@
  * @bug 4528331 5006032
  * @summary Test Collections.binarySearch() with a null comparator
  * @library /test/lib
- * @run main BinarySearchNullComparator
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -43,8 +42,8 @@ public class BinarySearchNullComparator {
         if (result != 2)
             throw new Exception("Result: " + result);
 
-        List<Tuple> values = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3));
-        int vresult = Collections.binarySearch(values, new Tuple(3, 3), null);
+        List<VClass> values = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 }));
+        int vresult = Collections.binarySearch(values, new VClass(3, new int[] { 3 }), null);
         if (vresult != 2)
             throw new Exception("Value result: " + vresult);
     }

--- a/test/jdk/java/util/Collections/CheckedListBash.java
+++ b/test/jdk/java/util/Collections/CheckedListBash.java
@@ -28,10 +28,9 @@
  * @author  Josh Bloch
  * @key randomness
  * @library /test/lib
- * @run main CheckedListBash
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -231,12 +230,12 @@ public class CheckedListBash {
     }
 
     static void testValueCheckedList() {
-        List<Tuple> list = Collections.checkedList(new ArrayList<>(), Tuple.class);
-        list.add(new Tuple(1, 1));
-        list.add(new Tuple(2, 2));
-        if (!list.contains(new Tuple(1, 1)) || list.indexOf(new Tuple(2, 2)) != 1)
+        List<VClass> list = Collections.checkedList(new ArrayList<>(), VClass.class);
+        list.add(new VClass(1, new int[] { 1 }));
+        list.add(new VClass(2, new int[] { 2 }));
+        if (!list.contains(new VClass(1, new int[] { 1 })) || list.indexOf(new VClass(2, new int[] { 2 })) != 1)
             fail("value checkedList lookup failed");
-        Tuple[] a = list.toArray(new Tuple[0]);
+        VClass[] a = list.toArray(new VClass[0]);
         if (!Arrays.asList(a).equals(list))
             fail("value checkedList toArray failed");
         try {

--- a/test/jdk/java/util/Collections/CheckedListBash.java
+++ b/test/jdk/java/util/Collections/CheckedListBash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,11 @@
  * @summary Unit test for Collections.checkedList
  * @author  Josh Bloch
  * @key randomness
+ * @library /test/lib
+ * @run main CheckedListBash
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -182,6 +185,7 @@ public class CheckedListBash {
             || !l.equals(Arrays.asList(ia).subList(0, listSize)))
             fail("toArray(Object[]) is hosed (3)");
 
+        testValueCheckedList();
     }
 
     // Done inefficiently so as to exercise toArray
@@ -224,5 +228,20 @@ public class CheckedListBash {
 
     static void fail(String s) {
         throw new RuntimeException(s);
+    }
+
+    static void testValueCheckedList() {
+        List<Tuple> list = Collections.checkedList(new ArrayList<>(), Tuple.class);
+        list.add(new Tuple(1, 1));
+        list.add(new Tuple(2, 2));
+        if (!list.contains(new Tuple(1, 1)) || list.indexOf(new Tuple(2, 2)) != 1)
+            fail("value checkedList lookup failed");
+        Tuple[] a = list.toArray(new Tuple[0]);
+        if (!Arrays.asList(a).equals(list))
+            fail("value checkedList toArray failed");
+        try {
+            ((List) list).add("not a Tuple");
+            fail("value checkedList accepted wrong type");
+        } catch (ClassCastException expected) { }
     }
 }

--- a/test/jdk/java/util/Collections/CheckedListReplaceAll.java
+++ b/test/jdk/java/util/Collections/CheckedListReplaceAll.java
@@ -27,10 +27,9 @@
  * @summary Ensure that replaceAll operator cannot add bad elements
  * @author  Mike Duigou
  * @library /test/lib
- * @run main CheckedListReplaceAll
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.*;
 import java.util.function.UnaryOperator;
 
@@ -62,12 +61,12 @@ public class CheckedListReplaceAll {
             System.out.println("Curses! Foiled again!");
         }
 
-        List<Tuple> vList = Collections.checkedList(new ArrayList<Tuple>(Arrays.asList(new Tuple(1, 1))), Tuple.class);
-        vList.replaceAll(v -> new Tuple(v.x + 1, v.x + 1));
-        if (!vList.get(0).equals(new Tuple(2, 2)))
+        List<VClass> vList = Collections.checkedList(new ArrayList<VClass>(Arrays.asList(new VClass(1, new int[] { 1 }))), VClass.class);
+        vList.replaceAll(v -> new VClass(v.x + 1, new int[] { v.x + 1 }));
+        if (!vList.get(0).equals(new VClass(2, new int[] { 2 })))
             throw new RuntimeException("value checkedList replaceAll failed");
 
-        List raw = Collections.checkedList(new ArrayList<Tuple>(Arrays.asList(new Tuple(1, 1))), Tuple.class);
+        List raw = Collections.checkedList(new ArrayList<VClass>(Arrays.asList(new VClass(1, new int[] { 1 }))), VClass.class);
         try {
             raw.replaceAll(e -> "not a Tuple");
             throw new RuntimeException("value checkedList replaceAll accepted wrong type");

--- a/test/jdk/java/util/Collections/CheckedListReplaceAll.java
+++ b/test/jdk/java/util/Collections/CheckedListReplaceAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,16 @@
  * @bug     8047795 8053938
  * @summary Ensure that replaceAll operator cannot add bad elements
  * @author  Mike Duigou
+ * @library /test/lib
+ * @run main CheckedListReplaceAll
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.*;
 import java.util.function.UnaryOperator;
 
 public class CheckedListReplaceAll {
+
     public static void main(String[] args) {
         List unwrapped = Arrays.asList(new Object[]{1, 2, 3});
         List<Object> wrapped = Collections.checkedList(unwrapped, Integer.class);
@@ -57,5 +61,16 @@ public class CheckedListReplaceAll {
             thwarted.printStackTrace(System.out);
             System.out.println("Curses! Foiled again!");
         }
+
+        List<Tuple> vList = Collections.checkedList(new ArrayList<Tuple>(Arrays.asList(new Tuple(1, 1))), Tuple.class);
+        vList.replaceAll(v -> new Tuple(v.x + 1, v.x + 1));
+        if (!vList.get(0).equals(new Tuple(2, 2)))
+            throw new RuntimeException("value checkedList replaceAll failed");
+
+        List raw = Collections.checkedList(new ArrayList<Tuple>(Arrays.asList(new Tuple(1, 1))), Tuple.class);
+        try {
+            raw.replaceAll(e -> "not a Tuple");
+            throw new RuntimeException("value checkedList replaceAll accepted wrong type");
+        } catch (ClassCastException expected) { }
     }
 }

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -31,7 +31,7 @@
  * @run testng CheckedMapBash
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -196,14 +196,14 @@ public class CheckedMapBash {
 
     @Test
     public static void testValueCheckedMap() {
-        Map<Tuple,Tuple> m = Collections.checkedMap(new HashMap<>(), Tuple.class, Tuple.class);
-        m.put(new Tuple(1, 1), new Tuple(10, 10));
-        if (!m.containsKey(new Tuple(1, 1)) || !m.containsValue(new Tuple(10, 10)))
+        Map<VClass,VClass> m = Collections.checkedMap(new HashMap<>(), VClass.class, VClass.class);
+        m.put(new VClass(1, new int[] { 1 }), new VClass(10, new int[] { 10 }));
+        if (!m.containsKey(new VClass(1, new int[] { 1 })) || !m.containsValue(new VClass(10, new int[] { 10 })))
             fail("value checkedMap lookup failed");
         if (!new HashMap<>(m).equals(m))
             fail("value checkedMap equals failed");
         try {
-            ((Map) m).put("not a Tuple", new Tuple(2, 2));
+            ((Map) m).put("not a Tuple", new VClass(2, new int[] { 2 }));
             fail("value checkedMap accepted wrong type");
         } catch (ClassCastException expected) { }
     }

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,12 @@
  * @bug     4904067 5023830 7129185 8072015 8292955
  * @summary Unit test for Collections.checkedMap
  * @author  Josh Bloch
- * @run testng CheckedMapBash
  * @key randomness
+ * @library /test/lib
+ * @run testng CheckedMapBash
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -190,5 +192,19 @@ public class CheckedMapBash {
         Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
         Assert.assertThrows(ClassCastException.class, () -> m.merge("key", "value", (v1, v2) -> null));
         Assert.assertThrows(ClassCastException.class, () -> m.merge("key", 3, (v1, v2) -> v2));
+    }
+
+    @Test
+    public static void testValueCheckedMap() {
+        Map<Tuple,Tuple> m = Collections.checkedMap(new HashMap<>(), Tuple.class, Tuple.class);
+        m.put(new Tuple(1, 1), new Tuple(10, 10));
+        if (!m.containsKey(new Tuple(1, 1)) || !m.containsValue(new Tuple(10, 10)))
+            fail("value checkedMap lookup failed");
+        if (!new HashMap<>(m).equals(m))
+            fail("value checkedMap equals failed");
+        try {
+            ((Map) m).put("not a Tuple", new Tuple(2, 2));
+            fail("value checkedMap accepted wrong type");
+        } catch (ClassCastException expected) { }
     }
 }

--- a/test/jdk/java/util/Collections/CheckedMapReplaceAll.java
+++ b/test/jdk/java/util/Collections/CheckedMapReplaceAll.java
@@ -27,10 +27,9 @@
  * @summary Ensure that replaceAll operator cannot add bad elements
  * @author  Mike Duigou
  * @library /test/lib
- * @run main CheckedMapReplaceAll
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.*;
 import java.util.function.BiFunction;
 
@@ -55,14 +54,14 @@ public class CheckedMapReplaceAll {
             System.out.println("Curses! Foiled again!");
         }
 
-        Map<Tuple,Tuple> vMap = Collections.checkedMap(new HashMap<>(), Tuple.class, Tuple.class);
-        vMap.put(new Tuple(1, 1), new Tuple(2, 2));
-        vMap.replaceAll((k, v) -> new Tuple(v.x + 1, v.x + 1));
-        if (!vMap.get(new Tuple(1, 1)).equals(new Tuple(3, 3)))
+        Map<VClass,VClass> vMap = Collections.checkedMap(new HashMap<>(), VClass.class, VClass.class);
+        vMap.put(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }));
+        vMap.replaceAll((k, v) -> new VClass(v.x + 1, new int[] { v.x + 1 }));
+        if (!vMap.get(new VClass(1, new int[] { 1 })).equals(new VClass(3, new int[] { 3 })))
             throw new RuntimeException("value checkedMap replaceAll failed");
 
-        Map raw = Collections.checkedMap(new HashMap<Tuple,Tuple>(), Tuple.class, Tuple.class);
-        raw.put(new Tuple(1, 1), new Tuple(2, 2));
+        Map raw = Collections.checkedMap(new HashMap<VClass,VClass>(), VClass.class, VClass.class);
+        raw.put(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }));
         try {
             raw.replaceAll((k, v) -> "not a Tuple");
             throw new RuntimeException("value checkedMap replaceAll accepted wrong type");

--- a/test/jdk/java/util/Collections/CheckedMapReplaceAll.java
+++ b/test/jdk/java/util/Collections/CheckedMapReplaceAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,16 @@
  * @bug     8047795
  * @summary Ensure that replaceAll operator cannot add bad elements
  * @author  Mike Duigou
+ * @library /test/lib
+ * @run main CheckedMapReplaceAll
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.*;
 import java.util.function.BiFunction;
 
 public class CheckedMapReplaceAll {
+
     public static void main(String[] args) {
         Map<Integer,Double> unwrapped = new HashMap<>();
         unwrapped.put(1, 1.0);
@@ -50,5 +54,18 @@ public class CheckedMapReplaceAll {
             thwarted.printStackTrace(System.out);
             System.out.println("Curses! Foiled again!");
         }
+
+        Map<Tuple,Tuple> vMap = Collections.checkedMap(new HashMap<>(), Tuple.class, Tuple.class);
+        vMap.put(new Tuple(1, 1), new Tuple(2, 2));
+        vMap.replaceAll((k, v) -> new Tuple(v.x + 1, v.x + 1));
+        if (!vMap.get(new Tuple(1, 1)).equals(new Tuple(3, 3)))
+            throw new RuntimeException("value checkedMap replaceAll failed");
+
+        Map raw = Collections.checkedMap(new HashMap<Tuple,Tuple>(), Tuple.class, Tuple.class);
+        raw.put(new Tuple(1, 1), new Tuple(2, 2));
+        try {
+            raw.replaceAll((k, v) -> "not a Tuple");
+            throw new RuntimeException("value checkedMap replaceAll accepted wrong type");
+        } catch (ClassCastException expected) { }
     }
 }

--- a/test/jdk/java/util/Collections/CheckedQueue.java
+++ b/test/jdk/java/util/Collections/CheckedQueue.java
@@ -29,7 +29,7 @@
  * @run testng CheckedQueue
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Queue;
@@ -155,9 +155,9 @@ public class CheckedQueue {
 
     @Test
     public void testValueCheckedQueue() {
-        Queue<Tuple> q = Collections.checkedQueue(new ArrayDeque<>(), Tuple.class);
-        q.add(new Tuple(1, 1));
-        if (!q.peek().equals(new Tuple(1, 1)))
+        Queue<VClass> q = Collections.checkedQueue(new ArrayDeque<>(), VClass.class);
+        q.add(new VClass(1, new int[] { 1 }));
+        if (!q.peek().equals(new VClass(1, new int[] { 1 })))
             fail("value checkedQueue peek failed");
         try {
             ((Queue) q).add("not a Tuple");

--- a/test/jdk/java/util/Collections/CheckedQueue.java
+++ b/test/jdk/java/util/Collections/CheckedQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,12 @@
  * @test
  * @bug 5020931 8048207
  * @summary Unit test for Collections.checkedQueue
+ * @library /test/lib
  * @run testng CheckedQueue
  */
 
+import jdk.test.lib.valueclass.Tuple;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -148,5 +151,17 @@ public class CheckedQueue {
 
         // no room at the inn!
         assertFalse(q.offer("1"), "queue should be full");
+    }
+
+    @Test
+    public void testValueCheckedQueue() {
+        Queue<Tuple> q = Collections.checkedQueue(new ArrayDeque<>(), Tuple.class);
+        q.add(new Tuple(1, 1));
+        if (!q.peek().equals(new Tuple(1, 1)))
+            fail("value checkedQueue peek failed");
+        try {
+            ((Queue) q).add("not a Tuple");
+            fail("value checkedQueue accepted wrong type");
+        } catch (ClassCastException expected) { }
     }
 }

--- a/test/jdk/java/util/Collections/CheckedSetBash.java
+++ b/test/jdk/java/util/Collections/CheckedSetBash.java
@@ -31,7 +31,7 @@
  * @run testng CheckedSetBash
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -182,13 +182,13 @@ public class CheckedSetBash {
 
     @Test
     public static void testValueCheckedSet() {
-        Set<Tuple> s = Collections.checkedSet(new HashSet<>(), Tuple.class);
-        s.add(new Tuple(1, 1));
-        s.add(new Tuple(2, 2));
-        if (!s.contains(new Tuple(1, 1)))
+        Set<VClass> s = Collections.checkedSet(new HashSet<>(), VClass.class);
+        s.add(new VClass(1, new int[] { 1 }));
+        s.add(new VClass(2, new int[] { 2 }));
+        if (!s.contains(new VClass(1, new int[] { 1 })))
             fail("value checkedSet lookup failed");
-        Set<Tuple> copy = Collections.checkedSet(new HashSet<>(), Tuple.class);
-        copy.addAll(Arrays.asList(s.toArray(new Tuple[0])));
+        Set<VClass> copy = Collections.checkedSet(new HashSet<>(), VClass.class);
+        copy.addAll(Arrays.asList(s.toArray(new VClass[0])));
         if (!s.equals(copy))
             fail("value checkedSet addAll failed");
         try {

--- a/test/jdk/java/util/Collections/CheckedSetBash.java
+++ b/test/jdk/java/util/Collections/CheckedSetBash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,12 @@
  * @bug     4904067 7129185
  * @summary Unit test for Collections.checkedSet
  * @author  Josh Bloch
- * @run testng CheckedSetBash
  * @key randomness
+ * @library /test/lib
+ * @run testng CheckedSetBash
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -176,5 +178,22 @@ public class CheckedSetBash {
              (Supplier) () -> Collections.checkedNavigableSet(new TreeSet().descendingSet(), Integer.class)},
         };
         return Arrays.asList(params);
+    }
+
+    @Test
+    public static void testValueCheckedSet() {
+        Set<Tuple> s = Collections.checkedSet(new HashSet<>(), Tuple.class);
+        s.add(new Tuple(1, 1));
+        s.add(new Tuple(2, 2));
+        if (!s.contains(new Tuple(1, 1)))
+            fail("value checkedSet lookup failed");
+        Set<Tuple> copy = Collections.checkedSet(new HashSet<>(), Tuple.class);
+        copy.addAll(Arrays.asList(s.toArray(new Tuple[0])));
+        if (!s.equals(copy))
+            fail("value checkedSet addAll failed");
+        try {
+            ((Set) s).add("not a Tuple");
+            fail("value checkedSet accepted wrong type");
+        } catch (ClassCastException expected) { }
     }
 }

--- a/test/jdk/java/util/Collections/Disjoint.java
+++ b/test/jdk/java/util/Collections/Disjoint.java
@@ -28,10 +28,9 @@
  * @author  Josh Bloch
  * @key randomness
  * @library /test/lib
- * @run main Disjoint
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,9 +75,9 @@ public class Disjoint {
             }
         }
 
-        List<Tuple> va = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2));
-        List<Tuple> vb = Arrays.asList(new Tuple(3, 3), new Tuple(4, 4));
-        List<Tuple> vc = Arrays.asList(new Tuple(2, 2), new Tuple(5, 5));
+        List<VClass> va = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }));
+        List<VClass> vb = Arrays.asList(new VClass(3, new int[] { 3 }), new VClass(4, new int[] { 4 }));
+        List<VClass> vc = Arrays.asList(new VClass(2, new int[] { 2 }), new VClass(5, new int[] { 5 }));
         if (!Collections.disjoint(va, vb)) throw new RuntimeException("value disjoint failed");
         if (Collections.disjoint(va, vc)) throw new RuntimeException("value non-disjoint failed");
     }

--- a/test/jdk/java/util/Collections/Disjoint.java
+++ b/test/jdk/java/util/Collections/Disjoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,13 @@
  * @summary Basic test for Collections.disjoint
  * @author  Josh Bloch
  * @key randomness
+ * @library /test/lib
+ * @run main Disjoint
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -71,5 +75,11 @@ public class Disjoint {
                     throw new RuntimeException("C: " + i + ", " + j);
             }
         }
+
+        List<Tuple> va = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2));
+        List<Tuple> vb = Arrays.asList(new Tuple(3, 3), new Tuple(4, 4));
+        List<Tuple> vc = Arrays.asList(new Tuple(2, 2), new Tuple(5, 5));
+        if (!Collections.disjoint(va, vb)) throw new RuntimeException("value disjoint failed");
+        if (Collections.disjoint(va, vc)) throw new RuntimeException("value non-disjoint failed");
     }
 }

--- a/test/jdk/java/util/Collections/Enum.java
+++ b/test/jdk/java/util/Collections/Enum.java
@@ -26,10 +26,9 @@
  * @bug 4323074
  * @summary Basic test for new Enumeration -> List converter
  * @library /test/lib
- * @run main Enum
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
@@ -50,9 +49,9 @@ public class Enum {
                 throw new Exception("Copy failed: "+size);
         }
 
-        Vector<Tuple> vv = new Vector<>();
-        for (int j = 0; j < SIZE; j++) vv.add(new Tuple(j, j));
-        List<Tuple> vl = Collections.list(vv.elements());
+        Vector<VClass> vv = new Vector<>();
+        for (int j = 0; j < SIZE; j++) vv.add(new VClass(j, new int[] { j }));
+        List<VClass> vl = Collections.list(vv.elements());
         if (!vl.equals(vv))
             throw new RuntimeException("value Enumeration -> List failed");
     }

--- a/test/jdk/java/util/Collections/Enum.java
+++ b/test/jdk/java/util/Collections/Enum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,19 @@
  * @test
  * @bug 4323074
  * @summary Basic test for new Enumeration -> List converter
+ * @library /test/lib
+ * @run main Enum
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
 public class Enum {
+
+    static final int SIZE = 10;
+
     public static void main(String[] args) throws Exception {
         int[] sizes = {0, 10, 100};
         for (int i=0; i<sizes.length; i++) {
@@ -43,5 +49,11 @@ public class Enum {
             if (!l.equals(v))
                 throw new Exception("Copy failed: "+size);
         }
+
+        Vector<Tuple> vv = new Vector<>();
+        for (int j = 0; j < SIZE; j++) vv.add(new Tuple(j, j));
+        List<Tuple> vl = Collections.list(vv.elements());
+        if (!vl.equals(vv))
+            throw new RuntimeException("value Enumeration -> List failed");
     }
 }

--- a/test/jdk/java/util/Collections/EnumerationAsIterator.java
+++ b/test/jdk/java/util/Collections/EnumerationAsIterator.java
@@ -29,7 +29,7 @@
  * @run testng EnumerationAsIterator
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -117,8 +117,8 @@ public class EnumerationAsIterator {
                Arrays.asList("a", "b", "c")),
 
             of("Value Collections.enumeration()",
-               () -> Collections.enumeration(Arrays.asList(new Tuple(1, 1), new Tuple(2, 2))),
-               Arrays.asList(new Tuple(1, 1), new Tuple(2, 2)))
+               () -> Collections.enumeration(Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }))),
+               Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 })))
         ).iterator();
     }
 

--- a/test/jdk/java/util/Collections/EnumerationAsIterator.java
+++ b/test/jdk/java/util/Collections/EnumerationAsIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,11 @@
  * @test
  * @bug 8072726
  * @summary Tests for Enumeration-to-Iterator conversion.
+ * @library /test/lib
  * @run testng EnumerationAsIterator
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -46,6 +48,7 @@ import static org.testng.Assert.*;
 
 @Test
 public class EnumerationAsIterator {
+
     static Object[] of(String description, Supplier<Enumeration<?>> s, Collection<?> exp) {
         return new Object[]{description, s, exp};
     }
@@ -111,7 +114,11 @@ public class EnumerationAsIterator {
 
             of("Arrays.asList(...)",
                Arrays.asList("a", "b", "c"),
-               Arrays.asList("a", "b", "c"))
+               Arrays.asList("a", "b", "c")),
+
+            of("Value Collections.enumeration()",
+               () -> Collections.enumeration(Arrays.asList(new Tuple(1, 1), new Tuple(2, 2))),
+               Arrays.asList(new Tuple(1, 1), new Tuple(2, 2)))
         ).iterator();
     }
 

--- a/test/jdk/java/util/Collections/FindSubList.java
+++ b/test/jdk/java/util/Collections/FindSubList.java
@@ -26,10 +26,9 @@
  * @bug 4323074
  * @summary Basic test for Collections.indexOfSubList/lastIndexOfSubList
  * @library /test/lib
- * @run main FindSubList
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -108,8 +107,8 @@ public class FindSubList {
               throw new Exception(s.getClass()+" lastIndexOfSubList: big tgt");
         }
 
-        List<Tuple> vsource = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3), new Tuple(2, 2), new Tuple(3, 3));
-        List<Tuple> vtarget = Arrays.asList(new Tuple(2, 2), new Tuple(3, 3));
+        List<VClass> vsource = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 }), new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 }));
+        List<VClass> vtarget = Arrays.asList(new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 }));
         if (Collections.indexOfSubList(vsource, vtarget) != 1)
             throw new Exception("value indexOfSubList failed");
         if (Collections.lastIndexOfSubList(vsource, vtarget) != 3)

--- a/test/jdk/java/util/Collections/FindSubList.java
+++ b/test/jdk/java/util/Collections/FindSubList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
  * @test
  * @bug 4323074
  * @summary Basic test for Collections.indexOfSubList/lastIndexOfSubList
+ * @library /test/lib
+ * @run main FindSubList
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +38,7 @@ import java.util.List;
 import java.util.Vector;
 
 public class FindSubList {
+
     public static void main(String[] args) throws Exception {
         int N = 500;
         List source = new ArrayList(3 * N);
@@ -103,5 +107,12 @@ public class FindSubList {
                                                                  "0")) != -1)
               throw new Exception(s.getClass()+" lastIndexOfSubList: big tgt");
         }
+
+        List<Tuple> vsource = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3), new Tuple(2, 2), new Tuple(3, 3));
+        List<Tuple> vtarget = Arrays.asList(new Tuple(2, 2), new Tuple(3, 3));
+        if (Collections.indexOfSubList(vsource, vtarget) != 1)
+            throw new Exception("value indexOfSubList failed");
+        if (Collections.lastIndexOfSubList(vsource, vtarget) != 3)
+            throw new Exception("value lastIndexOfSubList failed");
     }
 }

--- a/test/jdk/java/util/Collections/Frequency.java
+++ b/test/jdk/java/util/Collections/Frequency.java
@@ -27,10 +27,9 @@
  * @summary Basic test for Collections.frequency
  * @author  Josh Bloch
  * @library /test/lib
- * @run main Frequency
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -57,13 +56,13 @@ public class Frequency {
     }
 
     static void testValue() {
-        List<Tuple> values = new ArrayList<>();
+        List<VClass> values = new ArrayList<>();
         for (int i = 0; i < N; i++)
             for (int j = 0; j < i; j++)
-                values.add(new Tuple(i, i));
+                values.add(new VClass(i, new int[] { i }));
         Collections.shuffle(values);
         for (int i = 0; i < N; i++)
-            if (Collections.frequency(values, new Tuple(i, i)) != i)
+            if (Collections.frequency(values, new VClass(i, new int[] { i })) != i)
                 throw new RuntimeException("value frequency: " + i);
     }
 }

--- a/test/jdk/java/util/Collections/Frequency.java
+++ b/test/jdk/java/util/Collections/Frequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug     4193200
  * @summary Basic test for Collections.frequency
  * @author  Josh Bloch
+ * @library /test/lib
+ * @run main Frequency
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -35,9 +38,11 @@ import java.util.List;
 
 public class Frequency {
     static final int N = 100;
+
     public static void main(String[] args) {
         test(new ArrayList<Integer>());
         test(new LinkedList<Integer>());
+        testValue();
     }
 
     static void test(List<Integer> list) {
@@ -49,5 +54,16 @@ public class Frequency {
         for (int i = 0; i < N; i++)
             if (Collections.frequency(list, i) != i)
                 throw new RuntimeException(list.getClass() + ": " + i);
+    }
+
+    static void testValue() {
+        List<Tuple> values = new ArrayList<>();
+        for (int i = 0; i < N; i++)
+            for (int j = 0; j < i; j++)
+                values.add(new Tuple(i, i));
+        Collections.shuffle(values);
+        for (int i = 0; i < N; i++)
+            if (Collections.frequency(values, new Tuple(i, i)) != i)
+                throw new RuntimeException("value frequency: " + i);
     }
 }

--- a/test/jdk/java/util/Collections/NCopies.java
+++ b/test/jdk/java/util/Collections/NCopies.java
@@ -27,10 +27,9 @@
  * @summary Test Collections.nCopies
  * @author  Martin Buchholz
  * @library /test/lib
- * @run main NCopies
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.AbstractList;
@@ -146,11 +145,11 @@ public class NCopies {
     }
 
     private static void checkValueCopies() {
-        List<Tuple> copies = Collections.nCopies(10, new Tuple(7, 7));
-        check(copies.indexOf(new Tuple(7, 7)) == 0);
-        check(copies.lastIndexOf(new Tuple(7, 7)) == 9);
-        check(copies.equals(referenceNCopies(10, new Tuple(7, 7))));
-        check(copies.hashCode() == referenceNCopies(10, new Tuple(7, 7)).hashCode());
+        List<VClass> copies = Collections.nCopies(10, new VClass(7, new int[] { 7 }));
+        check(copies.indexOf(new VClass(7, new int[] { 7 })) == 0);
+        check(copies.lastIndexOf(new VClass(7, new int[] { 7 })) == 9);
+        check(copies.equals(referenceNCopies(10, new VClass(7, new int[] { 7 }))));
+        check(copies.hashCode() == referenceNCopies(10, new VClass(7, new int[] { 7 })).hashCode());
         check(copies.equals(copies.reversed()));
     }
 

--- a/test/jdk/java/util/Collections/NCopies.java
+++ b/test/jdk/java/util/Collections/NCopies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug     6267846 6275009
  * @summary Test Collections.nCopies
  * @author  Martin Buchholz
+ * @library /test/lib
+ * @run main NCopies
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.AbstractList;
@@ -142,6 +145,15 @@ public class NCopies {
         check(empty.equals(empty.reversed()));
     }
 
+    private static void checkValueCopies() {
+        List<Tuple> copies = Collections.nCopies(10, new Tuple(7, 7));
+        check(copies.indexOf(new Tuple(7, 7)) == 0);
+        check(copies.lastIndexOf(new Tuple(7, 7)) == 9);
+        check(copies.equals(referenceNCopies(10, new Tuple(7, 7))));
+        check(copies.hashCode() == referenceNCopies(10, new Tuple(7, 7)).hashCode());
+        check(copies.equals(copies.reversed()));
+    }
+
     public static void main(String[] args) {
         try {
             List<String> empty = Collections.nCopies(0, "foo");
@@ -157,6 +169,8 @@ public class NCopies {
             checkEquals();
 
             checkReversed();
+
+            checkValueCopies();
 
         } catch (Throwable t) { unexpected(t); }
 

--- a/test/jdk/java/util/Collections/NullComparator.java
+++ b/test/jdk/java/util/Collections/NullComparator.java
@@ -26,10 +26,9 @@
  * @bug 4224271
  * @summary A null Comparator is now specified to indicate natural ordering.
  * @library /test/lib
- * @run main NullComparator
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -66,17 +65,17 @@ public class NullComparator {
         if (!Collections.max(list, null).equals(new Integer(99)))
             throw new Exception("Collections.max");
 
-        List<Tuple> vlist = new ArrayList<>();
-        for (int i = 0; i < 100; i++) vlist.add(new Tuple(i, i));
+        List<VClass> vlist = new ArrayList<>();
+        for (int i = 0; i < 100; i++) vlist.add(new VClass(i, new int[] { i }));
         Collections.shuffle(vlist);
         Collections.sort(vlist, null);
         for (int i = 0; i < 100; i++)
-            if (!vlist.get(i).equals(new Tuple(i, i))) throw new Exception("value Collections.sort");
-        if (Collections.binarySearch(vlist, new Tuple(69, 69), null) != 69)
+            if (!vlist.get(i).equals(new VClass(i, new int[] { i }))) throw new Exception("value Collections.sort");
+        if (Collections.binarySearch(vlist, new VClass(69, new int[] { 69 }), null) != 69)
             throw new Exception("value binarySearch");
-        if (!Collections.min(vlist, null).equals(new Tuple(0, 0)))
+        if (!Collections.min(vlist, null).equals(new VClass(0, new int[] { 0 })))
             throw new Exception("value min");
-        if (!Collections.max(vlist, null).equals(new Tuple(99, 99)))
+        if (!Collections.max(vlist, null).equals(new VClass(99, new int[] { 99 })))
             throw new Exception("value max");
     }
 }

--- a/test/jdk/java/util/Collections/NullComparator.java
+++ b/test/jdk/java/util/Collections/NullComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,18 @@
  * @test
  * @bug 4224271
  * @summary A null Comparator is now specified to indicate natural ordering.
+ * @library /test/lib
+ * @run main NullComparator
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class NullComparator {
+
     public static void main(String[] args) throws Exception {
         List list = new ArrayList(100);
         for (int i=0; i<100; i++)
@@ -61,5 +65,18 @@ public class NullComparator {
             throw new Exception("Collections.min");
         if (!Collections.max(list, null).equals(new Integer(99)))
             throw new Exception("Collections.max");
+
+        List<Tuple> vlist = new ArrayList<>();
+        for (int i = 0; i < 100; i++) vlist.add(new Tuple(i, i));
+        Collections.shuffle(vlist);
+        Collections.sort(vlist, null);
+        for (int i = 0; i < 100; i++)
+            if (!vlist.get(i).equals(new Tuple(i, i))) throw new Exception("value Collections.sort");
+        if (Collections.binarySearch(vlist, new Tuple(69, 69), null) != 69)
+            throw new Exception("value binarySearch");
+        if (!Collections.min(vlist, null).equals(new Tuple(0, 0)))
+            throw new Exception("value min");
+        if (!Collections.max(vlist, null).equals(new Tuple(99, 99)))
+            throw new Exception("value max");
     }
 }

--- a/test/jdk/java/util/Collections/ReplaceAll.java
+++ b/test/jdk/java/util/Collections/ReplaceAll.java
@@ -26,10 +26,9 @@
  * @bug 4323074
  * @summary Basic test for new replaceAll algorithm
  * @library /test/lib
- * @run main ReplaceAll
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -61,11 +60,11 @@ public class ReplaceAll {
                 throw new Exception("True return value: "+i);
         }
 
-        List<Tuple> values = new ArrayList<>();
-        for (int j = 1; j <= SIZE; j++) values.add(new Tuple(j % 3, j % 3));
-        if (!Collections.replaceAll(values, new Tuple(1, 1), new Tuple(99, 99)))
+        List<VClass> values = new ArrayList<>();
+        for (int j = 1; j <= SIZE; j++) values.add(new VClass(j % 3, new int[] { j % 3 }));
+        if (!Collections.replaceAll(values, new VClass(1, new int[] { 1 }), new VClass(99, new int[] { 99 })))
             throw new Exception("value false return");
-        if (Collections.replaceAll(values, new Tuple(100, 100), new Tuple(0, 0)))
+        if (Collections.replaceAll(values, new VClass(100, new int[] { 100 }), new VClass(0, new int[] { 0 })))
             throw new Exception("value true return for absent element");
     }
 }

--- a/test/jdk/java/util/Collections/ReplaceAll.java
+++ b/test/jdk/java/util/Collections/ReplaceAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
  * @test
  * @bug 4323074
  * @summary Basic test for new replaceAll algorithm
+ * @library /test/lib
+ * @run main ReplaceAll
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -57,5 +60,12 @@ public class ReplaceAll {
             if (Collections.replaceAll(lst, "love", "hate"))
                 throw new Exception("True return value: "+i);
         }
+
+        List<Tuple> values = new ArrayList<>();
+        for (int j = 1; j <= SIZE; j++) values.add(new Tuple(j % 3, j % 3));
+        if (!Collections.replaceAll(values, new Tuple(1, 1), new Tuple(99, 99)))
+            throw new Exception("value false return");
+        if (Collections.replaceAll(values, new Tuple(100, 100), new Tuple(0, 0)))
+            throw new Exception("value true return for absent element");
     }
 }

--- a/test/jdk/java/util/Collections/ReverseOrder.java
+++ b/test/jdk/java/util/Collections/ReverseOrder.java
@@ -27,10 +27,9 @@
  * @summary Reverse comparator was subtly broken
  * @author Josh Bloch
  * @library /test/lib
- * @run main ReverseOrder
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -84,9 +83,9 @@ public class ReverseOrder {
         if (!list2.equals(goldenList))
             throw new Exception(list.toString());
 
-        List<Tuple> vl = Arrays.asList(new Tuple(1, 1), new Tuple(3, 3), new Tuple(2, 2));
+        List<VClass> vl = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(3, new int[] { 3 }), new VClass(2, new int[] { 2 }));
         Collections.sort(vl, Collections.reverseOrder());
-        if (!vl.equals(Arrays.asList(new Tuple(3, 3), new Tuple(2, 2), new Tuple(1, 1))))
+        if (!vl.equals(Arrays.asList(new VClass(3, new int[] { 3 }), new VClass(2, new int[] { 2 }), new VClass(1, new int[] { 1 }))))
             throw new RuntimeException("value reverseOrder failed");
     }
 }

--- a/test/jdk/java/util/Collections/ReverseOrder.java
+++ b/test/jdk/java/util/Collections/ReverseOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug 4593209 8001667
  * @summary Reverse comparator was subtly broken
  * @author Josh Bloch
+ * @library /test/lib
+ * @run main ReverseOrder
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -38,6 +41,7 @@ import java.util.Comparator;
 import java.util.List;
 
 public class ReverseOrder {
+
     static byte[] serialBytes(Object o) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -79,6 +83,11 @@ public class ReverseOrder {
         Collections.sort(list2, clone);
         if (!list2.equals(goldenList))
             throw new Exception(list.toString());
+
+        List<Tuple> vl = Arrays.asList(new Tuple(1, 1), new Tuple(3, 3), new Tuple(2, 2));
+        Collections.sort(vl, Collections.reverseOrder());
+        if (!vl.equals(Arrays.asList(new Tuple(3, 3), new Tuple(2, 2), new Tuple(1, 1))))
+            throw new RuntimeException("value reverseOrder failed");
     }
 }
 

--- a/test/jdk/java/util/Collections/ReverseOrder2.java
+++ b/test/jdk/java/util/Collections/ReverseOrder2.java
@@ -27,10 +27,9 @@
  * @summary Basic test for Collections.reverseOrder
  * @author  Josh Bloch, Martin Buchholz
  * @library /test/lib
- * @run main ReverseOrder2
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -71,10 +70,10 @@ public class ReverseOrder2 {
         test2(new ArrayList<Integer>());
         test2(new LinkedList<Integer>());
 
-        List<Tuple> values = new ArrayList<>(Arrays.asList(new Tuple(0, 0), new Tuple(1, 1), new Tuple(2, 2)));
+        List<VClass> values = new ArrayList<>(Arrays.asList(new VClass(0, new int[] { 0 }), new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 })));
         Collections.shuffle(values);
         Collections.sort(values, Collections.reverseOrder());
-        if (!values.equals(Arrays.asList(new Tuple(2, 2), new Tuple(1, 1), new Tuple(0, 0))))
+        if (!values.equals(Arrays.asList(new VClass(2, new int[] { 2 }), new VClass(1, new int[] { 1 }), new VClass(0, new int[] { 0 }))))
             throw new RuntimeException("value reverseOrder2 failed");
     }
 

--- a/test/jdk/java/util/Collections/ReverseOrder2.java
+++ b/test/jdk/java/util/Collections/ReverseOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug     4809442 6366832 4974878 6372554 4890211 6483125
  * @summary Basic test for Collections.reverseOrder
  * @author  Josh Bloch, Martin Buchholz
+ * @library /test/lib
+ * @run main ReverseOrder2
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,6 +38,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -66,6 +70,12 @@ public class ReverseOrder2 {
         test(new LinkedList<String>());
         test2(new ArrayList<Integer>());
         test2(new LinkedList<Integer>());
+
+        List<Tuple> values = new ArrayList<>(Arrays.asList(new Tuple(0, 0), new Tuple(1, 1), new Tuple(2, 2)));
+        Collections.shuffle(values);
+        Collections.sort(values, Collections.reverseOrder());
+        if (!values.equals(Arrays.asList(new Tuple(2, 2), new Tuple(1, 1), new Tuple(0, 0))))
+            throw new RuntimeException("value reverseOrder2 failed");
     }
 
     static void test(List<String> list) {

--- a/test/jdk/java/util/Collections/Rotate.java
+++ b/test/jdk/java/util/Collections/Rotate.java
@@ -27,10 +27,9 @@
  * @summary Basic test for new rotate algorithm
  * @key randomness
  * @library /test/lib
- * @run main Rotate
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,9 +73,9 @@ public class Rotate {
             }
         }
 
-        List<Tuple> vl = new ArrayList<>(Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3), new Tuple(4, 4)));
+        List<VClass> vl = new ArrayList<>(Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 }), new VClass(4, new int[] { 4 })));
         Collections.rotate(vl, 1);
-        if (!vl.equals(Arrays.asList(new Tuple(4, 4), new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3))))
+        if (!vl.equals(Arrays.asList(new VClass(4, new int[] { 4 }), new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 }))))
             throw new RuntimeException("value rotate failed");
     }
 }

--- a/test/jdk/java/util/Collections/Rotate.java
+++ b/test/jdk/java/util/Collections/Rotate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,13 @@
  * @bug 4323074
  * @summary Basic test for new rotate algorithm
  * @key randomness
+ * @library /test/lib
+ * @run main Rotate
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -69,5 +73,10 @@ public class Rotate {
                                             ", should be "+index);
             }
         }
+
+        List<Tuple> vl = new ArrayList<>(Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3), new Tuple(4, 4)));
+        Collections.rotate(vl, 1);
+        if (!vl.equals(Arrays.asList(new Tuple(4, 4), new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3))))
+            throw new RuntimeException("value rotate failed");
     }
 }

--- a/test/jdk/java/util/Collections/Ser.java
+++ b/test/jdk/java/util/Collections/Ser.java
@@ -27,7 +27,6 @@
  * @summary EMPTY_SET, EMPTY_LIST, and the collections returned by
  *          nCopies and singleton were spec'd to be serializable, but weren't.
  * @library /test/lib
- * @run main Ser
  */
 
 import jdk.test.lib.valueclass.AsValueClass;

--- a/test/jdk/java/util/Collections/Ser.java
+++ b/test/jdk/java/util/Collections/Ser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +26,36 @@
  * @bug 4190323
  * @summary EMPTY_SET, EMPTY_LIST, and the collections returned by
  *          nCopies and singleton were spec'd to be serializable, but weren't.
+ * @library /test/lib
+ * @run main Ser
  */
 
+import jdk.test.lib.valueclass.AsValueClass;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 public class Ser {
+
+    @AsValueClass
+    static class SerV implements Serializable {
+        int x;
+        SerV(int x) { this.x = x; }
+        public boolean equals(Object o) { return o instanceof SerV v && x == v.x; }
+        public int hashCode() { return x; }
+        private Object writeReplace() { return new SerProxy(x); }
+        private static class SerProxy implements Serializable {
+            int x;
+            SerProxy(int x) { this.x = x; }
+            private Object readResolve() { return new SerV(x); }
+        }
+    }
+
     public static void main(String[] args) throws Exception {
 
         try {
@@ -95,6 +114,34 @@ public class Ser {
                 throw new RuntimeException("nCopies Ser/Deser failure.");
         } catch (Exception e) {
             throw new RuntimeException("Failed to serialize nCopies:" + e);
+        }
+
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream out = new ObjectOutputStream(bos);
+            Set<SerV> one = Collections.singleton(new SerV(1));
+            out.writeObject(one);
+            out.flush();
+            ObjectInputStream in = new ObjectInputStream(
+                    new ByteArrayInputStream(bos.toByteArray()));
+            if (!one.equals(in.readObject()))
+                throw new RuntimeException("value singleton Ser/Deser failure");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize value singleton: " + e);
+        }
+
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream out = new ObjectOutputStream(bos);
+            List<SerV> many = Collections.nCopies(5, new SerV(2));
+            out.writeObject(many);
+            out.flush();
+            ObjectInputStream in = new ObjectInputStream(
+                    new ByteArrayInputStream(bos.toByteArray()));
+            if (!many.equals(in.readObject()))
+                throw new RuntimeException("value nCopies Ser/Deser failure");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize value nCopies: " + e);
         }
     }
 }

--- a/test/jdk/java/util/Collections/Ser.java
+++ b/test/jdk/java/util/Collections/Ser.java
@@ -43,7 +43,7 @@ import java.util.Set;
 public class Ser {
 
     @AsValueClass
-    static class SerV implements Serializable {
+    static final class SerV implements Serializable {
         int x;
         SerV(int x) { this.x = x; }
         public boolean equals(Object o) { return o instanceof SerV v && x == v.x; }

--- a/test/jdk/java/util/Collections/Shuffle.java
+++ b/test/jdk/java/util/Collections/Shuffle.java
@@ -27,10 +27,9 @@
  * @summary Basic test for Collections.shuffle
  * @key     randomness
  * @library /test/lib
- * @run main Shuffle
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -67,12 +66,12 @@ public class Shuffle {
     }
 
     static void testValue() {
-        List<Tuple> values = new ArrayList<>();
-        for (int i = 0; i < N; i++) values.add(new Tuple(i, i));
+        List<VClass> values = new ArrayList<>();
+        for (int i = 0; i < N; i++) values.add(new VClass(i, new int[] { i }));
         Collections.shuffle(values, new Random(1));
         if (values.size() != N) throw new RuntimeException("value shuffle size");
         for (int i = 0; i < N; i++)
-            if (Collections.frequency(values, new Tuple(i, i)) != 1)
+            if (Collections.frequency(values, new VClass(i, new int[] { i })) != 1)
                 throw new RuntimeException("value shuffle lost " + i);
     }
 

--- a/test/jdk/java/util/Collections/Shuffle.java
+++ b/test/jdk/java/util/Collections/Shuffle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug     8294693
  * @summary Basic test for Collections.shuffle
  * @key     randomness
+ * @library /test/lib
+ * @run main Shuffle
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -42,6 +45,7 @@ public class Shuffle {
     public static void main(String[] args) {
         test(new ArrayList<>());
         test(new LinkedList<>());
+        testValue();
     }
 
     static void test(List<Integer> list) {
@@ -60,6 +64,16 @@ public class Shuffle {
         checkRandom(list, l -> Collections.shuffle(l, new Random(1)));
         RandomGenerator.JumpableGenerator generator = RandomGenerator.JumpableGenerator.of("Xoshiro256PlusPlus");
         checkRandom(list, l -> Collections.shuffle(l, generator.copy()));
+    }
+
+    static void testValue() {
+        List<Tuple> values = new ArrayList<>();
+        for (int i = 0; i < N; i++) values.add(new Tuple(i, i));
+        Collections.shuffle(values, new Random(1));
+        if (values.size() != N) throw new RuntimeException("value shuffle size");
+        for (int i = 0; i < N; i++)
+            if (Collections.frequency(values, new Tuple(i, i)) != 1)
+                throw new RuntimeException("value shuffle lost " + i);
     }
 
     private static void checkRandom(List<Integer> list, Consumer<List<?>> randomizer) {

--- a/test/jdk/java/util/Collections/SingletonIterator.java
+++ b/test/jdk/java/util/Collections/SingletonIterator.java
@@ -28,7 +28,7 @@
  * @run testng SingletonIterator
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -67,10 +67,10 @@ public class SingletonIterator {
 
     @Test
     public void testValueSingletonIterator() {
-        Iterator<Tuple> it = Collections.singleton(new Tuple(42, 42)).iterator();
+        Iterator<VClass> it = Collections.singleton(new VClass(42, new int[] { 42 })).iterator();
         AtomicInteger cnt = new AtomicInteger(0);
         it.forEachRemaining(v -> {
-            if (!v.equals(new Tuple(42, 42))) throw new RuntimeException("wrong value");
+            if (!v.equals(new VClass(42, new int[] { 42 }))) throw new RuntimeException("wrong value");
             cnt.incrementAndGet();
         });
         assertEquals(cnt.get(), 1);

--- a/test/jdk/java/util/Collections/SingletonIterator.java
+++ b/test/jdk/java/util/Collections/SingletonIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,11 @@
 /*
  * @test
  * @bug 8024500 8166446
+ * @library /test/lib
  * @run testng SingletonIterator
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -62,6 +64,18 @@ public class SingletonIterator {
     }
 
     static class SingletonException extends RuntimeException { }
+
+    @Test
+    public void testValueSingletonIterator() {
+        Iterator<Tuple> it = Collections.singleton(new Tuple(42, 42)).iterator();
+        AtomicInteger cnt = new AtomicInteger(0);
+        it.forEachRemaining(v -> {
+            if (!v.equals(new Tuple(42, 42))) throw new RuntimeException("wrong value");
+            cnt.incrementAndGet();
+        });
+        assertEquals(cnt.get(), 1);
+        assertIteratorExhausted(it);
+    }
 
     public void testThrowFromForEachRemaining() {
         Iterator<String> it = Collections.singleton("TheOne").iterator();

--- a/test/jdk/java/util/Collections/Swap.java
+++ b/test/jdk/java/util/Collections/Swap.java
@@ -27,10 +27,9 @@
  * @summary Basic test for newly public swap algorithm
  * @author  Josh Bloch
  * @library /test/lib
- * @run main Swap
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,10 +48,10 @@ public class Swap {
         if (!l.equals(l2))
             throw new RuntimeException("Wrong result");
 
-        List<Tuple> vl = new ArrayList<>(Collections.nCopies(SIZE, new Tuple(0, 0)));
-        vl.set(0, new Tuple(1, 1));
+        List<VClass> vl = new ArrayList<>(Collections.nCopies(SIZE, new VClass(0, new int[] { 0 })));
+        vl.set(0, new VClass(1, new int[] { 1 }));
         for (int i = 0; i < SIZE - 1; i++) Collections.swap(vl, i, i + 1);
-        if (!vl.get(SIZE - 1).equals(new Tuple(1, 1)))
+        if (!vl.get(SIZE - 1).equals(new VClass(1, new int[] { 1 })))
             throw new RuntimeException("value swap failed");
     }
 }

--- a/test/jdk/java/util/Collections/Swap.java
+++ b/test/jdk/java/util/Collections/Swap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,11 @@
  * @bug     4323074
  * @summary Basic test for newly public swap algorithm
  * @author  Josh Bloch
+ * @library /test/lib
+ * @run main Swap
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -45,5 +48,11 @@ public class Swap {
         l2.set(SIZE-1, Boolean.TRUE);
         if (!l.equals(l2))
             throw new RuntimeException("Wrong result");
+
+        List<Tuple> vl = new ArrayList<>(Collections.nCopies(SIZE, new Tuple(0, 0)));
+        vl.set(0, new Tuple(1, 1));
+        for (int i = 0; i < SIZE - 1; i++) Collections.swap(vl, i, i + 1);
+        if (!vl.get(SIZE - 1).equals(new Tuple(1, 1)))
+            throw new RuntimeException("value swap failed");
     }
 }

--- a/test/jdk/java/util/Collections/T6433170.java
+++ b/test/jdk/java/util/Collections/T6433170.java
@@ -26,10 +26,9 @@
  * @bug 6433170
  * @summary CheckedCollection.addAll should be all-or-nothing
  * @library /test/lib
- * @run main T6433170
  */
 
-import jdk.test.lib.valueclass.Tuple;
+import jdk.test.lib.valueclass.VClass;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -61,8 +60,8 @@ public class T6433170 {
                  checkedCollection(new Vector(), String.class),
                  Object.class));
 
-        Collection<Tuple> vc = checkedCollection(new ArrayList<>(), Tuple.class);
-        List mixed = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), "not a Tuple");
+        Collection<VClass> vc = checkedCollection(new ArrayList<>(), VClass.class);
+        List mixed = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), "not a Tuple");
         THROWS(ClassCastException.class,
                new F(){void f(){ vc.addAll(mixed); }});
         checkEmpty(vc);

--- a/test/jdk/java/util/Collections/T6433170.java
+++ b/test/jdk/java/util/Collections/T6433170.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
  * @test
  * @bug 6433170
  * @summary CheckedCollection.addAll should be all-or-nothing
+ * @library /test/lib
+ * @run main T6433170
  */
 
+import jdk.test.lib.valueclass.Tuple;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,6 +43,7 @@ import static java.util.Collections.checkedSet;
 
 @SuppressWarnings("unchecked")
 public class T6433170 {
+
     private void checkEmpty(Collection x) {
         check(x.isEmpty());
         check(x.size() == 0);
@@ -56,6 +60,12 @@ public class T6433170 {
         test(checkedCollection(
                  checkedCollection(new Vector(), String.class),
                  Object.class));
+
+        Collection<Tuple> vc = checkedCollection(new ArrayList<>(), Tuple.class);
+        List mixed = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), "not a Tuple");
+        THROWS(ClassCastException.class,
+               new F(){void f(){ vc.addAll(mixed); }});
+        checkEmpty(vc);
     }
 
     void test(final Collection checked) {

--- a/test/lib/jdk/test/lib/valueclass/Tuple.java
+++ b/test/lib/jdk/test/lib/valueclass/Tuple.java
@@ -31,7 +31,7 @@ package jdk.test.lib.valueclass;
  * allowing the same tests to exercise both modes.
  */
 @AsValueClass
-public class Tuple implements Comparable<Tuple> {
+public final class Tuple implements Comparable<Tuple> {
     public int x;
     public int y;
     public Tuple(int x, int y) { this.x = x; this.y = y; }

--- a/test/lib/jdk/test/lib/valueclass/Tuple.java
+++ b/test/lib/jdk/test/lib/valueclass/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,31 +21,24 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 4528331 5006032
- * @summary Test Collections.binarySearch() with a null comparator
- * @library /test/lib
- * @run main BinarySearchNullComparator
+package jdk.test.lib.valueclass;
+
+/**
+ * A reusable value class helper for Collections tests.
+ * Wraps two ints (x, y), supports equality, ordering, and hashing.
+ * When compiled with -Xplugin:ValueClassPlugin --enable-preview this class
+ * is treated as a value class; otherwise it is a plain identity class,
+ * allowing the same tests to exercise both modes.
  */
-
-import jdk.test.lib.valueclass.Tuple;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-public class BinarySearchNullComparator {
-
-    public static void main(String[] args) throws Exception {
-        List list = Arrays.asList(new String[] {"I", "Love", "You"});
-
-        int result = Collections.binarySearch(list, "You", null);
-        if (result != 2)
-            throw new Exception("Result: " + result);
-
-        List<Tuple> values = Arrays.asList(new Tuple(1, 1), new Tuple(2, 2), new Tuple(3, 3));
-        int vresult = Collections.binarySearch(values, new Tuple(3, 3), null);
-        if (vresult != 2)
-            throw new Exception("Value result: " + vresult);
+@AsValueClass
+public class Tuple implements Comparable<Tuple> {
+    public int x;
+    public int y;
+    public Tuple(int x, int y) { this.x = x; this.y = y; }
+    public int compareTo(Tuple other) {
+        int cmp = Integer.compare(x, other.x);
+        return cmp != 0 ? cmp : Integer.compare(y, other.y);
     }
+    public boolean equals(Object o) { return o instanceof Tuple t && x == t.x && y == t.y; }
+    public int hashCode() { return 31 * x + y; }
 }

--- a/test/lib/jdk/test/lib/valueclass/VClass.java
+++ b/test/lib/jdk/test/lib/valueclass/VClass.java
@@ -23,22 +23,24 @@
 
 package jdk.test.lib.valueclass;
 
+import java.util.Arrays;
+
 /**
  * A reusable value class helper for Collections tests.
- * Wraps two ints (x, y), supports equality, ordering, and hashing.
+ * Wraps an int and an int array (x, arr), supports equality, ordering, and hashing.
  * When compiled with -Xplugin:ValueClassPlugin --enable-preview this class
  * is treated as a value class; otherwise it is a plain identity class,
  * allowing the same tests to exercise both modes.
  */
 @AsValueClass
-public final class Tuple implements Comparable<Tuple> {
+public final class VClass implements Comparable<VClass> {
     public int x;
-    public int y;
-    public Tuple(int x, int y) { this.x = x; this.y = y; }
-    public int compareTo(Tuple other) {
+    public int[] arr;
+    public VClass(int x, int[] arr) { this.x = x; this.arr = arr; }
+    public int compareTo(VClass other) {
         int cmp = Integer.compare(x, other.x);
-        return cmp != 0 ? cmp : Integer.compare(y, other.y);
+        return cmp != 0 ? cmp : Arrays.compare(arr, other.arr);
     }
-    public boolean equals(Object o) { return o instanceof Tuple t && x == t.x && y == t.y; }
-    public int hashCode() { return 31 * x + y; }
+    public boolean equals(Object o) { return o instanceof VClass t && x == t.x && Arrays.equals(arr, t.arr); }
+    public int hashCode() { return 31 * x + Arrays.hashCode(arr); }
 }


### PR DESCRIPTION
**Tests Updated**

**TEST.groups**
Add java/util/Collections to valhalla_adopted.

**test/lib**
Introduces a shared jdk.test.lib.valueclass.Tuple value class (two-int, Comparable, with equals/hashCode).

**AddAll.java**
Broaden the existing @AsValueClass Point path to cover the same collection types (LinkedList, HashSet, LinkedHashSet) and verify final contents using value equality.

**AsLifoQueue.java** 
Add a parallel LIFO-order block with value-class elements exercising the same add/peek/remove/poll operations.

**BigBinarySearch.java**
Add a minimal comparable value class backed by the existing sparse-list structure to verify huge binary search without new edge cases.

**BinarySearchNullComparator.java**
Add a comparable value-class list and confirm that a null comparator falls back to natural ordering correctly.

**CheckedListBash.java**
Add a checkedList(…, V.class) helper covering insert, contains/indexOf/toArray, and wrong-type raw-add rejection.

**CheckedListReplaceAll.java**
Verify that replaceAll on a checked value list accepts correct-type results and throws ClassCastException for wrong-type results.

**CheckedMapBash.java**
Add a value-key/value checked-map smoke path covering put/containsKey/containsValue/equals and raw wrong-type put rejection.

**CheckedMapReplaceAll.java**
Verify that Map.replaceAll on a checked value map accepts correct-type values and rejects wrong-type values.

**CheckedQueue.java**
Add a checkedQueue(…, V.class) block covering add/peek and wrong-type raw-add rejection.

**CheckedSetBash.java** 
Add a checked value-class set helper covering add/contains/remove, equality with a copy, and wrong-type raw-add rejection.

**Disjoint.java** 
Add overlapping and non-overlapping value-class collections to confirm that disjoint uses value-state equality.

**Enum.java** 
Add a value-class Vector<V> and assert that Collections.list produces an equal list in original order.

**EnumerationAsIterator.java** 
Add one value-class data-provider case using Collections.enumeration(Arrays.asList(…)) and verify element delivery.

**FindSubList.java** 
Add value-class source and target lists and assert correct first and last sublist indices.

**Frequency.java** 
Add a value-class list with repeated separately constructed equal values and confirm that frequency counts by value-state equality.

**NCopies.java** 
Add value-class versions of the indexOf/lastIndexOf/equals/hashCode/reversed checks using a repeated value element.

**NullComparator.java** 
Add value-class comparable list checks for Collections.sort, binarySearch, min, and max with a null comparator.

**ReplaceAll.java** 
Add one value-class list case mirroring the integer path to confirm equality-based replacement of value objects.

**ReverseOrder.java** 
Duplicate the custom comparable payload as a value class and run the same reverse-order sort assertion.

**ReverseOrder2.java** 
Add a comparable value-class list to the existing sort/reverse-sort checks only.

**Rotate.java** 
Add a value-class list and assert the expected rotated order for the existing rotation distances.

**Ser.java**
Add value-object payload checks for the singleton and nCopies serialization round-trips, leaving empty-collection cases unchanged.

**Shuffle.java** 
Add a value-class list and verify that size and per-element frequency are preserved after shuffle.

**SingletonIterator.java** 
Add a Collections.singleton(new V(…)).iterator() forEachRemaining check delivering the value object exactly once.

**Swap.java** 
Add a value-class marker element and perform the same sequential adjacent swaps, asserting final position by value equality.

**T6433170.java**
Add a value-class checked collection with a mixed-type addAll input and assert all-or-nothing behavior on type rejection.

**Tests With No Change**

**CheckedIdentityMap.java** 
The test is specifically about identity-based entry equality in IdentityHashMap, which is the opposite of value-class semantics and would require inverted expectations.

**CheckedNull.java** 
Null acceptance/rejection behavior is unchanged by JEP 401, so value-class elements add no distinct coverage.

**DelegatingIteratorForEachRemaining.java** 
The test is about iterator delegation and NPE propagation by wrapper classes, where element type is entirely incidental.

**EmptyCollectionSerialization.java** 
Empty singleton collections have no element payload, and the test is identity-sensitive with respect to the collection object itself, not its contents.

**EmptyIterator.java** 
There are no elements, and the existing == assertions target singleton iterator instances rather than user element identity.

**EmptyNavigableMap.java** 
The map is always empty, so value-class key/value semantics cannot be observed.

**EmptyNavigableSet.java** 
Same as EmptyNavigableMap: no elements are present to exercise value-class equality or ordering.

**EqualsTest.java** 
The test is about infinite recursion in equals for cyclic self-containing wrapper graphs, not element value semantics.

**MinMax.java** 
The bug under test is a malicious collection misreporting its size during iteration, making element kind entirely irrelevant.

**RacingCollections.java** 
The coverage is concurrent structural mutation and wrapper robustness, and extending it with value elements would require inventing new stress logic rather than conservatively extending existing behavior.

**RotateEmpty.java** 
The list is always empty, so no value element can participate, and adding one would convert it into non-empty rotate coverage.

**RotateHuge.java** 
The bug concerns distance/size arithmetic overflow using placeholder objects, not element equality or identity.

**SetFromMap.java** 
The key scenario depends on IdentityHashMap distinguishing equal-but-non-identical objects, which is incompatible with value-class identity-free semantics.

**SyncListBash.java** 
The lock is the synchronized wrapper object itself, not the list elements, so value-class payloads cannot affect synchronization correctness.

**SyncSubMutexes.java** 
The test is explicitly about monitor/mutex identity across synchronized views, and value objects cannot serve as synchronization monitors under JEP 401.

**T5078378.java** 
The test is a compile-time raw/generic type-inference regression, and adding value classes would require preview source changes unrelated to the original compilation check.

**UnmodifiableMapEntrySet.java**
Mutation is attempted on Map.Entry wrapper objects, not on the key/value payload, so element type is irrelevant to the coverage.

**ViewSynch.java**
Like SyncSubMutexes, the behavior under test is monitor identity and locking across sorted-map views, not element semantics.

**WrappedNull.java**
The scenario tests null wrapper arguments with no valid element instances, so there is nothing to substitute with a value class.

**WrappedUnmodifiableCollections.java**
The test checks whether Collections.unmodifiable* elides redundant wrapping based on the wrapper object's identity, which is unaffected by element type.

**Wrappers.java**
This is a reflection test inspecting whether wrapper classes override default methods, making element type completely irrelevant.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383658](https://bugs.openjdk.org/browse/JDK-8383658): [lworld] Add value class test coverage to java.util.Collections (**Task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer) ⚠️ Review applies to [2bd89460](https://git.openjdk.org/valhalla/pull/2421/files/2bd8946080843d67287619e2f5f30f05b6a3edeb)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2421/head:pull/2421` \
`$ git checkout pull/2421`

Update a local copy of the PR: \
`$ git checkout pull/2421` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2421`

View PR using the GUI difftool: \
`$ git pr show -t 2421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2421.diff">https://git.openjdk.org/valhalla/pull/2421.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2421#issuecomment-4425064840)
</details>
