### PR TITLE
8384525: [lworld] compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,12 @@
  * @enablePreview
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -Xbatch
- *                   -XX:CompileCommand=dontinline,*::*
- *                   -XX:CompileCommand=printcompilation,*::*
- *                   -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.CorrectlyRestoreRfp*::compile_me_*
- *                   compiler.valhalla.inlinetypes.CorrectlyRestoreRfp
+ * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                               -Xbatch
+ *                               -XX:CompileCommand=dontinline,*::*
+ *                               -XX:CompileCommand=printcompilation,*::*
+ *                               -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.CorrectlyRestoreRfp*::compile_me_*
+ *                               compiler.valhalla.inlinetypes.CorrectlyRestoreRfp
  **/
 
 package compiler.valhalla.inlinetypes;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
@@ -49,7 +49,7 @@ import java.util.concurrent.CountDownLatch;
 public class CorrectlyRestoreRfp {
     static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
     static final int COMP_LEVEL_SIMPLE = 1; // C1
-    static final int COMP_LEVEL_FULL_OPTIMIZATION = 4; // C2 or JVMCI
+    static final int COMP_LEVEL_FULL_OPTIMIZATION = 4; // C2
 
     static value class SmallValue {
         int x1;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
@@ -35,8 +35,8 @@
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                               -Xbatch
  *                               -XX:CompileCommand=dontinline,*::*
- *                               -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.CorrectlyRestoreRfp*::compile_me_*
- *                               compiler.valhalla.inlinetypes.CorrectlyRestoreRfp
+ *                               -XX:CompileCommand=compileonly,${test.main.class}*::compile_me_*
+ *                               ${test.main.class}
  **/
 
 package compiler.valhalla.inlinetypes;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java
@@ -35,7 +35,6 @@
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                               -Xbatch
  *                               -XX:CompileCommand=dontinline,*::*
- *                               -XX:CompileCommand=printcompilation,*::*
  *                               -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.CorrectlyRestoreRfp*::compile_me_*
  *                               compiler.valhalla.inlinetypes.CorrectlyRestoreRfp
  **/


### PR DESCRIPTION
The test is rather slow and times out intermittently. On my system, the test runs for 2m 41.932s with default arguments and therefore already times out. I set the timeout to 300s to be on the safe side. I also removed the print compilation which can be re-added if needed for debugging.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384525](https://bugs.openjdk.org/browse/JDK-8384525): [lworld] compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java timed out (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2439/head:pull/2439` \
`$ git checkout pull/2439`

Update a local copy of the PR: \
`$ git checkout pull/2439` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2439`

View PR using the GUI difftool: \
`$ git pr show -t 2439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2439.diff">https://git.openjdk.org/valhalla/pull/2439.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2439#issuecomment-4459421428)
</details>
