### PR TITLE
8384431: [lworld] Adjust tests affected by JDK-8370769

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFlatteningBudget.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFlatteningBudget.java
@@ -30,6 +30,7 @@
  * @enablePreview
  * @requires vm.opt.UseFieldFlattening != "false"
  * @requires vm.opt.UseNullableAtomicValueFlattening != "false"
+ * @requires vm.compMode != "Xcomp"
  * @run main runtime.valhalla.inlinetypes.TestFlatteningBudget
  */
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueComparisonTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueComparisonTest.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
  * @compile ValueClassGenerator.java ValueComparisonTest.java
- * @run main/othervm runtime.valhalla.inlinetypes.field_layout.ValueComparisonTest
+ * @run main/othervm -XX:MaxNodeLimit=100000 runtime.valhalla.inlinetypes.field_layout.ValueComparisonTest
  */
 
 package runtime.valhalla.inlinetypes.field_layout;


### PR DESCRIPTION
Adjusting two tests until [JDK-8370769](https://bugs.openjdk.org/browse/JDK-8370769) is fixed because they constantly fail in the CI. I first tried to also increase the MaxNodeLimit for TestFlatteningBudget.java but way too many nodes are created so I just excluded it from -Xcomp for now.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384431](https://bugs.openjdk.org/browse/JDK-8384431): [lworld] Adjust tests affected by JDK-8370769 (**Sub-task** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2424/head:pull/2424` \
`$ git checkout pull/2424`

Update a local copy of the PR: \
`$ git checkout pull/2424` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2424`

View PR using the GUI difftool: \
`$ git pr show -t 2424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2424.diff">https://git.openjdk.org/valhalla/pull/2424.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2424#issuecomment-4430864303)
</details>
