### PR TITLE
8385025: [lworld] TestStableArrayMembars.java still fails after JDK-8380921

### DIFF
--- a/test/hotspot/jtreg/compiler/stable/TestStableArrayMembars.java
+++ b/test/hotspot/jtreg/compiler/stable/TestStableArrayMembars.java
@@ -131,7 +131,8 @@ public class TestStableArrayMembars {
     @IR(counts = { IRNode.MEMBAR, ">0",
                    IRNode.LOAD, "=1"}, // There is exactly one load fence, but no load
         applyIfAnd = {"enable-valhalla", "true",
-                      "UseArrayFlattening", "true"})
+                      "UseArrayFlattening", "true",
+                      "TieredCompilation", "true"})
     static Integer test() {
         return la.get(0);
     }


### PR DESCRIPTION
Please kindly review this trivial test fix. My testing in JDK-8380921 failed to observe the intermittent failure of the new `--enable-preview` IR rule with `-XX:-TieredCompilation`. The comment further up thus also holds for Valhalla, granted, intermittently. Thus, I opted to disable the rule when tiered compilation is turned off.

Thanks,   
Manuel

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385025](https://bugs.openjdk.org/browse/JDK-8385025): [lworld] TestStableArrayMembars.java still fails after JDK-8380921 (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2460/head:pull/2460` \
`$ git checkout pull/2460`

Update a local copy of the PR: \
`$ git checkout pull/2460` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2460`

View PR using the GUI difftool: \
`$ git pr show -t 2460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2460.diff">https://git.openjdk.org/valhalla/pull/2460.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2460#issuecomment-4505521510)
</details>
