### PR TITLE
8385015: [lworld] cherry-pick JDK-8384553 ProblemList runtime/jni/critical/SuspendInCritical.java for virtual threads

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -24,6 +24,7 @@
 ####
 # Bugs
 
+runtime/jni/critical/SuspendInCritical.java 8384369 generic-all
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8308026 generic-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all


### PR DESCRIPTION
A trivial cherry-pick of the following fix from main-line:

[JDK-8384553](https://bugs.openjdk.org/browse/JDK-8384553) ProblemList runtime/jni/critical/SuspendInCritical.java for virtual threads

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385015](https://bugs.openjdk.org/browse/JDK-8385015): [lworld] cherry-pick JDK-8384553 ProblemList runtime/jni/critical/SuspendInCritical.java for virtual threads (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2457/head:pull/2457` \
`$ git checkout pull/2457`

Update a local copy of the PR: \
`$ git checkout pull/2457` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2457`

View PR using the GUI difftool: \
`$ git pr show -t 2457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2457.diff">https://git.openjdk.org/valhalla/pull/2457.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2457#issuecomment-4490726102)
</details>
