### PR TITLE
8381373: [lworld] C2 failed assert(!flat || flat_array) failed: inconsistency

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -666,7 +666,7 @@ bool ciMethod::parameter_profiled_type(int i, ciKlass*& type, ProfilePtrKind& pt
 
 // MDO updates are racy. C2 can observe the array type before the profiling code has updated the
 // corresponding flat/null-free flags. If the array type is known, prefer the properties it provides.
-static void sanitize_array_access_profile(ciKlass* array_type, bool& flat_array, bool& null_free_array) {
+static void update_flags_from_type(ciKlass* array_type, bool& flat_array, bool& null_free_array) {
   if (array_type != nullptr) {
     flat_array |= array_type->is_flat_array_klass();
     null_free_array |= array_type->as_array_klass()->is_elem_null_free();
@@ -684,14 +684,14 @@ bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass
         element_ptr = array_access->element()->ptr_kind();
         flat_array = array_access->flat_array();
         null_free_array = array_access->null_free_array();
-        sanitize_array_access_profile(array_type, flat_array, null_free_array);
+        update_flags_from_type(array_type, flat_array, null_free_array);
         return true;
       } else if (data->is_ArrayStoreData()) {
         ciArrayStoreData* array_access = (ciArrayStoreData*) data->as_ArrayStoreData();
         array_type = array_access->array()->valid_type();
         flat_array = array_access->flat_array();
         null_free_array = array_access->null_free_array();
-        sanitize_array_access_profile(array_type, flat_array, null_free_array);
+        update_flags_from_type(array_type, flat_array, null_free_array);
         ciCallProfile call_profile = call_profile_at_bci(bci);
         if (call_profile.morphism() == 1) {
           element_type = call_profile.receiver(0);

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -685,14 +685,6 @@ bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass
         flat_array = array_access->flat_array();
         null_free_array = array_access->null_free_array();
         sanitize_array_access_profile(array_type, flat_array, null_free_array);
-#ifdef ASSERT
-        if (array_type != nullptr) {
-          bool flat = array_type->is_flat_array_klass();
-          bool null_free = array_type->as_array_klass()->is_elem_null_free();
-          assert(!flat || flat_array, "inconsistency");
-          assert(!null_free || null_free_array, "inconsistency");
-        }
-#endif
         return true;
       } else if (data->is_ArrayStoreData()) {
         ciArrayStoreData* array_access = (ciArrayStoreData*) data->as_ArrayStoreData();
@@ -713,14 +705,6 @@ bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass
         } else {
           element_ptr = ProfileMaybeNull;
         }
-#ifdef ASSERT
-        if (array_type != nullptr) {
-          bool flat = array_type->is_flat_array_klass();
-          bool null_free = array_type->as_array_klass()->is_elem_null_free();
-          assert(!flat || flat_array, "inconsistency");
-          assert(!null_free || null_free_array, "inconsistency");
-        }
-#endif
         return true;
       }
     }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -664,6 +664,15 @@ bool ciMethod::parameter_profiled_type(int i, ciKlass*& type, ProfilePtrKind& pt
   return false;
 }
 
+// MDO updates are racy. C2 can observe the array type before the profiling code has updated the
+// corresponding flat/null-free flags. If the array type is known, prefer the properties it provides.
+static void sanitize_array_access_profile(ciKlass* array_type, bool& flat_array, bool& null_free_array) {
+  if (array_type != nullptr) {
+    flat_array |= array_type->is_flat_array_klass();
+    null_free_array |= array_type->as_array_klass()->is_elem_null_free();
+  }
+}
+
 bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass*& element_type, ProfilePtrKind& element_ptr, bool &flat_array, bool &null_free_array) {
   if (method_data() != nullptr && method_data()->is_mature()) {
     ciProfileData* data = method_data()->bci_to_data(bci);
@@ -675,6 +684,7 @@ bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass
         element_ptr = array_access->element()->ptr_kind();
         flat_array = array_access->flat_array();
         null_free_array = array_access->null_free_array();
+        sanitize_array_access_profile(array_type, flat_array, null_free_array);
 #ifdef ASSERT
         if (array_type != nullptr) {
           bool flat = array_type->is_flat_array_klass();
@@ -689,6 +699,7 @@ bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass
         array_type = array_access->array()->valid_type();
         flat_array = array_access->flat_array();
         null_free_array = array_access->null_free_array();
+        sanitize_array_access_profile(array_type, flat_array, null_free_array);
         ciCallProfile call_profile = call_profile_at_bci(bci);
         if (call_profile.morphism() == 1) {
           element_type = call_profile.receiver(0);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessProfileRace.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessProfileRace.java
@@ -41,7 +41,7 @@ import jdk.test.whitebox.WhiteBox;
  *          java.base/jdk.internal.vm.annotation
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI 
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::profileArray
  *                   ${test.main.class}
  */

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessProfileRace.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessProfileRace.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.lang.reflect.Method;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.test.lib.Utils;
+import jdk.test.whitebox.WhiteBox;
+
+/*
+ * @test
+ * @key randomness
+ * @summary Test racy array access profiling.
+ * @bug 8381373
+ * @library /test/lib /
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI 
+ *                   -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::profileArray
+ *                   ${test.main.class}
+ */
+public class TestArrayAccessProfileRace {
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final int C1_FULL_PROFILE = 3;
+    private static final int C2 = 4;
+    private static volatile boolean startProfiling;
+
+    @LooselyConsistentValue
+    static value class ArrayAccessValue {
+        int x;
+
+        ArrayAccessValue(int x) {
+            this.x = x;
+        }
+    }
+
+    // Trigger array load/store profiling
+    static int profileArray(Object[] array, Object val) {
+        int sum = 0;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        sum += ((ArrayAccessValue)array[0]).x;
+        array[0] = val;
+        return sum;
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Create an array with random properties
+        Object[] array;
+        Object val = new ArrayAccessValue(42);
+        int arrayKind = Utils.getRandomInstance().nextInt(5);
+        switch (arrayKind) {
+            case 0:
+                array = new ArrayAccessValue[1];
+                array[0] = val;
+                break;
+            case 1:
+                array = ValueClass.newNullRestrictedNonAtomicArray(ArrayAccessValue.class, 1, val);
+                break;
+            case 2:
+                array = ValueClass.newNullRestrictedAtomicArray(ArrayAccessValue.class, 1, val);
+                break;
+            case 3:
+                array = ValueClass.newNullableAtomicArray(ArrayAccessValue.class, 1);
+                array[0] = val;
+                break;
+            case 4:
+                array = ValueClass.newReferenceArray(ArrayAccessValue.class, 1);
+                array[0] = val;
+                break;
+            default:
+                throw new RuntimeException("Unexpected arrayKind: " + arrayKind);
+        }
+        Method method = TestArrayAccessProfileRace.class.getDeclaredMethod("profileArray", Object[].class, Object.class);
+
+        for (int i = 0; i < 100; i++) {
+            // Reset profile information
+            startProfiling = false;
+            WB.deoptimizeMethod(method);
+            WB.clearMethodState(method);
+
+            // C1 compile the profiling method and mark the profile
+            // as mature so that C2 will consume it immediately
+            WB.enqueueMethodForCompilation(method, C1_FULL_PROFILE);
+            WB.markMethodProfiled(method);
+
+            // Profile asynchronously to the C2 compilation
+            Thread profiler = new Thread(() -> {
+                while (!startProfiling) {
+                    Thread.onSpinWait();
+                }
+                profileArray(array, val);
+            });
+            profiler.start();
+
+            // Start profiling and C2 compilation in the hope
+            // that this will trigger the race.
+            startProfiling = true;
+            WB.enqueueMethodForCompilation(method, C2);
+            profiler.join();
+        }
+    }
+}
+


### PR DESCRIPTION
C1/interpreter array-access profiling is racy and can publish the exact array klass before the flat/null-free flag is visible:
https://github.com/openjdk/valhalla/blob/f87d6d1cea3b578b458075a411f7aaa5dddb2cd9/src/hotspot/share/c1/c1_LIRGenerator.cpp#L1968-L1971

C2 reads profile information lock-free and can therefore, in rare cases, observe the inconsistencies reported in the JBS issue. For example, it can observe profiling for an array load with an `array_type` that is knowingly flat but does not have the `flat_array` property set (yet). The new regression test reliably reproduces such inconsistencies for array loads and stores.

Since a valid profiled flat array klass is stronger information than the flat flag, the fix is to prefer that information if available. With that fix, the asserts don't make much sense anymore, so I removed them.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8381373](https://bugs.openjdk.org/browse/JDK-8381373): [lworld] C2 failed assert(!flat || flat_array) failed: inconsistency (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer) ⚠️ Review applies to [f693fc00](https://git.openjdk.org/valhalla/pull/2452/files/f693fc0013f800df702d85b712982de1e01871de)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role) ⚠️ Review applies to [f693fc00](https://git.openjdk.org/valhalla/pull/2452/files/f693fc0013f800df702d85b712982de1e01871de)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2452/head:pull/2452` \
`$ git checkout pull/2452`

Update a local copy of the PR: \
`$ git checkout pull/2452` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2452`

View PR using the GUI difftool: \
`$ git pr show -t 2452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2452.diff">https://git.openjdk.org/valhalla/pull/2452.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2452#issuecomment-4488943374)
</details>
