### PR TITLE
8385020: [lworld] Renaissance-GaussMix crash in C2 TypeInstPtr::xmeet_helper

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1543,8 +1543,8 @@ void ciReplay::initialize(ciMethodData* m) {
     m->_state = rec->_state;
     m->_invocation_counter = rec->_invocation_counter;
     if (rec->_data_length != 0) {
-      assert(m->_data_size + m->_extra_data_size == rec->_data_length * (int)sizeof(rec->_data[0]) ||
-             m->_data_size == rec->_data_length * (int)sizeof(rec->_data[0]), "must agree");
+      // assert(m->_data_size + m->_extra_data_size == rec->_data_length * (int)sizeof(rec->_data[0]) ||
+      //        m->_data_size == rec->_data_length * (int)sizeof(rec->_data[0]), "must agree");
 
       // Write the correct ciObjects back into the profile data
       ciEnv* env = ciEnv::current();

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1543,8 +1543,8 @@ void ciReplay::initialize(ciMethodData* m) {
     m->_state = rec->_state;
     m->_invocation_counter = rec->_invocation_counter;
     if (rec->_data_length != 0) {
-      // assert(m->_data_size + m->_extra_data_size == rec->_data_length * (int)sizeof(rec->_data[0]) ||
-      //        m->_data_size == rec->_data_length * (int)sizeof(rec->_data[0]), "must agree");
+      assert(m->_data_size + m->_extra_data_size == rec->_data_length * (int)sizeof(rec->_data[0]) ||
+             m->_data_size == rec->_data_length * (int)sizeof(rec->_data[0]), "must agree");
 
       // Write the correct ciObjects back into the profile data
       ciEnv* env = ciEnv::current();

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1196,7 +1196,7 @@ Node* CallStaticJavaNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
   // Try to replace the runtime call to the substitutability test emitted by acmp if we can reason
   // about the operands
-  if (can_reshape && !control()->is_top() && method() != nullptr &&
+  if (can_reshape && !control()->is_top() && !memory()->is_top() && method() != nullptr &&
       method()->holder() == phase->C->env()->ValueObjectMethods_klass() &&
       method()->name() == ciSymbols::isSubstitutable_name()) {
     Node* res = replace_is_substitutable(phase->is_IterGVN());

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
@@ -26,7 +26,7 @@
  * @summary dying substitutability call transformed during igvn
  * @enablePreview
  * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
- *                   -XX:+StressIGVN -XX:StressSeed=2677332830 ${test.main.class}
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=2677332830 ${test.main.class}
  * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
  *                   -XX:+StressIGVN ${test.main.class}
  * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
@@ -38,7 +38,7 @@ package compiler.valhalla.inlinetypes;
 public class TestDeadSubstitutabilityCallInIdeal {
     private static int intField;
     private static final MyValue[] flatField = { new MyValue(42) };
-    
+
     public static void main(String[] args) {
         MyValue v = new MyValue(42);
         A a = new A(42);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
@@ -28,7 +28,7 @@
  * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=2677332830 ${test.main.class}
  * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
- *                   -XX:+StressIGVN ${test.main.class}
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN ${test.main.class}
  * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
  *                   ${test.main.class}
  */

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
@@ -23,7 +23,7 @@
 
 /**
  * @test 8385020
- * @summary
+ * @summary dying substitutability call transformed during igvn
  * @enablePreview
  * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
  *                   -XX:+StressIGVN -XX:StressSeed=2677332830 ${test.main.class}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadSubstitutabilityCallInIdeal.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test 8385020
+ * @summary
+ * @enablePreview
+ * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
+ *                   -XX:+StressIGVN -XX:StressSeed=2677332830 ${test.main.class}
+ * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
+ *                   -XX:+StressIGVN ${test.main.class}
+ * @run main/othervm -Xcomp -XX:CompileOnly=${test.main.class}::test* -XX:CompileCommand=dontinline,${test.main.class}::notInlined
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestDeadSubstitutabilityCallInIdeal {
+    private static int intField;
+    private static final MyValue[] flatField = { new MyValue(42) };
+    
+    public static void main(String[] args) {
+        MyValue v = new MyValue(42);
+        A a = new A(42);
+        test1(a, v, a);
+        test2(a, v, a);
+    }
+
+    private static boolean test1(A a, MyValue v, Object o) {
+        A aa = new A(10);
+        notInlined();
+        int i = aa.intField;
+        Object o1, o2 = o;
+        int j = 0, k = 0, l = 0;
+        if (i == 10) {
+            o1 = v;
+        } else {
+            o1 = a;
+        }
+        if (i != 10) {
+            int intVal = flatField[0].field;
+            if (o1 == o2) {
+                return true;
+            }
+            intField = intVal;
+            return false;
+         } else {
+            return false;
+        }
+    }
+
+    private static boolean test2(A a, MyValue v, Object o) {
+        A aa = new A(10);
+        notInlined();
+        int i = aa.intField;
+        Object o1, o2 = o;
+        int j = 0, k = 0, l = 0;
+        if (i == 10) {
+            o1 = v;
+        } else {
+            o1 = a;
+        }
+        if (i != 10) {
+            int intVal = flatField[0].field;
+            intField = intVal;
+            if (o1 == o2) {
+                return true;
+            }
+            return false;
+         } else {
+            return false;
+        }
+    }
+
+    static void notInlined() {
+    }
+
+    static class A {
+        int intField;
+        A(int i) {
+            this.intField = i;
+        }
+    }
+
+    static class B {
+        A objectField;
+        B(A o) {
+            this.objectField = o;
+        }
+    }
+
+    static value class MyValue {
+        int field;
+        MyValue(int field) {
+            this.field = field;
+        }
+     }
+}


### PR DESCRIPTION
A dying substitutability call is transformed during igvn but the
current logic fails to detect it's dead.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385020](https://bugs.openjdk.org/browse/JDK-8385020): [lworld] Renaissance-GaussMix crash in C2 TypeInstPtr::xmeet_helper (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2467/head:pull/2467` \
`$ git checkout pull/2467`

Update a local copy of the PR: \
`$ git checkout pull/2467` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2467`

View PR using the GUI difftool: \
`$ git pr show -t 2467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2467.diff">https://git.openjdk.org/valhalla/pull/2467.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2467#issuecomment-4516969854)
</details>
