### PR TITLE
8385167: [lworld] C1: minor cleanups

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -277,9 +277,9 @@ class InstructionVisitor: public StackObj {
     return (enabled) ? HASH5(name(), f1, f2, f3, f4) : 0; \
   }                                                   \
   virtual bool is_equal(Value v) const {              \
-    if (!(enabled)  ) return false;                   \
+    if (!(enabled)) return false;                     \
     class_name* _v = v->as_##class_name();            \
-    if (_v == nullptr  ) return false;                   \
+    if (_v == nullptr) return false;                  \
     if (f1 != _v->f1) return false;                   \
     if (f2 != _v->f2) return false;                   \
     if (f3 != _v->f3) return false;                   \
@@ -934,7 +934,8 @@ BASE(AccessIndexed, AccessArray)
   , _length(length)
   , _elt_type(elt_type)
   , _mismatched(mismatched)
-  , _profiled_method(nullptr), _profiled_bci(0)
+  , _profiled_method(nullptr)
+  , _profiled_bci(0)
   {
     set_flag(Instruction::NeedsRangeCheckFlag, true);
     ASSERT_VALUES
@@ -957,7 +958,6 @@ BASE(AccessIndexed, AccessArray)
   bool      should_profile() const                   { return check_flag(ProfileMDOFlag); }
   ciMethod* profiled_method() const                  { return _profiled_method;     }
   int       profiled_bci() const                     { return _profiled_bci;        }
-
 
   // generic
   virtual void input_values_do(ValueVisitor* f)   { AccessArray::input_values_do(f); f->visit(&_index); if (_length != nullptr) f->visit(&_length); }
@@ -1182,7 +1182,7 @@ LEAF(IfOp, Op2)
   Condition cond() const                         { return (Condition)Op2::op(); }
   Value tval() const                             { return _tval; }
   Value fval() const                             { return _fval; }
-  bool substitutability_check() const             { return _substitutability_check; }
+  bool substitutability_check() const            { return _substitutability_check; }
   // generic
   virtual void input_values_do(ValueVisitor* f)   { Op2::input_values_do(f); f->visit(&_tval); f->visit(&_fval); }
 };
@@ -1500,7 +1500,7 @@ LEAF(CheckCast, TypeCheck)
  public:
   // creation
   CheckCast(ciKlass* klass, Value obj, ValueStack* state_before)
-  : TypeCheck(klass, obj, objectType, state_before) { }
+  : TypeCheck(klass, obj, objectType, state_before) {}
 
   void set_incompatible_class_change_check() {
     set_flag(ThrowIncompatibleClassChangeErrorFlag, true);
@@ -2073,7 +2073,7 @@ LEAF(If, BlockEnd)
   void set_profiled_method(ciMethod* method)      { _profiled_method = method; }
   void set_profiled_bci(int bci)                  { _profiled_bci = bci;       }
   void set_swapped(bool value)                    { _swapped = value;         }
-  bool substitutability_check() const              { return _substitutability_check; }
+  bool substitutability_check() const             { return _substitutability_check; }
   // generic
   virtual void input_values_do(ValueVisitor* f)   { BlockEnd::input_values_do(f); f->visit(&_x); f->visit(&_y); }
 };

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -500,6 +500,7 @@ void InstructionPrinter::do_NewTypeArray(NewTypeArray* x) {
   output()->put(']');
 }
 
+
 void InstructionPrinter::do_NewObjectArray(NewObjectArray* x) {
   output()->print("new object array [");
   print_value(x->length());
@@ -518,6 +519,7 @@ void InstructionPrinter::do_NewMultiArray(NewMultiArray* x) {
   output()->print("] ");
   print_klass(x->klass());
 }
+
 
 void InstructionPrinter::do_MonitorEnter(MonitorEnter* x) {
   output()->print("enter ");

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -331,6 +331,7 @@ void LIR_Assembler::check_no_unbound_labels() {
 
 //----------------------------------debug info--------------------------------
 
+
 void LIR_Assembler::add_debug_info_for_branch(CodeEmitInfo* info) {
   int pc_offset = code_offset();
   flush_debug_info(pc_offset);

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3679,7 +3679,6 @@ bool LIRGenerator::profile_inline_klass(ciMethodData* md, ciProfileData* data, V
   return true;
 }
 
-
 void LIRGenerator::do_ProfileACmpTypes(ProfileACmpTypes* x) {
   ciMethod* method = x->method();
   assert(method != nullptr, "method should be set if branch is profiled");

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -216,7 +216,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   LIR_Opr load_constant(Constant* x);
   LIR_Opr load_constant(LIR_Const* constant);
 
-  bool in_conditional_code() { return _in_conditional_code; }
+  bool in_conditional_code() const { return _in_conditional_code; }
   // Given an immediate value, return an operand usable in logical ops.
   LIR_Opr load_immediate(jlong x, BasicType type);
 

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -50,7 +50,6 @@ class C1_MacroAssembler: public MacroAssembler {
     return scalarized_entry(ces, frame_size_in_bytes, bang_size_in_bytes, sp_offset_for_orig_pc, verified_inline_entry_label, true);
   }
   void verified_entry(bool breakAtEntry);
-
   void verify_stack_oop(int offset) PRODUCT_RETURN;
   void verify_not_null_oop(Register r)  PRODUCT_RETURN;
 


### PR DESCRIPTION
The goal of this PR is to proactively fix some nitpicks in the C1 source that might come up in the review of the big PR. The secondary goal is to remove some unnecessary empty lines in the diff that do nothing but distract.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385167](https://bugs.openjdk.org/browse/JDK-8385167): [lworld] C1: minor cleanups (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2462/head:pull/2462` \
`$ git checkout pull/2462`

Update a local copy of the PR: \
`$ git checkout pull/2462` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2462`

View PR using the GUI difftool: \
`$ git pr show -t 2462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2462.diff">https://git.openjdk.org/valhalla/pull/2462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2462#issuecomment-4510445274)
</details>
