### PR TITLE
8384853: [lworld] Replay compilation fails with assert(props.is_valid()) failed: meaningless

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -892,14 +892,11 @@ class CompileReplay : public StackObj {
   }
 
   ObjArrayKlass* create_concrete_object_array_klass(ObjArrayKlass* obj_array_klass, TRAPS) {
-    const ArrayProperties array_properties(checked_cast<ArrayProperties::Type>(parse_int("array_properties")));
+    ArrayProperties array_properties(checked_cast<ArrayProperties::Type>(parse_int("array_properties")));
     if (!Arguments::is_valhalla_enabled()) {
-      // Ignore array properties.
-      return obj_array_klass;
+      // Ignore Valhalla-specific properties
+      array_properties = ArrayProperties::Default();
     }
-
-    guarantee(array_properties.is_valid(), "invalid array_properties: %d", array_properties.value());
-
     return obj_array_klass->klass_with_properties(array_properties, THREAD);
   }
 


### PR DESCRIPTION
The fix for [JDK-8377657](https://bugs.openjdk.org/browse/JDK-8377657) was incomplete: Although we should ignore array properties when `--enable-preview` is not set, we should still return a valid refined array and not a non-refined array with invalid properties.

I also removed the guarantee because we have the same check already in `klass_with_properties`. I'm omitting a regression test because these ci-replay tests are always a bit brittle.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384853](https://bugs.openjdk.org/browse/JDK-8384853): [lworld] Replay compilation fails with assert(props.is_valid()) failed: meaningless (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2447/head:pull/2447` \
`$ git checkout pull/2447`

Update a local copy of the PR: \
`$ git checkout pull/2447` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2447`

View PR using the GUI difftool: \
`$ git pr show -t 2447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2447.diff">https://git.openjdk.org/valhalla/pull/2447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2447#issuecomment-4477528901)
</details>
