### PR TITLE
8384283: [lworld] Post-parse call devirtualization with unloaded return type fails

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2310,7 +2310,6 @@ void GraphKit::replace_call(CallNode* call, Node* result, bool do_replaced_nodes
   CallProjections* callprojs = call->extract_projections(true, do_asserts);
 
   Unique_Node_List wl;
-  Node* init_mem = call->in(TypeFunc::Memory);
   Node* final_mem = final_state->in(TypeFunc::Memory);
   Node* final_ctl = final_state->in(TypeFunc::Control);
   Node* final_io = final_state->in(TypeFunc::I_O);
@@ -2341,9 +2340,14 @@ void GraphKit::replace_call(CallNode* call, Node* result, bool do_replaced_nodes
     // If we are doing strength reduction and the return type is not loaded we
     // need to rewire all projections since store_inline_type_fields_to_buf is already present
     if (C->strength_reduction() && InlineTypeReturnedAsFields && !call->as_CallJava()->method()->return_type()->is_loaded()) {
-      const TypeTuple* domain = OptoRuntime::store_inline_type_fields_Type()->domain_cc();
-      for (uint i = TypeFunc::Parms; i < domain->cnt(); i++) {
-        C->gvn_replace_by(callprojs->resproj[0], final_state->in(i));
+      CallNode* new_call = result->in(0)->as_Call();
+      assert(new_call->proj_out_or_null(TypeFunc::Parms) == result, "the first data projection should be result");
+      for (uint i = 0; i < callprojs->nb_resproj; i++) {
+        if (callprojs->resproj[i] != nullptr) {
+          Node* new_proj = new_call->proj_out_or_null(TypeFunc::Parms + i);
+          assert(new_proj != nullptr, "projection should be available");
+          C->gvn_replace_by(callprojs->resproj[i], new_proj);
+        }
       }
     } else {
       C->gvn_replace_by(callprojs->resproj[0], result);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallDevirtualizationWithUnloadedReturn.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallDevirtualizationWithUnloadedReturn.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test post-parse call devirtualization with an unloaded return type.
+ * @enablePreview
+ * @run main compiler.valhalla.inlinetypes.TestCallDevirtualizationWithUnloadedReturn
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,*TestCallDevirtualizationWithUnloadedReturn::*
+ *                   compiler.valhalla.inlinetypes.TestCallDevirtualizationWithUnloadedReturn
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestCallDevirtualizationWithUnloadedReturn {
+
+    static interface BaseClass {
+        public Unloaded method();
+    }
+
+    static class Impl1 implements BaseClass {
+        public Unloaded method() {
+            return null;
+        }
+    }
+
+    static class Impl2 implements BaseClass {
+        public Unloaded method() {
+            return null;
+        }
+    }
+
+    static class Impl3 implements BaseClass {
+        public Unloaded method() {
+            return null;
+        }
+    }
+
+    static class Unloaded { }
+
+    static Object test() {
+        BaseClass receiver = new Impl1();
+        // Hide the fact that receiver type is Impl2 until after loop
+        // opts to trigger post-parse call devirtualization below.
+        for (int i = 0; i < 3; i++) {
+            if (i > 1) {
+                receiver = new Impl2();
+            }
+        }
+        // This is strength-reduced to a static call but since the
+        // return type is unloaded it might be a scalarized return.
+        return receiver.method();
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; i++) {
+            test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallDevirtualizationWithUnloadedReturn.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallDevirtualizationWithUnloadedReturn.java
@@ -27,8 +27,7 @@
  * @summary Test post-parse call devirtualization with an unloaded return type.
  * @enablePreview
  * @run main ${test.main.class}
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
- *                   -Xcomp -XX:-TieredCompilation
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,${test.main.class}::*
  *                   ${test.main.class}
  */

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallDevirtualizationWithUnloadedReturn.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallDevirtualizationWithUnloadedReturn.java
@@ -23,13 +23,14 @@
 
 /**
  * @test
+ * @bug 8384283
  * @summary Test post-parse call devirtualization with an unloaded return type.
  * @enablePreview
- * @run main compiler.valhalla.inlinetypes.TestCallDevirtualizationWithUnloadedReturn
+ * @run main ${test.main.class}
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -Xcomp -XX:-TieredCompilation
- *                   -XX:CompileCommand=compileonly,*TestCallDevirtualizationWithUnloadedReturn::*
- *                   compiler.valhalla.inlinetypes.TestCallDevirtualizationWithUnloadedReturn
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::*
+ *                   ${test.main.class}
  */
 
 package compiler.valhalla.inlinetypes;


### PR DESCRIPTION
As suggested by Tobias, it seems that the loop
https://github.com/openjdk/valhalla/blob/de6aff4ffe3344bfb886fa27385e432016bbbeef/src/hotspot/share/opto/graphKit.cpp#L2344-L2347
is wrong, even with the index (`[0]`) fixed.

Indeed, `final_state` is the `SafePointNode` that tracks the JVM state, that is the stack, slots... This kind of things. There is no good reason this should replace the output of the existing call. Instead, we should replace the projection of the old call with the output of the new call. The new call can be found as being the input of `result`. Of course, `result` can be something else than a projection from a call, typically a load, a constant... But then, I don't think we can be in the case of an unloaded return type. Testing seems to agree with that.

Another thing to take care of: `callprojs->resproj[i]` might be null, when the projection isn't used. Indeed, `store_inline_type_fields_to_buf` has a lot of `double` input, and so the `Half` part of these inputs are `top` (and thus, not wired from the old call). On the other hand, the projection of the new call must be there, but they should:
https://github.com/openjdk/valhalla/blob/de6aff4ffe3344bfb886fa27385e432016bbbeef/src/hotspot/share/opto/graphKit.cpp#L2167-L2181

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384283](https://bugs.openjdk.org/browse/JDK-8384283): [lworld] Post-parse call devirtualization with unloaded return type fails (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2434/head:pull/2434` \
`$ git checkout pull/2434`

Update a local copy of the PR: \
`$ git checkout pull/2434` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2434`

View PR using the GUI difftool: \
`$ git pr show -t 2434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2434.diff">https://git.openjdk.org/valhalla/pull/2434.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2434#issuecomment-4441323833)
</details>
