### PR TITLE
8385159: [lworld] C2 parts of JDK-8350865 - Part. 1

### DIFF
--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -68,12 +68,14 @@ class InstanceKlassFlags {
      definition: empty inline fields must be flat otherwise the container won't
      be considered empty */
 
+public:
 #define IK_FLAGS_ENUM_NAME(name, value)    _misc_##name = value,
   enum {
     IK_FLAGS_DO(IK_FLAGS_ENUM_NAME)
   };
 #undef IK_FLAGS_ENUM_NAME
 
+private:
 #define IK_STATUS_DO(status)  \
     status(is_being_redefined                , 1 << 0) /* True if the klass is being redefined */ \
     status(has_resolved_methods              , 1 << 1) /* True if the klass has resolved MethodHandle methods */ \
@@ -143,6 +145,8 @@ class InstanceKlassFlags {
   void atomic_set_bits(u1 bits)   { AtomicAccess::fetch_then_or(&_status, bits); }
   void atomic_clear_bits(u1 bits) { AtomicAccess::fetch_then_and(&_status, (u1)(~bits)); }
   void print_on(outputStream* st) const;
+
+  static ByteSize flags_offset() { return byte_offset_of(InstanceKlassFlags, _flags); }
 };
 
 #endif // SHARE_OOPS_INSTANCEKLASSFLAGS_HPP

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4020,6 +4020,27 @@ Node* GraphKit::null_free_atomic_array_test(Node* array, ciInlineKlass* vk) {
   return _gvn.transform(new BoolNode(cmp, BoolTest::eq));
 }
 
+Node* GraphKit::atomic_layout_array_test_and_get_layout_kind(Node* array, RegionNode* atomic_region) {
+  Node* array_klass = load_object_klass(array);
+  int layout_kind_offset = in_bytes(FlatArrayKlass::layout_kind_offset());
+  Node* layout_kind_addr = basic_plus_adr(top(), array_klass, layout_kind_offset);
+  Node* layout_kind = make_load(nullptr, layout_kind_addr, TypeInt::INT, T_INT, MemNode::unordered);
+  Node* cmp_null_free = _gvn.transform(new CmpINode(layout_kind, intcon(static_cast<jint>(LayoutKind::NULL_FREE_ATOMIC_FLAT))));
+  Node* bol_null_free = _gvn.transform(new BoolNode(cmp_null_free, BoolTest::eq));
+  Node* cmp_nullable = _gvn.transform(new CmpINode(layout_kind, intcon(static_cast<jint>(LayoutKind::NULLABLE_ATOMIC_FLAT))));
+  Node* bol_nullable = _gvn.transform(new BoolNode(cmp_nullable, BoolTest::eq));
+
+  IfNode* iff_null_free = create_and_xform_if(control(), bol_null_free, PROB_FAIR, COUNT_UNKNOWN);
+  atomic_region->add_req(_gvn.transform(new IfTrueNode(iff_null_free)));
+  set_control(_gvn.transform(new IfFalseNode(iff_null_free)));
+
+  IfNode* iff_nullable = create_and_xform_if(control(), bol_nullable, PROB_FAIR, COUNT_UNKNOWN);
+  atomic_region->add_req(_gvn.transform(new IfTrueNode(iff_nullable)));
+  set_control(_gvn.transform(new IfFalseNode(iff_nullable)));
+
+  return layout_kind;
+}
+
 // Deoptimize if 'ary' is a null-free inline type array and 'val' is null
 Node* GraphKit::inline_array_null_guard(Node* ary, Node* val, int nargs, bool safe_for_replace) {
   RegionNode* region = new RegionNode(3);

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -841,6 +841,7 @@ class GraphKit : public Phase {
   Node* flat_array_test(Node* array_or_klass, bool flat = true);
   Node* null_free_array_test(Node* array, bool null_free = true);
   Node* null_free_atomic_array_test(Node* array, ciInlineKlass* vk);
+  Node* atomic_layout_array_test_and_get_layout_kind(Node* array, RegionNode* atomic_region);
   Node* inline_array_null_guard(Node* ary, Node* val, int nargs, bool safe_for_replace = false);
 
   Node* gen_subtype_check(Node* obj, Node* superklass);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4794,8 +4794,6 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
   Node* bol;
   switch(check) {
     case IsFlat:
-      // TODO 8350865 Use the object version here instead of loading the klass
-      // The problem is that PhaseMacroExpand::expand_flatarraycheck_node can only handle some IR shapes and will fail, for example, if the bol is directly wired to a ReturnNode
       bol = flat_array_test(load_object_klass(array));
       break;
     case IsNullRestricted:

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4861,9 +4861,9 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
 
       // ...non-atomic, but we tried everything.
       RegionNode* decision = new RegionNode(3);
-      PhiNode* result = PhiNode::make(decision, intcon(1), TypeInt::BOOL);
       decision->set_req(1, _gvn.transform(atomic_region));
       decision->set_req(2, _gvn.transform(non_atomic_region));
+      PhiNode* result = PhiNode::make(decision, intcon(1), TypeInt::BOOL);
       result->set_req(2, intcon(0));
       set_control(_gvn.transform(decision));
       set_result(_gvn.transform(result));

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4861,11 +4861,11 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
 
       // ...non-atomic, but we tried everything.
       RegionNode* decision = new RegionNode(3);
+      PhiNode* result = PhiNode::make(decision, intcon(1), TypeInt::BOOL);
       decision->set_req(1, _gvn.transform(atomic_region));
       decision->set_req(2, _gvn.transform(non_atomic_region));
-      set_control(_gvn.transform(decision));
-      PhiNode* result = PhiNode::make(decision, intcon(1), TypeInt::BOOL);
       result->set_req(2, intcon(0));
+      set_control(_gvn.transform(decision));
       set_result(_gvn.transform(result));
       return true;
     }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4796,7 +4796,7 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
     case IsFlat:
       // TODO 8350865 Use the object version here instead of loading the klass
       // The problem is that PhaseMacroExpand::expand_flatarraycheck_node can only handle some IR shapes and will fail, for example, if the bol is directly wired to a ReturnNode
-      bol = flat_array_test(load_object_klass(array));
+      bol = flat_array_test(array);
       break;
     case IsNullRestricted:
       bol = null_free_array_test(array);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4796,7 +4796,7 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
     case IsFlat:
       // TODO 8350865 Use the object version here instead of loading the klass
       // The problem is that PhaseMacroExpand::expand_flatarraycheck_node can only handle some IR shapes and will fail, for example, if the bol is directly wired to a ReturnNode
-      bol = flat_array_test(array);
+      bol = flat_array_test(load_object_klass(array));
       break;
     case IsNullRestricted:
       bol = null_free_array_test(array);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4812,11 +4812,62 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
     case IsNullRestricted:
       bol = null_free_array_test(array);
       break;
-    case IsAtomic:
-      // TODO 8350865 Implement this. It's a bit more complicated, see conditions in JVM_IsAtomicArray
-      // Enable TestIntrinsics::test87/88 once this is implemented
-      // bol = null_free_atomic_array_test
-      return false;
+    case IsAtomic: {
+      // See conditions in JVM_IsAtomicArray
+      // 1. If not flat, then atomic, or else...
+      RegionNode* atomic_region = new RegionNode(1);
+      RegionNode* non_atomic_region = new RegionNode(1);
+      Node* array_klass = load_object_klass(array);
+      Node* is_flat_bol = flat_array_test(array_klass);
+      IfNode* iff_is_flat = create_and_xform_if(control(), is_flat_bol, PROB_FAIR, COUNT_UNKNOWN);
+      atomic_region->add_req(_gvn.transform(new IfFalseNode(iff_is_flat)));
+      set_control(_gvn.transform(new IfTrueNode(iff_is_flat)));
+
+      // 2. ...if the layout is atomic, then atomic, or else...
+      Node* layout_kind = atomic_layout_array_test_and_get_layout_kind(array, atomic_region);
+
+      // 3. ...if the element type is naturally atomic and null-free OR empty and nullable, then atomic, or else...
+      int element_klass_offset = in_bytes(ObjArrayKlass::element_klass_offset());
+      Node* array_element_klass_addr = off_heap_plus_addr(array_klass, element_klass_offset);
+      Node* array_element_klass = _gvn.transform(LoadKlassNode::make(_gvn, immutable_memory(), array_element_klass_addr, _gvn.type(array_klass)->is_klassptr()));
+      int klass_flags_offset = in_bytes(InstanceKlass::misc_flags_offset() + InstanceKlassFlags::flags_offset());
+      Node* array_element_klass_flags_addr = off_heap_plus_addr(array_element_klass, klass_flags_offset);
+      Node* array_element_klass_flags = make_load(control(), array_element_klass_flags_addr, TypeInt::INT, T_INT, MemNode::unordered);
+
+      Node* is_null_free_cmp = _gvn.transform(new CmpINode(layout_kind, intcon(static_cast<jint>(LayoutKind::NULL_FREE_ATOMIC_FLAT))));
+      Node* is_null_free_bol = _gvn.transform(new BoolNode(is_null_free_cmp, BoolTest::eq));
+      IfNode* iff_is_null_free_bol = create_and_xform_if(control(), is_null_free_bol, PROB_FAIR, COUNT_UNKNOWN);
+      Node* is_null_free_ctl = _gvn.transform(new IfTrueNode(iff_is_null_free_bol));
+      Node* is_nullable_ctl = _gvn.transform(new IfFalseNode(iff_is_null_free_bol));
+
+      Node* is_naturally_atomic_flag = _gvn.transform(new AndINode(array_element_klass_flags, intcon(InstanceKlassFlags::_misc_is_naturally_atomic)));
+      Node* is_naturally_atomic_cmp = _gvn.transform(new CmpINode(is_naturally_atomic_flag, intcon(0)));
+      Node* is_naturally_atomic_bol = _gvn.transform(new BoolNode(is_naturally_atomic_cmp, BoolTest::ne));
+      IfNode* iff_is_naturally_atomic = create_and_xform_if(is_null_free_ctl, is_naturally_atomic_bol, PROB_FAIR, COUNT_UNKNOWN);
+      Node* is_naturally_atomic_ctl = _gvn.transform(new IfTrueNode(iff_is_naturally_atomic));
+      Node* is_not_naturally_atomic_ctl = _gvn.transform(new IfFalseNode(iff_is_naturally_atomic));
+      atomic_region->add_req(is_naturally_atomic_ctl);
+      non_atomic_region->add_req(is_not_naturally_atomic_ctl);
+
+      Node* is_empty_inline_type_flag = _gvn.transform(new AndINode(array_element_klass_flags, intcon(InstanceKlassFlags::_misc_is_empty_inline_type)));
+      Node* is_empty_inline_type_cmp = _gvn.transform(new CmpINode(is_empty_inline_type_flag, intcon(0)));
+      Node* is_empty_inline_type_bol = _gvn.transform(new BoolNode(is_empty_inline_type_cmp, BoolTest::ne));
+      IfNode* iff_is_empty_inline_type = create_and_xform_if(is_nullable_ctl, is_empty_inline_type_bol, PROB_FAIR, COUNT_UNKNOWN);
+      Node* is_empty_inline_type_ctl = _gvn.transform(new IfTrueNode(iff_is_empty_inline_type));
+      Node* is_nonempty_inline_type_ctl = _gvn.transform(new IfFalseNode(iff_is_empty_inline_type));
+      atomic_region->add_req(is_empty_inline_type_ctl);
+      non_atomic_region->add_req(is_nonempty_inline_type_ctl);
+
+      // ...non-atomic, but we tried everything.
+      RegionNode* decision = new RegionNode(3);
+      decision->set_req(1, _gvn.transform(atomic_region));
+      decision->set_req(2, _gvn.transform(non_atomic_region));
+      set_control(_gvn.transform(decision));
+      PhiNode* result = PhiNode::make(decision, intcon(1), TypeInt::BOOL);
+      result->set_req(2, intcon(0));
+      set_result(_gvn.transform(result));
+      return true;
+    }
     default:
       ShouldNotReachHere();
   }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4834,7 +4834,8 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
       Node* array_element_klass_flags_addr = off_heap_plus_addr(array_element_klass, klass_flags_offset);
       Node* array_element_klass_flags = make_load(control(), array_element_klass_flags_addr, TypeInt::INT, T_INT, MemNode::unordered);
 
-      Node* is_null_free_cmp = _gvn.transform(new CmpINode(layout_kind, intcon(static_cast<jint>(LayoutKind::NULL_FREE_ATOMIC_FLAT))));
+      // Here, layout can only be non-atomic, otherwise atomic_layout_array_test_and_get_layout_kind already decides the array to be atomic.
+      Node* is_null_free_cmp = _gvn.transform(new CmpINode(layout_kind, intcon(static_cast<jint>(LayoutKind::NULL_FREE_NON_ATOMIC_FLAT))));
       Node* is_null_free_bol = _gvn.transform(new BoolNode(is_null_free_cmp, BoolTest::eq));
       IfNode* iff_is_null_free_bol = create_and_xform_if(control(), is_null_free_bol, PROB_FAIR, COUNT_UNKNOWN);
       Node* is_null_free_ctl = _gvn.transform(new IfTrueNode(iff_is_null_free_bol));

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3183,8 +3183,6 @@ bool LibraryCallKit::inline_getFieldMap() {
 
   Node* map_addr = basic_plus_adr(mirror, field_map_offset);
   const TypeAryPtr* val_type = TypeAryPtr::INTS->cast_to_ptr_type(TypePtr::NotNull)->with_offset(0);
-  // TODO 8350865 Remove this
-  val_type = val_type->cast_to_not_flat(true)->cast_to_not_null_free(true);
   Node* map = access_load_at(mirror, map_addr, TypeAryPtr::INTS, val_type, T_ARRAY, IN_HEAP | MO_UNORDERED);
 
   set_result(map);

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3046,7 +3046,6 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
 // }
 void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
   bool array_inputs = _igvn.type(check->in(FlatArrayCheckNode::ArrayOrKlass))->isa_oopptr() != nullptr;
-  assert(!array_inputs, "Found an array input!");
   if (array_inputs) {
     Node* mark = MakeConX(0);
     Node* locked_bit = MakeConX(markWord::unlocked_value);

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3046,6 +3046,7 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
 // }
 void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
   bool array_inputs = _igvn.type(check->in(FlatArrayCheckNode::ArrayOrKlass))->isa_oopptr() != nullptr;
+  assert(!array_inputs, "Found an array input!");
   if (array_inputs) {
     Node* mark = MakeConX(0);
     Node* locked_bit = MakeConX(markWord::unlocked_value);

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -199,19 +199,6 @@ const Type* MulNode::Value(PhaseGVN* phase) const {
     if( t2->higher_equal( zero ) ) return zero;
   }
 
-  // TODO 8350865 Still needed? Yes, I think this is from PhaseMacroExpand::expand_mh_intrinsic_return
-  // Code pattern on return from a call that returns an __Value.  Can
-  // be optimized away if the return value turns out to be an oop.
-  if (op == Op_AndX &&
-      in(1) != nullptr &&
-      in(1)->Opcode() == Op_CastP2X &&
-      in(1)->in(1) != nullptr &&
-      phase->type(in(1)->in(1))->isa_oopptr() &&
-      t2->isa_intptr_t()->_lo >= 0 &&
-      t2->isa_intptr_t()->_hi <= MinObjAlignmentInBytesMask) {
-    return add_id();
-  }
-
   // Either input is BOTTOM ==> the result is the local BOTTOM
   if( t1 == Type::BOTTOM || t2 == Type::BOTTOM )
     return bottom_type();

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2588,7 +2588,7 @@ bool TypeAry::singleton(void) const {
 
 bool TypeAry::empty(void) const {
   assert(!_size->empty(), "TypeInt is never empty");
-  // TODO 8370914 This should be simplified at construction time once we get rid of dual
+  // TODO 8385426 This should be simplified at construction time once we get rid of dual
   // Doing it with the dual-based join is annoying. TypeAry::empty tests whether the
   // element type is empty. When computing the dual of an array that can be flat or not,
   // we will get an element type that is empty, and doesn't need more. We even shouldn't

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5709,6 +5709,14 @@ bool TypeAryPtr::empty(void) const {
   if (_ary->empty())       return true;
   // TODO 8350865 This should go to the meet implementation
   if (is_flat() && is_not_flat()) {
+#ifndef PRODUCT
+    stringStream ss;
+    ss.print("this: ");
+    dump_on(&ss);
+    assert(false, "something is wrong: %s", ss.base());
+#else
+    assert(false, "something is wrong");
+#endif
     return true;
   }
   return TypeOopPtr::empty();

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2587,7 +2587,16 @@ bool TypeAry::singleton(void) const {
 }
 
 bool TypeAry::empty(void) const {
-  return _elem->empty() || _size->empty();
+  assert(!_size->empty(), "TypeInt is never empty");
+  // TODO 8370914 This should be simplified at construction time once we get rid of dual
+  // Doing it with the dual-based join is annoying. TypeAry::empty tests whether the
+  // element type is empty. When computing the dual of an array that can be flat or not,
+  // we will get an element type that is empty, and doesn't need more. We even shouldn't
+  // do more otherwise, we can't make the dual involutive. But if we compute the
+  // intersection of a flat and a non-flat array, we could change the element type to an
+  // empty type to reduce the abstract value. And we must be careful not to do that in
+  // the dual world.
+  return _elem->empty() || (_flat && _not_flat);
 }
 
 //--------------------------ary_must_be_exact----------------------------------
@@ -5707,18 +5716,6 @@ void TypeAryPtr::dump2( Dict &d, uint depth, outputStream *st ) const {
 
 bool TypeAryPtr::empty(void) const {
   if (_ary->empty())       return true;
-  // TODO 8350865 This should go to the meet implementation
-  if (is_flat() && is_not_flat()) {
-#ifndef PRODUCT
-    stringStream ss;
-    ss.print("this: ");
-    dump_on(&ss);
-    assert(false, "something is wrong: %s", ss.base());
-#else
-    assert(false, "something is wrong");
-#endif
-    return true;
-  }
   return TypeOopPtr::empty();
 }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1919,8 +1919,7 @@ public class TestIntrinsics {
 
     // Test correctness of the ValueClass::isAtomicArray intrinsic
     @Test
-    // TODO 8350865 Implemented intrinsic
-    // @IR(failOn = {STATIC_CALL_OF_METHOD, "jdk.internal.value.ValueClass::isAtomicArray"})
+    @IR(failOn = {STATIC_CALL_OF_METHOD, "jdk.internal.value.ValueClass::isAtomicArray"})
     public boolean test87(Object[] array) {
         return ValueClass.isAtomicArray(array);
     }
@@ -1936,8 +1935,7 @@ public class TestIntrinsics {
 
     // Verify that ValueClass::isAtomicArray checks with statically known classes are folded
     @Test
-    // TODO 8350865 Implemented intrinsic
-    // @IR(failOn = {LOAD_KLASS, STATIC_CALL_OF_METHOD, "jdk.internal.value.ValueClass::isAtomicArray"})
+    @IR(failOn = {LOAD_KLASS, STATIC_CALL_OF_METHOD, "jdk.internal.value.ValueClass::isAtomicArray"})
     public boolean test88() {
         boolean check1 = ValueClass.isAtomicArray(TEST_ARRAY1);
         if (!TEST_ARRAY1_IS_ATOMIC) {


### PR DESCRIPTION
### `LibraryCallKit::inline_getArrayProperties`
https://github.com/openjdk/valhalla/blob/f09dea673b68e51ff3604d7c6f0f0561dd0f8c98/src/hotspot/share/opto/library_call.cpp#L4805-L4807

Done.

This one uncovered a bug, then I ran into something unrelated, but polluting testing. It looks good now. The logic is not quite simple, but it is exactly as it is described in the runtime version of it.

### `LibraryCallKit::inline_getArrayProperties`
https://github.com/openjdk/valhalla/blob/f09dea673b68e51ff3604d7c6f0f0561dd0f8c98/src/hotspot/share/opto/library_call.cpp#L4797-L4798

This one, we need to keep. `inline_getArrayProperties` and `flat_array_test` builds a graph like
```
CMoveI(Bool(FlatArrayCheck(mem, array_klass), cmp), 0, 1, BOOL)
```
which is fine for
https://github.com/openjdk/valhalla/blob/f09dea673b68e51ff3604d7c6f0f0561dd0f8c98/src/hotspot/share/opto/macro.cpp#L3047-L3049
and we take the else-branch. But if instead of `array_klass`, we had just an `array`, we would take the if-branch. And this one expects a different shape:
- it looks for the `BoolNode` (let it be `bol`) under the `FlatArrayCheckNode`
- it looks at outputs of `bol`, and for each, expects it to be an `IfNode`
- use the control of the `IfNode` to build more control flow (with the lock/unlock paths...)

Clearly, our graph has a `CMoveINode` under the `BoolNode`, so this crashes. It's not just a matter of `expand_flatarraycheck_node` being too strict, but rather the problem is that we need a control input for this expansion, and we don't have with the `CMoveINode`.

I can see two easy solutions:
- change `inline_getArrayProperties` to generate something more like
```
  Phi(
    Region(
        r,
        IfTrue(If(ctrl, Bool(FlatArrayCheck(mem, array_klass), cmp)) as iff),
        IfFalse(iff)
    ) as r,
    0,
    1
  )
```
  which would allow the expansion to work.
- not change anything.

I went with not changing anything because loading the class seems less bad (and might already happen, and thus be share, as it is used by some other operations) than making a more complicate structure, that is control-pinned.



### `LibraryCallKit::inline_getFieldMap`
https://github.com/openjdk/valhalla/blob/f09dea673b68e51ff3604d7c6f0f0561dd0f8c98/src/hotspot/share/opto/library_call.cpp#L3186-L3187

Yes, sir! Testing seems to be happy.

### `MulNode::Value`
https://github.com/openjdk/valhalla/blob/f09dea673b68e51ff3604d7c6f0f0561dd0f8c98/src/hotspot/share/opto/mulnode.cpp#L202-L213

There is no test that seems to be on fire without that. It's not clear to me why it'd be useful, so I removed...

### `TypeAryPtr::empty`
https://github.com/openjdk/valhalla/blob/f09dea673b68e51ff3604d7c6f0f0561dd0f8c98/src/hotspot/share/opto/type.cpp#L5734-L5737

Here, I went for fixing the underlying `TypeAry::empty`, as fundamentally, that's where the magic happens, and here too, if we have flat and non-flat, we should end-up with an empty type.

https://github.com/openjdk/valhalla/blob/f09dea673b68e51ff3604d7c6f0f0561dd0f8c98/src/hotspot/share/opto/type.cpp#L2589-L2591

Thanks to [Add unsigned bounds and known bits to TypeInt/Long](https://bugs.openjdk.org/browse/JDK-8315066), `TypeInt::empty` is constantly false, so `_size->empty()` is redundant. There is the question of how we end-up with something that is both flat and non-flat. If I remember well, it is because of an intersection of a speculative type (that can be flat), and a signature type (assumed non-flat), which must give an empty value. It would be nice if we had bottom-coalescence, that is if one of the component of a product of abstract value is bottom (Hotspot's top), we put everything to bottom (HS's top) since the concretization is empty anyway. That is a simple case of reduction. In our case, it would be nice if, when we see such clash at construction type, to simply go with setting `_elem` to something empty, and not test more than one thing/have a consistent view, whichever part we are looking at. But if we do that in the dual world, we would reduce to bottom (HS's top), something that is the dual of non-empty, and thus, losing information. The easiest fix would simply be to come back later, once we have a proper join, and we get rid of the dual. That will be trivial then.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385159](https://bugs.openjdk.org/browse/JDK-8385159): [lworld] C2 parts of JDK-8350865 - Part. 1 (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [d63f36f3](https://git.openjdk.org/valhalla/pull/2468/files/d63f36f3d42ff6fdfa53222878a5631a9c248976)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2468/head:pull/2468` \
`$ git checkout pull/2468`

Update a local copy of the PR: \
`$ git checkout pull/2468` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2468`

View PR using the GUI difftool: \
`$ git pr show -t 2468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2468.diff">https://git.openjdk.org/valhalla/pull/2468.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2468#issuecomment-4517316630)
</details>
