### PR TITLE
8384759: [lworld] fix recently introduced typo in ObjectFree event spec

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -14148,7 +14148,7 @@ myInit() {
       must not use <jvmti/> functions except those which
       specifically allow such use (see the raw monitor, memory management,
       and environment local storage functions).
-      When preview features are enabled, this event does not supports value object allocations.
+      When preview features are enabled, this event does not support value object allocations.
     </description>
     <origin>new</origin>
     <capabilities>


### PR DESCRIPTION
This fixes recently introduced simple typo in the JVMTI `ObjectFree` event spec.
Thanks to @plummercj for catching it.

Testing: N/A

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384759](https://bugs.openjdk.org/browse/JDK-8384759): [lworld] fix recently introduced typo in ObjectFree event spec (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2443/head:pull/2443` \
`$ git checkout pull/2443`

Update a local copy of the PR: \
`$ git checkout pull/2443` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2443`

View PR using the GUI difftool: \
`$ git pr show -t 2443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2443.diff">https://git.openjdk.org/valhalla/pull/2443.diff</a>

</details>
