### PR TITLE
8385021: [lworld] ProblemList vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -65,4 +65,9 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 
 # Valhalla failures start here:
 
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#AVF 8374742 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF 8374742 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-AVF 8374742 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF 8374742 generic-all
+
 runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8378071 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -216,6 +216,7 @@ serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compil
 
 vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java 8375062 windows-x64
 vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java 8375076 windows-x64
+vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all
 
 # The following test failures DID NOT reproduce during Tier[1-8] testing
 # done for 8377828. Further analysis is being done with 8376235:


### PR DESCRIPTION
Trivial fixes to ProblemList tests:

- [JDK-8385021](https://bugs.openjdk.org/browse/JDK-8385021) [lworld] ProblemList vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java
- [JDK-8385023](https://bugs.openjdk.org/browse/JDK-8385023) [lworld] ProblemList tests afffected by JDK-8374742 in Xcomp

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385021](https://bugs.openjdk.org/browse/JDK-8385021): [lworld] ProblemList vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java (**Sub-task** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2458/head:pull/2458` \
`$ git checkout pull/2458`

Update a local copy of the PR: \
`$ git checkout pull/2458` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2458`

View PR using the GUI difftool: \
`$ git pr show -t 2458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2458.diff">https://git.openjdk.org/valhalla/pull/2458.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2458#issuecomment-4491916946)
</details>
