### PR TITLE
8374742: [lworld] assert(phi->_idx >= nodes_size()) failed: only new Phi per instance memory slice

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1004,7 +1004,7 @@ void ShenandoahBarrierSetC2::eliminate_gc_barrier(PhaseIterGVN* igvn, Node* node
             continue;
           }
           assert(mem->is_Store(), "store required");
-          macro->replace_node(mem, mem->in(MemNode::Memory));
+          igvn->replace_node(mem, mem->in(MemNode::Memory));
         }
       }
     }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4608,6 +4608,8 @@ Node* ConnectionGraph::find_inst_mem(Node *orig_mem, int alias_idx, GrowableArra
           }
         }
         result = proj_in->in(TypeFunc::Memory);
+      } else if (proj_in->is_LoadFlat()) {
+        result = proj_in->in(TypeFunc::Memory);
       }
     } else if (result->is_MergeMem()) {
       MergeMemNode *mmem = result->as_MergeMem();

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -65,9 +65,4 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 
 # Valhalla failures start here:
 
-compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#AVF 8374742 generic-all
-compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF 8374742 generic-all
-compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-AVF 8374742 generic-all
-compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF 8374742 generic-all
-
 runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8378071 generic-all

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayMemoryPhi.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayMemoryPhi.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+
+/*
+ * @test
+ * @summary Test EA memory splitting with pre-existing flat array memory Phis.
+ * @requires vm.gc.Z
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @run main/othervm -XX:+UseZGC -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+public class TestFlatArrayMemoryPhi {
+    static value class MyValue {
+        byte b1 = 42;
+        byte b2 = 43;
+    }
+
+    static MyValue[] array = (MyValue[])ValueClass.newReferenceArray(MyValue.class, 2);
+
+    static void equals(MyValue a, MyValue b) {
+        if (a != b && !a.equals(b)) {
+            throw new RuntimeException("Unexpected result");
+        }
+    }
+
+    public static void test() {
+        MyValue[] flatArray = new MyValue[2];
+
+        equals(array[0], array[0]);
+        equals(flatArray[1], flatArray[1]);
+        equals(flatArray[0], array[0]);
+    }
+
+    public static void main(String[] args) {
+        test();
+    }
+}
+


### PR DESCRIPTION
EA runs a first time, finds a non escaping allocation, splits unique
types, creates extra phi nodes, then `LoadFlat` nodes for that
allocation are expanded. EA runs a second time. At a `Region`, it
finds 2 `Phi` for alias 19:
```
1866  Phi  === 1206 1867 1858  [[ 1948 1304 1855 1317 1250 1936 1263 ]]  #memory  Memory: @aryptr:flat:atomic:instptr:compiler/valhalla/inlinetypes/TestFlatArrayMemoryPhi$MyValue:BotPTR:exact *,iid=bot[int:2] (java/lang/Cloneable,java/io/Serializable):NotNull:exact:flat():atomic+any,iid=44, name=b1, idx=19; !orig=[1208],[1938],[1553],[1239] !jvms: TestFlatArrayMemoryPhi::test @ bci:34 (line 58)
2073  Phi  === 1206 1149 1858  [[ 1948 2061 ]]  #memory  Memory: @aryptr:flat:atomic:instptr:compiler/valhalla/inlinetypes/TestFlatArrayMemoryPhi$MyValue:BotPTR:exact *,iid=bot[int:2] (java/lang/Cloneable,java/io/Serializable):NotNull:exact:flat():atomic+any,iid=44, name=b1, idx=19; !orig=2060,[1208],[1938],[1553],[1239] !jvms: TestFlatArrayMemoryPhi::test @ bci:34 (line 58)
```

The first one was created by EA on its first run. The second was
created after the first round of EA: it's the result of the
transformation of `(Phi (MergeMem ))` into `(MergeMem (Phi ..) (Phi ..)`.

The second `Phi` references another bottom memory `Phi` (1149) and
that confuses the logic of EA.

The reason, that second `Phi` is created after EA is that initially
the bottom `Phi` has a `LoadFlat` as input but it gets removed because
it's from the non escaping allocation and the `Phi`'s input becomes a
`MergeMem`. To fix that, I propose that the logic that finds the
memory state for a particular alias during EA skips over `LoadFloat`
nodes: either a `LoadFloat` is for the current non escaping allocation
and it's going away anyway or it's from some other allocation and it's
unrelated.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8374742](https://bugs.openjdk.org/browse/JDK-8374742): [lworld] assert(phi-&gt;_idx &gt;= nodes_size()) failed: only new Phi per instance memory slice (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2459/head:pull/2459` \
`$ git checkout pull/2459`

Update a local copy of the PR: \
`$ git checkout pull/2459` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2459`

View PR using the GUI difftool: \
`$ git pr show -t 2459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2459.diff">https://git.openjdk.org/valhalla/pull/2459.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2459#issuecomment-4499357729)
</details>
