### PR TITLE
8385010: [lworld] cherry-pick JDK-8384124 TestCompilerCounts.java fails CICompilerCount is too large

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -67,7 +67,7 @@ JVMFlag::Error CICompilerCountConstraintFunc(intx value, bool verbose) {
 #ifndef ASSERT
   int active_processor_count = os::active_processor_count();
   // On a single-CPU machine we still can run C1 and C2 compiler threads, so allow up to 2x for tiered.
-  int reasonable_threads_num = CompilerConfig::is_tiered() ? active_processor_count * 2 : active_processor_count;
+  int reasonable_threads_num = MAX2(2, CompilerConfig::is_tiered() ? active_processor_count * 2 : active_processor_count);
   if (value > reasonable_threads_num) {
     JVMFlag::printError(verbose, "CICompilerCount is too large (%" PRIdPTR ") for current active processor count %d \n",
                         CICompilerCount, active_processor_count);

--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -23,7 +23,7 @@
 
 /*
  * @test CheckCheckCICompilerCount
- * @bug 8130858 8132525 8162881 8379396
+ * @bug 8130858 8132525 8162881 8379396 8384124
  * @summary Check that correct range of values for CICompilerCount are allowed depending on whether tiered is enabled or not
  * @library /test/lib /
  * @requires vm.flagless
@@ -204,6 +204,41 @@ public class CheckCICompilerCount {
         1,
     };
 
+    private static final String[][] ACTIVE_PROCESSOR_ARGUMENTS = {
+        {
+            "-server",
+            "-XX:ActiveProcessorCount=1",
+            "-XX:TieredStopAtLevel=0",
+            "-XX:+PrintFlagsFinal",
+            "-version"
+        },
+        {
+            "-server",
+            "-XX:ActiveProcessorCount=1",
+            "-XX:TieredStopAtLevel=1",
+            "-XX:+PrintFlagsFinal",
+            "-version"
+        },
+        {
+            "-server",
+            "-XX:ActiveProcessorCount=1",
+            "-XX:+PrintFlagsFinal",
+            "-version"
+        },
+    };
+
+    private static final String[] ACTIVE_PROCESSOR_EXPECTED_OUTPUTS = {
+            "intx CICompilerCount                          = 0                                         {product}",
+            "intx CICompilerCount                          = 1                                         {product}",
+            "intx CICompilerCount                          = 2                                         {product}",
+    };
+
+    private static final int[] ACTIVE_PROCESSOR_EXIT = {
+        0,
+        0,
+        0,
+    };
+
     private static void verifyOptionBehavior(String[] arguments, String expected_output, int exit, boolean tiered) throws Exception {
         ProcessBuilder pb;
         OutputAnalyzer out;
@@ -232,6 +267,14 @@ public class CheckCICompilerCount {
             throw new RuntimeException("Test is set up incorrectly: length of arguments, expected outputs and exit codes in tiered mode of operation do not match.");
         }
 
+        if (INVALID_ARGUMENTS.length != INVALID_EXPECTED_OUTPUTS.length || INVALID_ARGUMENTS.length != INVALID_EXIT.length) {
+            throw new RuntimeException("Test is set up incorrectly: length of arguments, expected outputs and exit codes in invalid arguments cases do not match.");
+        }
+
+        if (ACTIVE_PROCESSOR_ARGUMENTS.length != ACTIVE_PROCESSOR_EXPECTED_OUTPUTS.length || ACTIVE_PROCESSOR_ARGUMENTS.length != ACTIVE_PROCESSOR_EXIT.length) {
+            throw new RuntimeException("Test is set up incorrectly: length of arguments, expected outputs and exit codes in ActiveProcessorCount cases do not match.");
+        }
+
         for (int i = 0; i < NON_TIERED_ARGUMENTS.length; i++) {
             verifyOptionBehavior(NON_TIERED_ARGUMENTS[i], NON_TIERED_EXPECTED_OUTPUTS[i], NON_TIERED_EXIT[i], false);
         }
@@ -242,6 +285,13 @@ public class CheckCICompilerCount {
 
         for (int i = 0; i < INVALID_ARGUMENTS.length; i++) {
             verifyOptionBehavior(INVALID_ARGUMENTS[i], INVALID_EXPECTED_OUTPUTS[i], INVALID_EXIT[i], true);
+        }
+
+        for (int i = 0; i < ACTIVE_PROCESSOR_ARGUMENTS.length; i++) {
+            verifyOptionBehavior(ACTIVE_PROCESSOR_ARGUMENTS[i],
+                                 ACTIVE_PROCESSOR_EXPECTED_OUTPUTS[i],
+                                 ACTIVE_PROCESSOR_EXIT[i],
+                                 false);
         }
     }
 }


### PR DESCRIPTION
A trivial cherry-pick of the following fix from main-line:

[JDK-8385010](https://bugs.openjdk.org/browse/JDK-8385010) [lworld] cherry-pick JDK-8384124 TestCompilerCounts.java fails CICompilerCount is too large

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385010](https://bugs.openjdk.org/browse/JDK-8385010): [lworld] cherry-pick JDK-8384124 TestCompilerCounts.java fails CICompilerCount is too large (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2455/head:pull/2455` \
`$ git checkout pull/2455`

Update a local copy of the PR: \
`$ git checkout pull/2455` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2455`

View PR using the GUI difftool: \
`$ git pr show -t 2455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2455.diff">https://git.openjdk.org/valhalla/pull/2455.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2455#issuecomment-4490471631)
</details>
