### PR TITLE
8385259: [lworld] Clean up LP64 in x86 code

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -756,9 +756,9 @@ void TemplateTable::index_check(Register array, Register index)
   Label ok;
   __ br(Assembler::LO, ok);
   // ??? convention: move array into r3 for exception message
-   __ mov(r3, array);
-   __ mov(rscratch1, Interpreter::_throw_ArrayIndexOutOfBoundsException_entry);
-   __ br(rscratch1);
+  __ mov(r3, array);
+  __ mov(rscratch1, Interpreter::_throw_ArrayIndexOutOfBoundsException_entry);
+  __ br(rscratch1);
   __ bind(ok);
 }
 

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -86,8 +86,8 @@ define_pd_global(bool, PreserveFramePointer, false);
 
 define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
 
-define_pd_global(bool, InlineTypePassFieldsAsArgs, LP64_ONLY(true) NOT_LP64(false));
-define_pd_global(bool, InlineTypeReturnedAsFields, LP64_ONLY(true) NOT_LP64(false));
+define_pd_global(bool, InlineTypePassFieldsAsArgs, true);
+define_pd_global(bool, InlineTypeReturnedAsFields, true);
 
 #define ARCH_FLAGS(develop,                                                 \
                    product,                                                 \

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -292,7 +292,7 @@ void InterpreterMacroAssembler::call_VM_leaf_base(address entry_point,
   // super call
   MacroAssembler::call_VM_leaf_base(entry_point, number_of_arguments);
   // interpreter specific
-  // LP64: Used to ASSERT that r13/r14 were equal to frame's bcp/locals
+  // Used to ASSERT that r13/r14 were equal to frame's bcp/locals
   // but since they may not have been saved (and we don't want to
   // save them here (see note above) the assert is invalid.
 }
@@ -430,7 +430,7 @@ void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result,
                                          Register arg_1,
                                          Register arg_2,
                                          bool check_exceptions) {
-  LP64_ONLY(assert_different_registers(arg_1, c_rarg2));
+  assert_different_registers(arg_1, c_rarg2);
   pass_arg2(this, arg_2);
   pass_arg1(this, arg_1);
   call_VM_preemptable_helper(oop_result, entry_point, 2, check_exceptions);
@@ -1074,9 +1074,6 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     // Check if we are returning a non-null inline type and load its fields into registers
     test_oop_is_not_inline_type(rax, rscratch1, skip, /* can_be_null= */ false);
 
-#ifndef _LP64
-    super_call_VM_leaf(StubRoutines::load_inline_type_fields_in_regs());
-#else
     // Load fields from a buffered value with an inline class specific handler
     load_klass(rdi, rax, rscratch1);
     movptr(rdi, Address(rdi, InlineKlass::adr_members_offset()));
@@ -1085,7 +1082,6 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     testptr(rdi, rdi);
     jcc(Assembler::zero, skip);
     call(rdi);
-#endif
     // call above kills the value in rbx. Reload it.
     movptr(rbx, Address(rbp, frame::interpreter_frame_sender_sp_offset * wordSize));
     bind(skip);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2446,40 +2446,20 @@ void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int
 
 void MacroAssembler::test_flat_array_oop(Register oop, Register temp_reg,
                                          Label& is_flat_array) {
-#ifdef _LP64
   test_oop_prototype_bit(oop, temp_reg, markWord::flat_array_bit_in_place, true, is_flat_array);
-#else
-  load_klass(temp_reg, oop, noreg);
-  movl(temp_reg, Address(temp_reg, Klass::layout_helper_offset()));
-  test_flat_array_layout(temp_reg, is_flat_array);
-#endif
 }
 
 void MacroAssembler::test_non_flat_array_oop(Register oop, Register temp_reg,
                                              Label& is_non_flat_array) {
-#ifdef _LP64
   test_oop_prototype_bit(oop, temp_reg, markWord::flat_array_bit_in_place, false, is_non_flat_array);
-#else
-  load_klass(temp_reg, oop, noreg);
-  movl(temp_reg, Address(temp_reg, Klass::layout_helper_offset()));
-  test_non_flat_array_layout(temp_reg, is_non_flat_array);
-#endif
 }
 
 void MacroAssembler::test_null_free_array_oop(Register oop, Register temp_reg, Label&is_null_free_array) {
-#ifdef _LP64
   test_oop_prototype_bit(oop, temp_reg, markWord::null_free_array_bit_in_place, true, is_null_free_array);
-#else
-  Unimplemented();
-#endif
 }
 
 void MacroAssembler::test_non_null_free_array_oop(Register oop, Register temp_reg, Label&is_non_null_free_array) {
-#ifdef _LP64
   test_oop_prototype_bit(oop, temp_reg, markWord::null_free_array_bit_in_place, false, is_non_null_free_array);
-#else
-  Unimplemented();
-#endif
 }
 
 void MacroAssembler::test_flat_array_layout(Register lh, Label& is_flat_array) {
@@ -6061,7 +6041,6 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
   jcc(Assembler::zero, skip);
   int call_offset = -1;
 
-#ifdef _LP64
   // The following code is similar to allocation code in TemplateTable::_new but has some slight differences,
   // e.g. object size is always not zero, sometimes it's constant; storing klass ptr after
   // allocating is not necessary if vk != nullptr, etc.
@@ -6126,7 +6105,6 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
   // tell. That runtime call will take care of preserving them
   // across a GC if there's one.
   mov(rax, rscratch1);
-#endif
 
   if (from_interpreter) {
     super_call_VM_leaf(StubRoutines::store_inline_type_fields_to_buf());


### PR DESCRIPTION
Please review this trivial patch to fix some formatting diff and to remove LP64 in the x86 code that is no longer needed.
Testing with tier1 in progress.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385259](https://bugs.openjdk.org/browse/JDK-8385259): [lworld] Clean up LP64 in x86 code (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2463/head:pull/2463` \
`$ git checkout pull/2463`

Update a local copy of the PR: \
`$ git checkout pull/2463` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2463`

View PR using the GUI difftool: \
`$ git pr show -t 2463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2463.diff">https://git.openjdk.org/valhalla/pull/2463.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2463#issuecomment-4514402899)
</details>
