### PR TITLE
8382504: [lworld] TestIntrinsics.java triggers assert "must not cast to a different type"

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2779,7 +2779,7 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
     const Type* value_type = _gvn.type(value);
     if (!value_type->is_inlinetypeptr()) {
       value_type = Type::get_const_type(value_klass)->filter_speculative(value_type);
-      Node* new_value = _gvn.transform(new CastPPNode(control(), value, value_type, ConstraintCastNode::DependencyType::NonFloatingNarrowing));
+      Node* new_value = _gvn.transform(new CheckCastPPNode(control(), value, value_type, ConstraintCastNode::DependencyType::NonFloatingNarrowing));
       new_value = InlineTypeNode::make_from_oop(this, new_value, value_klass);
       replace_in_map(value, new_value);
       value = new_value;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2745,6 +2745,7 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
     if (layout == LayoutKind::REFERENCE) {
       if (!base_type->is_aryptr()->is_not_flat()) {
         const TypeAryPtr* array_type = base_type->is_aryptr()->cast_to_not_flat();
+        // TODO 8350865 This should be a CheckCastPP, can we add a test?
         Node* new_base = _gvn.transform(new CastPPNode(control(), base, array_type, ConstraintCastNode::DependencyType::NonFloatingNarrowing));
         replace_in_map(base, new_base);
         base = new_base;
@@ -2761,6 +2762,7 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
         ptr = basic_plus_adr(base, ConvL2X(offset));
         const TypeAryPtr* ptr_type = _gvn.type(ptr)->is_aryptr();
         if (ptr_type->field_offset().get() != 0) {
+          // TODO 8350865 This should be a CheckCastPP, can we add a test?
           ptr = _gvn.transform(new CastPPNode(control(), ptr, ptr_type->with_field_offset(0), ConstraintCastNode::DependencyType::NonFloatingNarrowing));
         }
       } else {

--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -40,12 +40,6 @@ compiler/c2/ReachabilityFenceFlagsTest.java                                     
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java      8372605 generic-all
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java       8372605 generic-all
 compiler/stable/TestStableArrayMembars.java                                                      8380921 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id0                                            8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id1                                            8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id3                                            8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id4                                            8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id5                                            8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id6                                            8382504 generic-all
 
 # Runtime:
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#default_gc 8382398 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -208,12 +208,6 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 compiler/c2/irTests/TestFloat16ScalarOperations.java 8377808 linux-aarch64
 compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
 compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF 8384262 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id0       8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id1       8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id3       8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id4       8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id5       8382504 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id6       8382504 generic-all
 
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8382548 linux-aarch64
 


### PR DESCRIPTION
Mainline fix [JDK-8373248](https://bugs.openjdk.org/browse/JDK-8373248) added additional code to verify that a `CastPPNode` does not change the type and we now assert when casting the value of an unsafe flat access to the proper type. The `CastPP` should be replaced by a `CheckCastPP`.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382504](https://bugs.openjdk.org/browse/JDK-8382504): [lworld] TestIntrinsics.java triggers assert "must not cast to a different type" (**Bug** - P3)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer) ⚠️ Review applies to [241244d1](https://git.openjdk.org/valhalla/pull/2425/files/241244d160779a95d634745584d6b668e15ec1fc)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer) ⚠️ Review applies to [241244d1](https://git.openjdk.org/valhalla/pull/2425/files/241244d160779a95d634745584d6b668e15ec1fc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2425/head:pull/2425` \
`$ git checkout pull/2425`

Update a local copy of the PR: \
`$ git checkout pull/2425` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2425`

View PR using the GUI difftool: \
`$ git pr show -t 2425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2425.diff">https://git.openjdk.org/valhalla/pull/2425.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2425#issuecomment-4431174037)
</details>
