### PR TITLE
8384127: [lworld] C2 compilation failed with "graph should be schedulable" assert

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4767,6 +4767,17 @@ bool LibraryCallKit::inline_newArray(bool null_free, bool atomic) {
                 init_val = init_val->as_InlineType()->buffer(this);
               }
             }
+#ifdef ASSERT
+            init_val = null_check(init_val);
+            Node* wrong_type_ctl = gen_subtype_check(init_val, makecon(TypeKlassPtr::make(array_klass->element_klass())));
+            {
+              PreserveJVMState pjvms(this);
+              set_control(wrong_type_ctl);
+              halt(control(), frameptr(), "incompatible type for initVal in newArray");
+              stop_and_kill_map();
+            }
+#endif
+            init_val = _gvn.transform(new CheckCastPPNode(control(), init_val, TypeOopPtr::make_from_klass(array_klass->element_klass())));
             // TODO 8350865 Should we add a check of the init_val type (maybe in debug only + halt)?
             // If we insert a checkcast here, we can be sure that init_val is an InlineTypeNode, so
             // when we folded a field load from an allocation (e.g. during escape analysis), we can

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4778,7 +4778,7 @@ bool LibraryCallKit::inline_newArray(bool null_free, bool atomic) {
                 stop_and_kill_map();
               }
 #endif
-              init_val = _gvn.transform(new CheckCastPPNode(control(), init_val, TypeOopPtr::make_from_klass(array_klass->element_klass())));
+              init_val = _gvn.transform(new CheckCastPPNode(control(), init_val, TypeOopPtr::make_from_klass(array_klass->element_klass()), ConstraintCastNode::DependencyType::NonFloatingNarrowing));
             }
           }
           Node* obj = new_array(makecon(array_klass_type), length, 0, nullptr, false, init_val);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4767,21 +4767,19 @@ bool LibraryCallKit::inline_newArray(bool null_free, bool atomic) {
                 init_val = init_val->as_InlineType()->buffer(this);
               }
             }
+            if (init_val != nullptr) {
 #ifdef ASSERT
-            init_val = null_check(init_val);
-            Node* wrong_type_ctl = gen_subtype_check(init_val, makecon(TypeKlassPtr::make(array_klass->element_klass())));
-            {
-              PreserveJVMState pjvms(this);
-              set_control(wrong_type_ctl);
-              halt(control(), frameptr(), "incompatible type for initVal in newArray");
-              stop_and_kill_map();
-            }
+              init_val = null_check(init_val);
+              Node* wrong_type_ctl = gen_subtype_check(init_val, makecon(TypeKlassPtr::make(array_klass->element_klass())));
+              {
+                PreserveJVMState pjvms(this);
+                set_control(wrong_type_ctl);
+                halt(control(), frameptr(), "incompatible type for initVal in newArray");
+                stop_and_kill_map();
+              }
 #endif
-            init_val = _gvn.transform(new CheckCastPPNode(control(), init_val, TypeOopPtr::make_from_klass(array_klass->element_klass())));
-            // TODO 8350865 Should we add a check of the init_val type (maybe in debug only + halt)?
-            // If we insert a checkcast here, we can be sure that init_val is an InlineTypeNode, so
-            // when we folded a field load from an allocation (e.g. during escape analysis), we can
-            // remove the check init_val->is_InlineType().
+              init_val = _gvn.transform(new CheckCastPPNode(control(), init_val, TypeOopPtr::make_from_klass(array_klass->element_klass())));
+            }
           }
           Node* obj = new_array(makecon(array_klass_type), length, 0, nullptr, false, init_val);
           const TypeAryPtr* arytype = gvn().type(obj)->is_aryptr();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
@@ -29,9 +29,9 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
- * @summary We hit "graph should be schedulable" in LCM because of wrongly added precedence edges because some fields aren't found to be strict final.
- *          This happens because the type of the object we load from is lost during can_see_stored_value because the initial value of null-free newArray
- *          is not behind a checkcast.
+ * @summary We need to make sure to have a CheckCastPP under the initial value in ValueClass.newNull.*AtomicArray. If missing,
+ *          a load of the initial value of the array may find an object with an imprecise type (initVal1 in this case, that is
+ *          an Object), potentially leading to wrong alias indices.
  * @library /test/lib /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
  * @enablePreview
@@ -57,6 +57,7 @@ public class GraphShouldBeSchedulable {
     }
 
     static final TwoBytes CANARY1 = new TwoBytes((byte)42, (byte)42);
+    // We hide the type of the initial value so that C2 can only tell is a load of type Object.
     static Object initVal1 = CANARY1;
 
     public static void main(String[] args) {
@@ -64,8 +65,11 @@ public class GraphShouldBeSchedulable {
             TwoBytes val1 = new TwoBytes((byte)i, (byte)(i + 1));
             TwoBytes[] nullFreeAtomicArray1 = (TwoBytes[])ValueClass.newNullRestrictedAtomicArray(TwoBytes.class, 3, TwoBytes.DEFAULT);
             nullFreeAtomicArray1[1] = val1;
+            // Here, initVal1 is a load of type Object. Now, with a CheckCastPP under.
             TwoBytes[] nullFreeAtomicArray2 = (TwoBytes[])ValueClass.newNullRestrictedAtomicArray(TwoBytes.class, 3, initVal1);
             Asserts.assertEquals(ValueClass.isFlatArray(nullFreeAtomicArray2), false);
+            // Here, the access is simplified into the initial value: we need to make sure we find the CheckCastPP otherwise
+            // the fields b1 and b2 are not recognized as strict final fields, and wrong precedence edges are added during GCM.
             Asserts.assertEquals(nullFreeAtomicArray2[1], CANARY1);
         }
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @summary We hit "graph should be schedulable" in LCM because of wrongly added precedence edges because some fields aren't found to be strict final.
+ *          This happens because the type of the object we load from is lost during can_see_stored_value because the initial value of null-free newArray
+ *          is not behind a checkcast.
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @run main/othervm/timeout -XX:+UnlockDiagnosticVMOptions
+ *                           -XX:+UnlockExperimentalVMOptions -Xbatch
+ *                           -XX:-UseNullableAtomicValueFlattening -XX:-UseNullFreeAtomicValueFlattening -XX:+UseNullFreeNonAtomicValueFlattening
+ *                           -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-DoEscapeAnalysis -XX:+AlwaysIncrementalInline
+ *                           ${test.main.class}
+ */
+
+public class GraphShouldBeSchedulable {
+    static value class TwoBytes {
+        byte b1;
+        byte b2;
+
+        public TwoBytes(byte b1, byte b2) {
+            this.b1 = b1;
+            this.b2 = b2;
+        }
+
+        static final TwoBytes DEFAULT = new TwoBytes((byte)0, (byte)0);
+    }
+
+    static final TwoBytes CANARY1 = new TwoBytes((byte)42, (byte)42);
+    static Object initVal1 = CANARY1;
+
+    public static void main(String[] args) {
+        for (int i = -50_000; i < 50_000; ++i) {
+            TwoBytes val1 = new TwoBytes((byte)i, (byte)(i + 1));
+            TwoBytes[] nullFreeAtomicArray1 = (TwoBytes[])ValueClass.newNullRestrictedAtomicArray(TwoBytes.class, 3, TwoBytes.DEFAULT);
+            nullFreeAtomicArray1[1] = val1;
+            TwoBytes[] nullFreeAtomicArray2 = (TwoBytes[])ValueClass.newNullRestrictedAtomicArray(TwoBytes.class, 3, initVal1);
+            Asserts.assertEquals(ValueClass.isFlatArray(nullFreeAtomicArray2), false);
+            Asserts.assertEquals(nullFreeAtomicArray2[1], CANARY1);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GraphShouldBeSchedulable.java
@@ -36,11 +36,11 @@ import jdk.test.lib.Asserts;
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
  * @enablePreview
  * @modules java.base/jdk.internal.value
- * @run main/othervm/timeout -XX:+UnlockDiagnosticVMOptions
- *                           -XX:+UnlockExperimentalVMOptions -Xbatch
- *                           -XX:-UseNullableAtomicValueFlattening -XX:-UseNullFreeAtomicValueFlattening -XX:+UseNullFreeNonAtomicValueFlattening
- *                           -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-DoEscapeAnalysis -XX:+AlwaysIncrementalInline
- *                           ${test.main.class}
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+UnlockExperimentalVMOptions -Xbatch
+ *                   -XX:-UseNullableAtomicValueFlattening -XX:-UseNullFreeAtomicValueFlattening -XX:+UseNullFreeNonAtomicValueFlattening
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-DoEscapeAnalysis -XX:+AlwaysIncrementalInline
+ *                   ${test.main.class}
  */
 
 public class GraphShouldBeSchedulable {


### PR DESCRIPTION
That was discovered when working on the intrinsic for isAtomic. It turns out it is actually not needed, but the shape of the graph to trigger the issue needs to be complex enough not to be simplified too hard, but simple enough that optimization triggers.

Let's see what happens. In this screenshot, let's look at
<img width="2520" height="1935" alt="1  before" src="https://github.com/user-attachments/assets/e6e1d0d1-2034-49b6-948c-138c23f56d48" />
Nodes `569 LoadB` and `573 LoadB` are loading the fields from `nullFreeAtomicArray2[1]`, in the inlined `Asserts.assertEquals`. Since they are strict final fields, they cannot be observed to be mutated, and we can rewire the memory input a lot higher. We get
<img width="1601" height="1841" alt="2  after" src="https://github.com/user-attachments/assets/cec607fd-16e8-4462-881d-658a5200bd45" />


The difficulty comes from the node `563 LoadN` that corresponds to the access `nullFreeAtomicArray2[1]`: we can climb up to the initial value of the `355 AllocateArray`.
<img width="1750" height="910" alt="3  getting input" src="https://github.com/user-attachments/assets/0b0bb92a-4d7d-40c9-a24d-847245f8f52a" />


Here, the default value is the value `initVal1`, which is `340 LoadN`, and the type is opaque here. Then, the graph becomes
<img width="1719" height="777" alt="4  nope" src="https://github.com/user-attachments/assets/ad1aa005-a77a-4c26-a65c-651c48d82cf5" />

then
<img width="539" height="427" alt="5  nope" src="https://github.com/user-attachments/assets/b41c119e-e0a5-4fcb-8ee5-1a30ae718389" />


and here, it is not clear that these `LoadB` are for strict final fields. That starts to be wrong. Later, during GCM, precedence edges from `538 MemBarStoreStore` to the `LoadB` nodes, creating a cycle inside the same block, and then, the graph becomes not schedulable.

The fix is either not to subsume `563 LoadN` by `340 LoadN` (which is sad) because types don't match, or subsumes it by something correct. Here, we can just add a `CheckCastPPNode` under the initial value to subsumes by something correct, and all is fine again.

Should we check that the initial value indeed has the right type? Yes, but not here, and it is worked on (see [JDK-8383820: [lworld] Several native methods of ValueClass class lack proper argument validation](https://bugs.openjdk.org/browse/JDK-8383820)). I've just added a debug only check and halt, it shall be enough for now.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384127](https://bugs.openjdk.org/browse/JDK-8384127): [lworld] C2 compilation failed with "graph should be schedulable" assert (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2432/head:pull/2432` \
`$ git checkout pull/2432`

Update a local copy of the PR: \
`$ git checkout pull/2432` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2432`

View PR using the GUI difftool: \
`$ git pr show -t 2432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2432.diff">https://git.openjdk.org/valhalla/pull/2432.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2432#issuecomment-4441032283)
</details>
