### PR TITLE
8385344: [lworld] ProblemList tools/javac/platform/CanHandleClassFilesTest.java with --enable-preview

### DIFF
--- a/test/langtools/ProblemList-enable-preview.txt
+++ b/test/langtools/ProblemList-enable-preview.txt
@@ -34,3 +34,4 @@
 #############################################################################
 
 # Valhalla failures start here:
+tools/javac/platform/CanHandleClassFilesTest.java 8385328 windows-x64


### PR DESCRIPTION
A trivial fix to ProblemList tools/javac/platform/CanHandleClassFilesTest.java with --enable-preview
on windows-x64.

This failure has reproduced in 4 of the last 5 Tier3 job sets and only on windows-x64
when the --enable-preview option is specified. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385344](https://bugs.openjdk.org/browse/JDK-8385344): [lworld] ProblemList tools/javac/platform/CanHandleClassFilesTest.java with --enable-preview (**Sub-task** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2472/head:pull/2472` \
`$ git checkout pull/2472`

Update a local copy of the PR: \
`$ git checkout pull/2472` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2472`

View PR using the GUI difftool: \
`$ git pr show -t 2472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2472.diff">https://git.openjdk.org/valhalla/pull/2472.diff</a>

</details>
