### PR TITLE
8382377: [lworld] The JvmtiHeapwalkObject(obj) set incorrect layout

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,22 +35,27 @@ class JvmtiEnv;
 
 // Describes an object which can be tagged during heap walk operation.
 // - generic heap object: _obj: oop, offset == 0, _inline_klass == nullptr;
-// - value heap object: _obj: oop, offset == 0, _inline_klass == _obj.klass();
 // - flat value object: _obj: holder object, offset == offset in the holder, _inline_klass == klass of the flattened object;
+// - value heap object: _obj: oop, offset == 0, _inline_klass == _obj.klass();
 class JvmtiHeapwalkObject {
   oop _obj;                   // for flattened value object this is holder object
   int _offset;                // == 0 for heap objects
   InlineKlass* _inline_klass; // for value object, nullptr otherwise
   LayoutKind _layout_kind;    // layout kind in holder object, used only for flat->heap conversion
 
-  static InlineKlass* inline_klass_or_null(oop obj) {
-    Klass* k = obj->klass();
-    return k->is_inline_klass() ? InlineKlass::cast(k) : nullptr;
-  }
 public:
   JvmtiHeapwalkObject(): _obj(nullptr), _offset(0), _inline_klass(nullptr), _layout_kind(LayoutKind::UNKNOWN) {}
-  JvmtiHeapwalkObject(oop obj): _obj(obj), _offset(0), _inline_klass(inline_klass_or_null(obj)), _layout_kind(LayoutKind::REFERENCE) {}
   JvmtiHeapwalkObject(oop obj, int offset, InlineKlass* ik, LayoutKind lk): _obj(obj), _offset(offset), _inline_klass(ik), _layout_kind(lk) {}
+  JvmtiHeapwalkObject(oop obj): _obj(obj), _offset(0) {
+    Klass* k = obj->klass();
+    if (k->is_inline_klass()) {
+    _inline_klass = InlineKlass::cast(k);
+    _layout_kind = LayoutKind::BUFFERED;
+    } else {
+    _inline_klass = nullptr;
+    _layout_kind = LayoutKind::REFERENCE;
+    }
+  }
 
   inline bool is_empty() const { return _obj == nullptr; }
   inline bool is_value() const { return _inline_klass != nullptr; }


### PR DESCRIPTION
Fixed layout.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382377](https://bugs.openjdk.org/browse/JDK-8382377): [lworld] The JvmtiHeapwalkObject(obj) set incorrect layout (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2473/head:pull/2473` \
`$ git checkout pull/2473`

Update a local copy of the PR: \
`$ git checkout pull/2473` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2473`

View PR using the GUI difftool: \
`$ git pr show -t 2473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2473.diff">https://git.openjdk.org/valhalla/pull/2473.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2473#issuecomment-4546256206)
</details>
