### PR TITLE
8385343: [lworld] Add ResourceMark for logging field names

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2299,7 +2299,7 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
         && ((flags & JVM_ACC_STATIC) == 0 )
         && !_access_flags.is_identity_class()) {
       classfile_parse_error("Invalid synchronized method in non-identity class %s", THREAD);
-        return nullptr;
+      return nullptr;
     }
   }
 
@@ -4921,8 +4921,7 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
     case JVM_SIGNATURE_LONG:
     case JVM_SIGNATURE_DOUBLE:
       return signature + 1;
-    case JVM_SIGNATURE_CLASS:
-    {
+    case JVM_SIGNATURE_CLASS: {
       if (_major_version < JAVA_1_5_VERSION) {
         signature++;
         length--;
@@ -6372,6 +6371,7 @@ void ClassFileParser::fetch_field_classes(ConstantPool* cp, TRAPS) {
       TempNewSymbol name = Signature::strip_envelope(sig);
       if (name == _class_name) continue;
       if (PreloadClasses && is_class_in_loadable_descriptors_attribute(sig)) {
+        ResourceMark rm(THREAD);
         log_info(class, preload)("Preloading of class %s during loading of class %s. "
                                  "Cause: field type in LoadableDescriptors attribute",
                                  name->as_C_string(), _class_name->as_C_string());
@@ -6423,12 +6423,14 @@ void ClassFileParser::fetch_field_classes(ConstantPool* cp, TRAPS) {
         InstanceKlass* klass = SystemDictionary::find_instance_klass(THREAD, name, Handle(THREAD, loader));
         if (klass != nullptr && klass->is_inline_klass()) {
           set_inline_layout_info_klass(fieldinfo.index(), InlineKlass::cast(klass), CHECK);
+          ResourceMark rm(THREAD);
           log_info(class, preload)("During loading of class %s , class %s found in local system dictionary"
                                    "(field type not in LoadableDescriptors attribute)",
                                    _class_name->as_C_string(), name->as_C_string());
         } else if (fieldinfo.field_flags().is_null_free_inline_type()) {
+          ResourceMark rm(THREAD);
           if (klass == nullptr) {
-          log_warning(class, preload)("During loading of class %s, class %s is unknown, "
+            log_warning(class, preload)("During loading of class %s, class %s is unknown, "
                                  "but a field of this type was annotated with @NullRestricted, "
                                  "the annotation is ignored",
                                  _class_name->as_C_string(), name->as_C_string());

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -192,7 +192,6 @@ class ClassFileParser {
 
   int _num_miranda_methods;
 
-
   Handle _protection_domain;
   AccessFlags _access_flags;
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -252,7 +252,6 @@ class java_lang_Class : AllStatic {
   static int _class_loader_offset;
   static int _module_offset;
   static int _component_mirror_offset;
-
   static int _name_offset;
   static int _source_file_offset;
   static int _classData_offset;

--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,6 @@ bool VerificationType::is_reference_assignable_from(
   } else if (is_array() && from.is_array()) {
     VerificationType comp_this = get_component(context);
     VerificationType comp_from = from.get_component(context);
-
     if (!comp_this.is_bogus() && !comp_from.is_bogus()) {
       return comp_this.is_component_assignable_from(comp_from, context,
                                                     from_field_is_protected, THREAD);


### PR DESCRIPTION
Please review this trivial change to add ResourceMarks before fetch_field_classes() logging, and fix some whitespace differences and revert a whitespace and copyright change in verificationType.cpp.

Tested with runtime/valhalla/inlinetypes tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385343](https://bugs.openjdk.org/browse/JDK-8385343): [lworld] Add ResourceMark for logging field names (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2471/head:pull/2471` \
`$ git checkout pull/2471`

Update a local copy of the PR: \
`$ git checkout pull/2471` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2471`

View PR using the GUI difftool: \
`$ git pr show -t 2471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2471.diff">https://git.openjdk.org/valhalla/pull/2471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2471#issuecomment-4522571542)
</details>
