### PR TITLE
8380921: [lworld] compiler/stable/TestStableArrayMembars.java IR mismatch with preview enabled

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2002,7 +2002,7 @@ static bool return_val_keeps_allocations_alive(Node* ret_val) {
                n->in(1)->is_Proj() &&
                n->in(1)->in(0)->is_Allocate()) {
       some_allocations = true;
-    } else if (n->is_CheckCastPP()) {
+    } else if (n->is_CheckCastPP() || n->is_CastPP()) {
       wq.push(n->in(1));
     }
   }
@@ -3275,9 +3275,12 @@ void Compile::Optimize() {
     if (failing()) {
       return;
     }
-    process_inline_types(igvn);
   }
   assert(_late_inlines.length() == 0, "late inline queue must be drained");
+
+  // Process inline types before macro expansion. Otherwise, we will not be able to
+  // remove unused allocations because it cannot match the expanded allocation.
+  process_inline_types(igvn);
 
   {
     TracePhase tp(_t_macroExpand);

--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -39,7 +39,6 @@
 compiler/c2/ReachabilityFenceFlagsTest.java                                                      8382503 generic-all
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java      8372605 generic-all
 compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java       8372605 generic-all
-compiler/stable/TestStableArrayMembars.java                                                      8380921 generic-all
 
 # Runtime:
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#default_gc 8382398 generic-all

--- a/test/hotspot/jtreg/compiler/stable/TestStableArrayMembars.java
+++ b/test/hotspot/jtreg/compiler/stable/TestStableArrayMembars.java
@@ -131,7 +131,7 @@ public class TestStableArrayMembars {
     @IR(counts = { IRNode.MEMBAR, ">0",
                    IRNode.LOAD, "=1"}, // There is exactly one load fence, but no load
         applyIfAnd = {"enable-valhalla", "true",
-                     "UseArrayFlattening", "true"})
+                      "UseArrayFlattening", "true"})
     static Integer test() {
         return la.get(0);
     }

--- a/test/hotspot/jtreg/compiler/stable/TestStableArrayMembars.java
+++ b/test/hotspot/jtreg/compiler/stable/TestStableArrayMembars.java
@@ -27,6 +27,7 @@
  * @summary Test that membars are eliminated when loading from a stable array.
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.value
  * @modules java.base/jdk.internal.vm.annotation
  * @run driver ${test.main.class}
  */
@@ -34,20 +35,32 @@
 package compiler.stable;
 
 import java.util.Objects;
+import java.util.Set;
 
 import jdk.internal.misc.Unsafe;
+import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.Stable;
 
+import jdk.test.lib.Asserts;
 import compiler.lib.ir_framework.*;
 
 public class TestStableArrayMembars {
 
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
 
+    private static final int THE_VALUE = 42;
+
     public static void main(String[] args) {
         TestFramework tf = new TestFramework();
         tf.addTestClassesToBootClassPath();
-        tf.addFlags( "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED");
+        tf.addFlags("--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                    "--add-exports=java.base/jdk.internal.value=ALL-UNNAMED");
+        if (Integer.class.isValue()) {
+            tf.addCrossProductScenarios(Set.of("", "-XX:-UseArrayFlattening",
+                                               "-XX:-UseArrayFlattening -XX:-InlineTypePassFieldsAsArgs",
+                                               "-XX:-UseArrayFlattening -XX:-InlineTypeReturnedAsFields",
+                                               "-XX:-UseArrayFlattening -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields"));
+        }
         tf.start();
     }
 
@@ -61,36 +74,42 @@ public class TestStableArrayMembars {
 
         @ForceInline
         Integer get(int idx) {
-            Integer i = contentsAcquire(offsetFor(idx));
+            Integer i = contentsAcquire(offsetFor(arr, idx));
             return i == null ? slowPath(arr, idx) : i;
         }
 
         @ForceInline
         private Integer contentsAcquire(long offset) {
-            return (Integer) UNSAFE.getReferenceAcquire(arr, offset);
+            return (Integer) (ValueClass.isFlatArray(arr) ?
+                UNSAFE.getFlatValueAcquire(arr, offset, UNSAFE.arrayLayout(arr), Integer.class) :
+                UNSAFE.getReferenceAcquire(arr, offset));
         }
 
         @ForceInline
-        private static long offsetFor(long index) {
-            return Unsafe.ARRAY_OBJECT_BASE_OFFSET + Unsafe.ARRAY_OBJECT_INDEX_SCALE * index;
+        private static long offsetFor(Integer[] arr, long index) {
+            return UNSAFE.arrayInstanceBaseOffset(arr) + UNSAFE.arrayInstanceIndexScale(arr) * index;
         }
 
         static Integer slowPath(final Integer[] array, final int index) {
-            final long offset = offsetFor(index);
+            final long offset = offsetFor(array, index);
             final Integer t = array[index];
             if (t == null) {
-                final Integer newValue = Integer.valueOf(42);
+                final Integer newValue = Integer.valueOf(THE_VALUE);
                 Objects.requireNonNull(newValue);
-                set(array, index, newValue);
+                set(array, index, offset, newValue);
 
                 return newValue;
             }
             return t;
         }
 
-        static void set(Integer[] array, int index, Integer newValue) {
+        static void set(Integer[] array, int index, long offset, Integer newValue) {
             if (array[index] == null) {
-                UNSAFE.putReferenceRelease(array, Unsafe.ARRAY_OBJECT_BASE_OFFSET + Unsafe.ARRAY_OBJECT_INDEX_SCALE * (long) index, newValue);
+                if (!ValueClass.isFlatArray(array)) {
+                    UNSAFE.putReferenceRelease(array, offset, newValue);
+                } else {
+                    UNSAFE.putFlatValueRelease(array, offset, UNSAFE.arrayLayout(array), Integer.class, newValue);
+                }
             }
         }
     }
@@ -98,8 +117,27 @@ public class TestStableArrayMembars {
     static final LazyIntArray la = new LazyIntArray();
 
     @Test
-    @IR(failOn = { IRNode.LOAD, IRNode.MEMBAR })
+    // We cannot eliminate all barriers with flat arrays, because Unsafe.getFlatValueAcquire()
+    // explicitly adds a loadFence() in Java. Hence, there is no way for C2 to correlate those
+    // barriers to an eliminated memory access and thus no way to remove them.
+    // The barrier elimination only works with tiered compilation as the profiling information
+    // is nessecary to inline the low-frequency Unsafe.put* methods.
+    @IR(failOn = { IRNode.LOAD, IRNode.MEMBAR },
+        applyIfAnd = {"enable-valhalla", "false",
+                      "TieredCompilation", "true"})
+    @IR(failOn = { IRNode.LOAD, IRNode.MEMBAR },
+        applyIfAnd = {"UseArrayFlattening", "false",
+                      "TieredCompilation", "true"})
+    @IR(counts = { IRNode.MEMBAR, ">0",
+                   IRNode.LOAD, "=1"}, // There is exactly one load fence, but no load
+        applyIfAnd = {"enable-valhalla", "true",
+                     "UseArrayFlattening", "true"})
     static Integer test() {
         return la.get(0);
+    }
+
+    @Check(test = "test")
+    static void check(Integer testResult) {
+        Asserts.assertEQ(THE_VALUE, testResult.intValue(), "Incorrect result from LazyIntArray");
     }
 }


### PR DESCRIPTION
This PR updates the Test `compiler/stable/TestStableArrayMembars.java` for Valhalla. This involves creating a code path for migrated value classes and a slight change to C2 to be able to clean up more barriers than previously.

Unfortunately, with `--enable-preview` C2 is not able to fully clean up all membars as it is for mainline. This is due to the later elision of the loads. After parsing, membars do not carry information that could relate them to any particular memory access, so we cannot remove them without potentially violating the JMM. Further, the implementation of `Unsafe.getFlatValueAcquire` emits a barrier in Java that cannot be eliminated by the JIT anyways.

Testing:
 - [x] tier1,tier2 and additional stress testing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8380921](https://bugs.openjdk.org/browse/JDK-8380921): [lworld] compiler/stable/TestStableArrayMembars.java IR mismatch with preview enabled (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [9bbe2279](https://git.openjdk.org/valhalla/pull/2441/files/9bbe227938b1572a23240558843ff1a9f5b90e27)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2441/head:pull/2441` \
`$ git checkout pull/2441`

Update a local copy of the PR: \
`$ git checkout pull/2441` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2441`

View PR using the GUI difftool: \
`$ git pr show -t 2441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2441.diff">https://git.openjdk.org/valhalla/pull/2441.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2441#issuecomment-4460028814)
</details>
