### PR TITLE
8384405: [lworld] C2: Load nodes inserted by InlineTypeNode::make_from_flat() need to be pinned

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -1456,7 +1456,8 @@ InlineTypeNode* InlineTypeNode::make_from_flat_impl(GraphKit* kit, ciInlineKlass
 InlineTypeNode* InlineTypeNode::make_from_flat_array(GraphKit* kit, ciInlineKlass* vk, Node* base, Node* idx) {
   assert(vk->maybe_flat_in_array(), "element type %s cannot be flat in array", vk->name()->as_utf8());
   PhaseGVN& gvn = kit->gvn();
-  DecoratorSet decorators = IN_HEAP | IS_ARRAY | MO_UNORDERED | C2_CONTROL_DEPENDENT_LOAD;
+  // The flat field loads are dependent on both the array layout checks as well as the range check.
+  DecoratorSet decorators = IN_HEAP | IS_ARRAY | MO_UNORDERED | C2_CONTROL_DEPENDENT_LOAD | C2_UNKNOWN_CONTROL_LOAD;
   kit->C->set_flat_accesses();
   InlineTypeNode* vt_nullable = nullptr;
   InlineTypeNode* vt_null_free = nullptr;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayLoadPinning.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayLoadPinning.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test correct pinning of loads from flat arrays.
+ * @bug 8384405
+ * @requires vm.compiler2.enabled
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class}
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+
+public class TestFlatArrayLoadPinning {
+
+    @LooselyConsistentValue
+    static value class MyValueWithInts {
+        int i1;
+        int i2;
+
+        MyValueWithInts(int i) {
+            i1 = i;
+            i2 = i;
+        }
+    }
+
+    static int test(MyValueWithInts[] array, int limit) {
+        int res = 0;
+        for (int i = 0; i < limit; ++i) {
+            int index = (i == 7) ? Integer.MAX_VALUE : i;
+            // If below accesses are not pinned to both the flat-array layout check,
+            // as well as the range check, they can float above and access out-of-bounds.
+            MyValueWithInts val = array[index];
+            res += val.i1 + val.i2;
+        }
+        return res;
+    }
+
+
+    public static void main(String[] args) {
+        MyValueWithInts[] array = (MyValueWithInts[])ValueClass.newNullRestrictedAtomicArray(MyValueWithInts.class, 10, new MyValueWithInts(42));
+        for (int i = 0; i < 10; ++i) {
+            try {
+                test(array, 10);
+                throw new RuntimeException("No ArrayIndexOutOfBoundsException thrown!");
+            } catch (ArrayIndexOutOfBoundsException expected) {
+                // Expected
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
@rwestrel (thanks!) noticed that flat array loads are control dependent on the flat-array layout checks, but they are not pinned strongly enough relative to the range check. New `TestFlatArrayLoadPinning.java` demonstrates this: With `-XX:+StressGCM`, C2 can schedule one of the field loads from the flat array to before the range check. When the array index is out of bounds, compiled code performs an out-of-bounds memory load from the flat array payload and crashes with a `SIGSEGV` instead of throwing the expected `ArrayIndexOutOfBoundsException`.

The fix is to use `C2_UNKNOWN_CONTROL_LOAD` for these loads.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384405](https://bugs.openjdk.org/browse/JDK-8384405): [lworld] C2: Load nodes inserted by InlineTypeNode::make_from_flat() need to be pinned (**Bug** - P4)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - Committer)


### Contributors
 * Roland Westrelin `<roland@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2445/head:pull/2445` \
`$ git checkout pull/2445`

Update a local copy of the PR: \
`$ git checkout pull/2445` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2445`

View PR using the GUI difftool: \
`$ git pr show -t 2445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2445.diff">https://git.openjdk.org/valhalla/pull/2445.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2445#issuecomment-4475931944)
</details>
