### PR TITLE
8383996: [lworld] C2: assert(false) failed: no node with a side effect

### DIFF
--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -573,7 +573,8 @@ class Parse : public GraphKit {
   bool    path_is_suitable_for_uncommon_trap(float prob) const;
 
   void    do_ifnull(BoolTest::mask btest, Node* c);
-  void    do_if(BoolTest::mask btest, Node* c, bool can_trap = true, bool new_path = false, Node** ctrl_taken = nullptr, Node** stress_count_mem = nullptr);
+  void    do_if(BoolTest::mask btest, Node* c, bool can_trap = true, bool new_path = false, Node** ctrl_taken = nullptr,
+                Node** mem_taken = nullptr, Node** id_taken = nullptr);
   void    do_acmp(BoolTest::mask btest, Node* left, Node* right);
   void    acmp_always_null_input(Node* input, const TypeOopPtr* tinput, BoolTest::mask btest, Node* eq_region);
   void    acmp_type_check_or_trap(Node** non_null_input, ciKlass* input_type, Deoptimization::DeoptReason);

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1843,7 +1843,7 @@ void Parse::do_ifnull(BoolTest::mask btest, Node *c) {
 }
 
 //------------------------------------do_if------------------------------------
-void Parse::do_if(BoolTest::mask btest, Node* c, bool can_trap, bool new_path, Node** ctrl_taken, Node** stress_count_mem) {
+void Parse::do_if(BoolTest::mask btest, Node* c, bool can_trap, bool new_path, Node** ctrl_taken, Node** mem_taken, Node** io_taken) {
   int target_bci = iter().get_dest();
 
   Block* branch_block = successor_for_bci(target_bci);
@@ -1874,9 +1874,6 @@ void Parse::do_if(BoolTest::mask btest, Node* c, bool can_trap, bool new_path, N
   bool do_stress_trap = StressUnstableIfTraps && ((C->random() % 2) == 0);
   if (do_stress_trap) {
     increment_trap_stress_counter(counter, incr_store);
-    if (stress_count_mem != nullptr) {
-      *stress_count_mem = incr_store;
-    }
   }
 
   // Sanity check the probability value
@@ -1950,6 +1947,12 @@ void Parse::do_if(BoolTest::mask btest, Node* c, bool can_trap, bool new_path, N
         } else if (ctrl_taken != nullptr) {
           // Don't merge but save taken branch to be wired by caller
           *ctrl_taken = control();
+          if (mem_taken != nullptr) {
+            *mem_taken = reset_memory();
+          }
+          if (io_taken != nullptr) {
+            *io_taken = i_o();
+          }
         } else {
           merge(target_bci);
         }
@@ -2391,29 +2394,29 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   // This is the last check, do_if can emit traps now.
   Node* subst_cmp = _gvn.transform(new CmpINode(ret, intcon(1)));
   Node* ctl = C->top();
-  Node* stress_count_mem = nullptr;
+  Node* mem_taken = nullptr;
+  Node* io_taken = nullptr;
   if (btest == BoolTest::eq) {
     PreserveJVMState pjvms(this);
-    do_if(btest, subst_cmp, can_trap, false, nullptr, &stress_count_mem);
+    do_if(btest, subst_cmp, can_trap, false, nullptr, &mem_taken, &io_taken);
     if (!stopped()) {
       ctl = control();
+      mem_taken = reset_memory();
+      io_taken = i_o();
     }
   } else {
     assert(btest == BoolTest::ne, "only eq or ne");
     PreserveJVMState pjvms(this);
-    do_if(btest, subst_cmp, can_trap, false, &ctl, &stress_count_mem);
+    do_if(btest, subst_cmp, can_trap, false, &ctl, &mem_taken, &io_taken);
     if (!stopped()) {
       eq_region->init_req(2, control());
       eq_io_phi->init_req(2, i_o());
       eq_mem_phi->init_req(2, reset_memory());
     }
   }
-  if (stress_count_mem != nullptr) {
-    set_memory(stress_count_mem, stress_count_mem->adr_type());
-  }
   ne_region->init_req(5, ctl);
-  ne_io_phi->init_req(5, i_o());
-  ne_mem_phi->init_req(5, reset_memory());
+  ne_io_phi->init_req(5, io_taken);
+  ne_mem_phi->init_req(5, mem_taken);
 
   record_for_igvn(ne_region);
   set_control(_gvn.transform(ne_region));


### PR DESCRIPTION
This is an improved fix for an earlier incomplete fix (#1716). The problem with the original fix is that I assumed that the branch with the stress counter only ever contains the stress counter. The failure in the bug description shows that this assumption is incorrect.

The fix is to wire the full memory state instead. For completeness, I also wired the I/O state, just to be sure that this fix will not also be incomplete.

Testing:
 - [x] tier1,tier2,tier3 plus addtional stress testing with `--enable-preview`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383996](https://bugs.openjdk.org/browse/JDK-8383996): [lworld] C2: assert(false) failed: no node with a side effect (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2448/head:pull/2448` \
`$ git checkout pull/2448`

Update a local copy of the PR: \
`$ git checkout pull/2448` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2448`

View PR using the GUI difftool: \
`$ git pr show -t 2448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2448.diff">https://git.openjdk.org/valhalla/pull/2448.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2448#issuecomment-4478849379)
</details>
