### PR TITLE
8384193: [lworld] Remove identity field from java.lang.Class

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -871,7 +871,6 @@ int java_lang_Class::_classRedefinedCount_offset;
 int java_lang_Class::_reflectionData_offset;
 int java_lang_Class::_modifiers_offset;
 int java_lang_Class::_is_primitive_offset;
-int java_lang_Class::_is_identity_offset;
 int java_lang_Class::_raw_access_flags_offset;
 
 bool java_lang_Class::_offsets_computed = false;
@@ -1095,7 +1094,6 @@ void java_lang_Class::allocate_mirror(Klass* k, bool is_scratch, Handle protecti
   // Set the modifiers flag.
   u2 computed_modifiers = k->compute_modifier_flags();
   set_modifiers(mirror(), computed_modifiers);
-  set_is_identity(mirror(), k->is_array_klass() || k->is_identity_class());
 
   InstanceMirrorKlass* mk = InstanceMirrorKlass::cast(mirror->klass());
   assert(oop_size(mirror()) == mk->instance_size(k), "should have been set");
@@ -1402,11 +1400,6 @@ void java_lang_Class::set_is_primitive(oop java_class) {
   java_class->bool_field_put(_is_primitive_offset, true);
 }
 
-void java_lang_Class::set_is_identity(oop java_class, bool value) {
-  assert(_is_identity_offset != 0, "must be set");
-  java_class->bool_field_put(_is_identity_offset, value);
-}
-
 oop java_lang_Class::create_basic_type_mirror(const char* basic_type_name, BasicType type, TRAPS) {
   // Mirrors for basic types have a null klass field, which makes them special.
   oop java_class = InstanceMirrorKlass::cast(vmClasses::Class_klass())->allocate_instance(nullptr, CHECK_NULL);
@@ -1565,8 +1558,7 @@ oop java_lang_Class::primitive_mirror(BasicType t) {
   macro(_modifiers_offset,           k, vmSymbols::modifiers_name(), char_signature,    false); \
   macro(_raw_access_flags_offset,    k, "classFileAccessFlags",      char_signature,    false); \
   macro(_protection_domain_offset,   k, "protectionDomain",    java_security_ProtectionDomain_signature,  false); \
-  macro(_is_primitive_offset,        k, "primitive",           bool_signature,         false); \
-  macro(_is_identity_offset,         k, "identity",            bool_signature,         false);
+  macro(_is_primitive_offset,        k, "primitive",           bool_signature,         false);
 
 void java_lang_Class::compute_offsets() {
   if (_offsets_computed) {

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -260,7 +260,6 @@ class java_lang_Class : AllStatic {
   static int _reflectionData_offset;
   static int _modifiers_offset;
   static int _is_primitive_offset;
-  static int _is_identity_offset;
   static int _raw_access_flags_offset;
 
   static bool _offsets_computed;
@@ -275,7 +274,6 @@ class java_lang_Class : AllStatic {
   static void initialize_mirror_fields(InstanceKlass* ik, Handle mirror, Handle protection_domain,
                                        Handle classData, TRAPS);
   static void set_mirror_module_field(JavaThread* current, Klass* K, Handle mirror, Handle module);
-  static void set_is_identity(oop java_class, bool value);
 
   static void set_modifiers(oop java_class, u2 value);
   static void set_raw_access_flags(oop java_class, u2 value);

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -247,7 +247,7 @@ public final class Class<T> implements java.io.Serializable,
      * This constructor is not used and prevents the default constructor being
      * generated.
      */
-    private Class(ClassLoader loader, Class<?> arrayComponentType, char mods, ProtectionDomain pd, boolean isPrim, boolean isIdentity, char flags) {
+    private Class(ClassLoader loader, Class<?> arrayComponentType, char mods, ProtectionDomain pd, boolean isPrim, char flags) {
         // Initialize final field for classLoader.  The initialization value of non-null
         // prevents future JIT optimizations from assuming this final field is null.
         // The following assignments are done directly by the VM without calling this constructor.
@@ -256,7 +256,6 @@ public final class Class<T> implements java.io.Serializable,
         modifiers = mods;
         protectionDomain = pd;
         primitive = isPrim;
-        identity = isIdentity;
         classFileAccessFlags = flags;
     }
 
@@ -1050,7 +1049,6 @@ public final class Class<T> implements java.io.Serializable,
     private final transient char modifiers;  // Set by the VM
     private final transient char classFileAccessFlags;  // Set by the VM
     private final transient boolean primitive;  // Set by the VM if the Class is a primitive type
-    private final transient boolean identity;   // Set by the VM if the Class is an identity class
 
     // package-private
     Object getClassData() {

--- a/test/jdk/java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java
+++ b/test/jdk/java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java
@@ -129,7 +129,7 @@ public class ModuleSetAccessibleTest {
         // non-public constructor
         Constructor<?> ctor
             = Class.class.getDeclaredConstructor(ClassLoader.class, Class.class, char.class,
-                                                 ProtectionDomain.class, boolean.class, boolean.class, char.class);
+                                                 ProtectionDomain.class, boolean.class, char.class);
         AccessibleObject[] ctors = { ctor };
 
         assertThrows(SecurityException.class, () -> ctor.setAccessible(true));

--- a/test/jdk/java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java
+++ b/test/jdk/java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java
@@ -174,7 +174,7 @@ public class TrySetAccessibleTest {
         // non-public constructor
         Constructor<?> ctor
             = Class.class.getDeclaredConstructor(ClassLoader.class, Class.class, char.class,
-                                                 ProtectionDomain.class, boolean.class, boolean.class, char.class);
+                                                 ProtectionDomain.class, boolean.class, char.class);
         AccessibleObject[] ctors = { ctor };
 
         assertFalse(ctor.trySetAccessible());


### PR DESCRIPTION

This change removes the identity field from java.lang.Class since java.lang.Class has the info already with ACC_IDENTITY and there's no real efficiency for the VM to set it.
Tested with tier1-3 complete.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384193](https://bugs.openjdk.org/browse/JDK-8384193): [lworld] Remove identity field from java.lang.Class (**Bug** - P2)


### Reviewers
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2426/head:pull/2426` \
`$ git checkout pull/2426`

Update a local copy of the PR: \
`$ git checkout pull/2426` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2426`

View PR using the GUI difftool: \
`$ git pr show -t 2426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2426.diff">https://git.openjdk.org/valhalla/pull/2426.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2426#issuecomment-4433319324)
</details>
