### PR TITLE
8384202: [lworld] C2: assert(offset == field->offset_in_bytes()) failed: offset mismatch

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -229,10 +229,14 @@ Node* InlineTypeNode::field_value_by_offset(int offset, bool recursive) const {
   ciField* field = this->field(index);
   assert(!field->is_flat() || field->type()->is_inlinetype(), "must be an inline type");
 
-  if (!recursive || !field->is_flat() || value->is_top()) {
-    // If the graph is dying (value is top), a load may still ask for a nested
-    // field inside a flattened field before the dead load itself is folded away.
-    assert((offset == field->offset_in_bytes()) || (value->is_top() && field->is_flat()), "offset mismatch");
+  if (value->is_top()) {
+    // The graph is dying but a load may still ask for a nested field
+    // inside a flattened field before the dead load itself is folded away.
+    assert(offset == field->offset_in_bytes() || field->is_flat(), "offset mismatch");
+    return value;
+  }
+  if (!recursive || !field->is_flat()) {
+    assert(offset == field->offset_in_bytes(), "offset mismatch");
     return value;
   }
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -230,7 +230,9 @@ Node* InlineTypeNode::field_value_by_offset(int offset, bool recursive) const {
   assert(!field->is_flat() || field->type()->is_inlinetype(), "must be an inline type");
 
   if (!recursive || !field->is_flat() || value->is_top()) {
-    assert(offset == field->offset_in_bytes(), "offset mismatch");
+    // If the graph is dying (value is top), a load may still ask for a nested
+    // field inside a flattened field before the dead load itself is folded away.
+    assert((offset == field->offset_in_bytes()) || (value->is_top() && field->is_flat()), "offset mismatch");
     return value;
   }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadInlineTypeFieldOffset.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadInlineTypeFieldOffset.java
@@ -29,6 +29,7 @@ import jdk.internal.vm.annotation.NullRestricted;
 /*
  * @test
  * @summary Test loads from a dead InlineTypeNode with top field values.
+ * @bug 8384202
  * @requires vm.compiler2.enabled
  * @requires (vm.opt.PreloadClasses == null | vm.opt.PreloadClasses == "true")
  * @enablePreview

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadInlineTypeFieldOffset.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadInlineTypeFieldOffset.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.internal.vm.annotation.NullRestricted;
+
+/*
+ * @test
+ * @summary Test loads from a dead InlineTypeNode with top field values.
+ * @requires vm.compiler2.enabled
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class}
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+StressIGVN -XX:StressSeed=8 -XX:+AlwaysIncrementalInline
+ *                   ${test.main.class}
+ */
+public value class TestDeadInlineTypeFieldOffset {
+    MyValue valueField1;
+    @NullRestricted
+    MyValue valueField2;
+
+    TestDeadInlineTypeFieldOffset(MyValue valueField1, MyValue valueField2) {
+        this.valueField1 = valueField1;
+        this.valueField2 = valueField2;
+    }
+
+    TestDeadInlineTypeFieldOffset test1() {
+        return new TestDeadInlineTypeFieldOffset(null, valueField2);
+    }
+
+    TestDeadInlineTypeFieldOffset test2() {
+        return new TestDeadInlineTypeFieldOffset(valueField1, null);
+    }
+
+    @LooselyConsistentValue
+    static value class NestedValue {
+        int x;
+        int y;
+
+        NestedValue(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    @LooselyConsistentValue
+    static value class MyValue {
+        NestedValue v1;
+        @NullRestricted
+        NestedValue v2;
+
+        MyValue(NestedValue v1, NestedValue v2) {
+            this.v1 = v1;
+            this.v2 = v2;
+        }
+    }
+
+    static TestDeadInlineTypeFieldOffset test(TestDeadInlineTypeFieldOffset vt) {
+        vt = vt.test1();
+        try {
+            vt = vt.test2();
+            throw new RuntimeException();
+        } catch (NullPointerException e) {
+            // Expected.
+        }
+        return vt;
+    }
+
+    public static void main(String[] args) {
+        MyValue val = new MyValue(null, new NestedValue(5, 6));
+        TestDeadInlineTypeFieldOffset vt = new TestDeadInlineTypeFieldOffset(null, val);
+        for (int i = 0; i < 10_000; ++i) {
+            vt = test(vt);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadInlineTypeFieldOffset.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadInlineTypeFieldOffset.java
@@ -30,6 +30,7 @@ import jdk.internal.vm.annotation.NullRestricted;
  * @test
  * @summary Test loads from a dead InlineTypeNode with top field values.
  * @requires vm.compiler2.enabled
+ * @requires (vm.opt.PreloadClasses == null | vm.opt.PreloadClasses == "true")
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
  * @run main ${test.main.class}


### PR DESCRIPTION
The original failure was in `test21` from `compiler/valhalla/inlinetypes/TestNullableInlineTypes.java#id5`. I extracted it into a standalone reproducer.

C2 asserts in `InlineTypeNode::field_value_by_offset` while looking up a field value by offset. The lookup reaches a flat field whose corresponding input is already `TOP`. This happens on the normal return path from `test2()` in `test()`. That path is dead because `test2()` always throws a `NullPointerException` when it tries to initialize a null restricted field with null. We only "know" this after incremental inlining though.

So at this point, with `-XX:+StressIGVN`, the impossible control path has not been removed yet, but the data path has already started dying: field values on the dead `InlineTypeNode` have been replaced by `TOP`. `InlineTypeNode::field_value_by_offset` already accounts for this with a `value->is_top()` check, but the offset assert in that case is too strict.

In this reproducer, the lookup is recursive: it asks for a field inside a flat field whose value is already `TOP`. Therefore, the requested offset is the offset of a nested field within the flattened payload, while `field->offset_in_bytes()` is the offset of the enclosing flat field. Those offsets are not expected to match.

I adjusted the assert accordingly.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384202](https://bugs.openjdk.org/browse/JDK-8384202): [lworld] C2: assert(offset == field-&gt;offset_in_bytes()) failed: offset mismatch (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer) ⚠️ Review applies to [426af5ba](https://git.openjdk.org/valhalla/pull/2433/files/426af5ba760b8cf7cbbbc3d65dc88ac02aac4a5f)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2433/head:pull/2433` \
`$ git checkout pull/2433`

Update a local copy of the PR: \
`$ git checkout pull/2433` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2433`

View PR using the GUI difftool: \
`$ git pr show -t 2433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2433.diff">https://git.openjdk.org/valhalla/pull/2433.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2433#issuecomment-4441274165)
</details>
