### PR TITLE
8384630: [lworld] Build failure after JDK-8383164

### DIFF
--- a/src/java.base/share/classes/java/io/Serializable.java
+++ b/src/java.base/share/classes/java/io/Serializable.java
@@ -144,7 +144,7 @@ package java.io;
  * <cite>Java Object Serialization Specification,</cite> Section 1.13,
  * "Serialization of Records"</a>. Any declarations of the special
  * handling methods discussed above, except {@code writeReplace},
- * are ignored for record types.<p>
+ * are ignored for record types.
  *
  * <div class="preview-block">
  *      <div class="preview-comment">


### PR DESCRIPTION
Doclint warns about an empty `<p>` tag. I removed it for now to unblock the build.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384630](https://bugs.openjdk.org/browse/JDK-8384630): [lworld] Build failure after JDK-8383164 (**Bug** - P1)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2437/head:pull/2437` \
`$ git checkout pull/2437`

Update a local copy of the PR: \
`$ git checkout pull/2437` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2437`

View PR using the GUI difftool: \
`$ git pr show -t 2437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2437.diff">https://git.openjdk.org/valhalla/pull/2437.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2437#issuecomment-4457665296)
</details>
