### PR TITLE
8384924: [lworld] misc cleanups

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2623,6 +2623,15 @@ void MachVEPNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc* ra_) const
       __ jmp(*_verified_entry);
     }
   }
+  if (ra_->C->stub_function() == nullptr) {
+    // Pad so that the next call to MachVEPNode::emit() starts out with the
+    // correct alignment.  This is needed by entry_barrier() to aling the
+    // compare.  But unfortunately we need to align all 4 MachVEPNodes because
+    // entry point offsets are computed using scratch_emit_size(), so starting
+    // alignment must match the alignment of scratch buffer, otherwise the sizes
+    // will be off.
+    __ align(4);
+  }
 }
 
 //=============================================================================

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2600,7 +2600,6 @@ void MachVEPNode::format(PhaseRegAlloc* ra_, outputStream* st) const
 void MachVEPNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc* ra_) const
 {
   CodeBuffer* cbuf = masm->code();
-  uint insts_size = cbuf->insts_size();
   if (!_verified) {
     __ ic_check(1);
   } else {
@@ -2623,13 +2622,6 @@ void MachVEPNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc* ra_) const
     } else {
       __ jmp(*_verified_entry);
     }
-  }
-  /* WARNING these NOPs are critical so that verified entry point is properly
-     4 bytes aligned for patching by NativeJump::patch_verified_entry() */
-  int nops_cnt = 4 - ((cbuf->insts_size() - insts_size) & 0x3);
-  nops_cnt &= 0x3; // Do not add nops if code is aligned.
-  if (nops_cnt > 0) {
-    __ nop(nops_cnt);
   }
 }
 

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2625,10 +2625,10 @@ void MachVEPNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc* ra_) const
   }
   if (ra_->C->stub_function() == nullptr) {
     // Pad so that the next call to MachVEPNode::emit() starts out with the
-    // correct alignment.  This is needed by entry_barrier() to aling the
+    // correct alignment.  This is needed by entry_barrier() to align the
     // compare.  But unfortunately we need to align all 4 MachVEPNodes because
     // entry point offsets are computed using scratch_emit_size(), so starting
-    // alignment must match the alignment of scratch buffer, otherwise the sizes
+    // alignment must match the alignment of the scratch buffer, otherwise the sizes
     // will be off.
     __ align(4);
   }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -148,8 +148,6 @@ class InlineLayoutInfo : public MetaspaceObj {
 
  public:
   InlineLayoutInfo(): _klass(nullptr), _kind(LayoutKind::UNKNOWN), _null_marker_offset(-1)  {}
-  InlineLayoutInfo(InlineKlass* ik, LayoutKind kind, int size, int nm_offset):
-    _klass(ik), _kind(kind), _null_marker_offset(nm_offset) {}
 
   InlineKlass* klass() const { return _klass; }
   void set_klass(InlineKlass* k) { _klass = k; }


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384924](https://bugs.openjdk.org/browse/JDK-8384924): [lworld] misc cleanups (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2451/head:pull/2451` \
`$ git checkout pull/2451`

Update a local copy of the PR: \
`$ git checkout pull/2451` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2451`

View PR using the GUI difftool: \
`$ git pr show -t 2451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2451.diff">https://git.openjdk.org/valhalla/pull/2451.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2451#issuecomment-4482614965)
</details>
