### PR TITLE
8385311: [lworld] TypePtr::eq() should use accessor method for _offset

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2941,7 +2941,7 @@ const TypePtr *TypePtr::with_offset(intptr_t offset) const {
 // Structural equality check for Type representations
 bool TypePtr::eq( const Type *t ) const {
   const TypePtr *a = (const TypePtr*)t;
-  return _ptr == a->ptr() && _offset == a->_offset && _reloc == a->reloc() &&
+  return _ptr == a->ptr() && offset() == a->offset() && _reloc == a->reloc() &&
          eq_speculative(a) && _inline_depth == a->_inline_depth;
 }
 


### PR DESCRIPTION
Using accessor method for `_offset` in `TypePtr::eq` for consistency with `TypePtr::hash`. This is semantically equivalent because `Offset` overrides the `==` operator.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385311](https://bugs.openjdk.org/browse/JDK-8385311): [lworld] TypePtr::eq() should use accessor method for _offset (**Enhancement** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2469/head:pull/2469` \
`$ git checkout pull/2469`

Update a local copy of the PR: \
`$ git checkout pull/2469` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2469`

View PR using the GUI difftool: \
`$ git pr show -t 2469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2469.diff">https://git.openjdk.org/valhalla/pull/2469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2469#issuecomment-4517576689)
</details>
