### PR TITLE
8384105: [lworld] serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java fails after JDK-8382702

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -209,7 +209,6 @@ compiler/c2/irTests/TestFloat16ScalarOperations.java 8377808 linux-aarch64
 compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
 compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF 8384262 generic-all
 
-serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java 8384105 generic-all
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8382548 linux-aarch64
 
 vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java 8375062 windows-x64

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/SampledObjectAllocValue/libSampledObjectAllocValue.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/SampledObjectAllocValue/libSampledObjectAllocValue.cpp
@@ -60,14 +60,14 @@ SampledObjectAlloc(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, jobject object,
   if (klass == nullptr) {
     fatal(jni, "klass in SampledObjectAlloc callback is not expected to be null");
   }
+  if (!is_test_class(jvmti, jni, klass)) {
+    return; // interested in tested class only
+  }
   if (size == 0L) {
     fatal(jni, "size in SampledObjectAlloc callback is not expected to be 0");
   }
   if (object != nullptr) {
     fatal(jni, "object in SampledObjectAlloc callback is expected to be null for value object allocations");
-  }
-  if (!is_test_class(jvmti, jni, klass)) {
-    return; // interested in tested class only
   }
   events_counter++;
   LOG("SampledObjectAlloc: events_counter: %d\n", events_counter.load());


### PR DESCRIPTION
This fixes the test issue. The order of checks in the failing test is corrected. 

Testing:
 - Run test locally
 - In progress: submit mach5 tier-5


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384105](https://bugs.openjdk.org/browse/JDK-8384105): [lworld] serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java fails after JDK-8382702 (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2431/head:pull/2431` \
`$ git checkout pull/2431`

Update a local copy of the PR: \
`$ git checkout pull/2431` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2431`

View PR using the GUI difftool: \
`$ git pr show -t 2431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2431.diff">https://git.openjdk.org/valhalla/pull/2431.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2431#issuecomment-4440264459)
</details>
