### PR TITLE
8384359: [lworld] ConstraintCastNode::Ideal should not push incompatible casts through InlineTypeNodes

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -118,7 +118,8 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Push cast through InlineTypeNode but be careful because in dead parts of the graph,
   // an InlineTypeNode can be casted to some completely unrelated type.
   InlineTypeNode* vt = in(1)->isa_InlineType();
-  if (vt != nullptr && vt->is_allocated(phase) && vt->type()->inline_klass()->is_subtype_of(_type->is_instptr()->instance_klass())) {
+  if (vt != nullptr && vt->is_allocated(phase) && _type->isa_instptr() != nullptr &&
+      vt->type()->inline_klass()->is_subtype_of(_type->is_instptr()->instance_klass())) {
     Node* cast = clone();
     cast->set_req(1, vt->get_oop());
     vt = vt->clone()->as_InlineType();

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -115,9 +115,10 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     return this;
   }
 
-  // Push cast through InlineTypeNode
+  // Push cast through InlineTypeNode but be careful because in dead parts of the graph,
+  // an InlineTypeNode can be casted to some completely unrelated type.
   InlineTypeNode* vt = in(1)->isa_InlineType();
-  if (vt != nullptr && vt->is_allocated(phase)) {
+  if (vt != nullptr && vt->is_allocated(phase) && vt->type()->inline_klass()->is_subtype_of(_type->is_instptr()->instance_klass())) {
     Node* cast = clone();
     cast->set_req(1, vt->get_oop());
     vt = vt->clone()->as_InlineType();

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -1220,6 +1220,7 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* oop = get_oop();
   if (oop->isa_InlineType() && !phase->type(oop)->maybe_null()) {
     InlineTypeNode* vtptr = oop->as_InlineType();
+    assert(inline_klass() == vtptr->inline_klass(), "inconsistent types");
     set_oop(*phase, vtptr->get_oop());
     set_is_buffered(*phase);
     set_null_marker(*phase);


### PR DESCRIPTION
The problem is that we are pushing casts through InlineTypeNodes without checking if their types are even compatible. In dead parts of the graph, when a type check wasn't folded yet, the type of the CheckCastPP can be completely unrelated to the type of the InlineTypeNode. Pushing the cast through leads to an incorrect type being used further below in the graph and subsequent failures.

I tried hard to come up with standalone reproducer for this but failed. It reproduces reliably with replay compilation though.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384359](https://bugs.openjdk.org/browse/JDK-8384359): [lworld] ConstraintCastNode::Ideal should not push incompatible casts through InlineTypeNodes (**Bug** - P2)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2423/head:pull/2423` \
`$ git checkout pull/2423`

Update a local copy of the PR: \
`$ git checkout pull/2423` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2423`

View PR using the GUI difftool: \
`$ git pr show -t 2423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2423.diff">https://git.openjdk.org/valhalla/pull/2423.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2423#issuecomment-4430645745)
</details>
