### PR TITLE
8384642: [lworld] TestMemBars.java assert(C->failure_is_artificial()) after jdk-27+22

### DIFF
--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -778,6 +778,7 @@ bool InstructForm::captures_bottom_type(FormDict &globals) const {
        !strcmp(_matrule->_rChild->_opType,"CastLL")       ||
        !strcmp(_matrule->_rChild->_opType,"CastVV")       ||
        !strcmp(_matrule->_rChild->_opType,"CastX2P")      ||  // new result type
+       !strcmp(_matrule->_rChild->_opType,"CastI2N")      ||
        !strcmp(_matrule->_rChild->_opType,"DecodeN")      ||
        !strcmp(_matrule->_rChild->_opType,"EncodeP")      ||
        !strcmp(_matrule->_rChild->_opType,"DecodeNKlass") ||

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -211,7 +211,6 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 compiler/c2/irTests/TestFloat16ScalarOperations.java 8377808 linux-aarch64
 compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
 compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF 8384262 generic-all
-compiler/valhalla/inlinetypes/TestMemBars.java  8384642 generic-all
 
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8382548 linux-aarch64
 


### PR DESCRIPTION
[C2: Deep recursion with cmovP_regNode::bottom_type](https://bugs.openjdk.org/browse/JDK-8379667) removed
```
bool InstructForm::captures_bottom_type(FormDict &globals) const
```
But in Valhalla, we had a special case on top for `CastI2N`

https://github.com/openjdk/valhalla/blob/ef03842c0d869c7a88407a41102dacaa6a1707fa/src/hotspot/share/adlc/formssel.cpp#L781

which was removed in the merge https://github.com/openjdk/valhalla/pull/2414 (see https://github.com/openjdk/valhalla/pull/2414/changes#diff-6faeae52c6c7f235b9f763fb9b018d072e61133a1d4a56fee82fc42311f2c4f3L781)

When the changed was backed out by [[BACKOUT] C2: Deep recursion with cmovP_regNode::bottom_type](https://bugs.openjdk.org/browse/JDK-8384281) and integrated in Valhalla by https://github.com/openjdk/valhalla/pull/2440 this special case wasn't restored (see https://github.com/openjdk/valhalla/pull/2440/changes#diff-6faeae52c6c7f235b9f763fb9b018d072e61133a1d4a56fee82fc42311f2c4f3R772-R812).

The result is that CastI2N lose their types during matching, and then, a load from such a pointer can't be identified to be strict final (when loading a field from a value object), which causes the addition of wrong precedence edges in GCM, making the graph too cyclic.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384642](https://bugs.openjdk.org/browse/JDK-8384642): [lworld] TestMemBars.java assert(C-&gt;failure_is_artificial()) after jdk-27+22 (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2449/head:pull/2449` \
`$ git checkout pull/2449`

Update a local copy of the PR: \
`$ git checkout pull/2449` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2449`

View PR using the GUI difftool: \
`$ git pr show -t 2449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2449.diff">https://git.openjdk.org/valhalla/pull/2449.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2449#issuecomment-4479220568)
</details>
