### PR TITLE
8385301: [lworld] Remove serviceability/sa/TestJhsdbJstackMixedWithXComp.java from problem list

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -212,8 +212,6 @@ compiler/c2/irTests/TestFloat16ScalarOperations.java 8377808 linux-aarch64
 compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
 compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF 8384262 generic-all
 
-serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8382548 linux-aarch64
-
 vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java 8375062 windows-x64
 vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java 8375076 windows-x64
 vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all


### PR DESCRIPTION
[JDK-8382548](https://bugs.openjdk.org/browse/JDK-8382548) was fixed in mainline and integrated into the valhalla repo. There is no longer a need for valhalla to problem list the test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385301](https://bugs.openjdk.org/browse/JDK-8385301): [lworld] Remove serviceability/sa/TestJhsdbJstackMixedWithXComp.java from problem list (**Sub-task** - P4)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2465/head:pull/2465` \
`$ git checkout pull/2465`

Update a local copy of the PR: \
`$ git checkout pull/2465` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2465`

View PR using the GUI difftool: \
`$ git pr show -t 2465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2465.diff">https://git.openjdk.org/valhalla/pull/2465.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2465#issuecomment-4514118440)
</details>
