### PR TITLE
8370769: [lworld] C2 is too aggressive in scalarizing large value objects

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -115,19 +115,9 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     return this;
   }
 
-  // Push cast through InlineTypeNode but be careful because in dead parts of the graph,
-  // an InlineTypeNode can be casted to some completely unrelated type.
-  InlineTypeNode* vt = in(1)->isa_InlineType();
-  if (vt != nullptr && vt->is_allocated(phase) && _type->isa_instptr() != nullptr &&
-      vt->type()->inline_klass()->is_subtype_of(_type->is_instptr()->instance_klass())) {
-    Node* cast = clone();
-    cast->set_req(1, vt->get_oop());
-    vt = vt->clone()->as_InlineType();
-    if (!_type->maybe_null()) {
-      vt->as_InlineType()->set_null_marker(*phase);
-    }
-    vt->set_oop(*phase, phase->transform(cast));
-    return vt;
+  // Push cast through InlineTypeNode
+  if (in(1)->is_InlineType()) {
+    return ideal_inline_type_node(phase);
   }
 
   if (in(1) != nullptr && phase->type(in(1)) != Type::TOP) {
@@ -230,6 +220,49 @@ bool ConstraintCastNode::higher_equal_types(PhaseGVN* phase, const Node* other) 
 Node* ConstraintCastNode::pin_node_under_control_impl() const {
   assert(_dependency.is_floating(), "already pinned");
   return make_cast_for_type(in(0), in(1), bottom_type(), _dependency.with_pinned_dependency(), _extra_types);
+}
+
+Node* ConstraintCastNode::ideal_inline_type_node(PhaseGVN* phase) {
+  InlineTypeNode* vt = in(1)->as_InlineType();
+  const Type* join = vt->type()->filter(type());
+  if (join == Type::TOP) {
+    // Do not push a dead Cast since its type can be unrelated
+    return nullptr;
+  }
+
+  if (join == vt->type()->remove_speculative()) {
+    // Redundant cast, let Identity handle
+    return nullptr;
+  }
+
+  if (join == TypePtr::NULL_PTR) {
+    // Will collapse to the constant null
+    return nullptr;
+  }
+
+  // The only possible case left is that the cast is a cast to not-null
+  assert(join == vt->type()->filter(TypePtr::NOTNULL), "must be");
+  InlineTypeNode* res = vt->clone()->as_InlineType();
+  res->set_null_marker(*phase);
+
+  // Push the cast to the oop input if possible
+  if (vt->is_allocated(phase)) {
+    Node* new_oop = clone();
+    new_oop->set_req(1, vt->get_oop());
+    res->set_oop(*phase, phase->transform(new_oop));
+  }
+
+  // Push the cast to the null-free inputs of vt
+  for (uint i = 0; i < vt->field_count(); i++) {
+    if (vt->field(i)->is_null_free()) {
+      const ConstraintCastNode::DependencyType& dep = _dependency.is_floating() ? ConstraintCastNode::DependencyType::FloatingNarrowing
+                                                                                : ConstraintCastNode::DependencyType::NonFloatingNarrowing;
+      Node* new_fv = new CastPPNode(in(0), vt->field_value(i), TypePtr::NOTNULL, dep);
+      res->set_field_value(i, phase->transform(new_fv));
+    }
+  }
+
+  return res;
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -117,7 +117,7 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Push cast through InlineTypeNode
   if (in(1)->is_InlineType()) {
-    return ideal_inline_type_node(phase);
+    return ideal_cast_of_inline_type_node(phase);
   }
 
   if (in(1) != nullptr && phase->type(in(1)) != Type::TOP) {
@@ -222,7 +222,7 @@ Node* ConstraintCastNode::pin_node_under_control_impl() const {
   return make_cast_for_type(in(0), in(1), bottom_type(), _dependency.with_pinned_dependency(), _extra_types);
 }
 
-Node* ConstraintCastNode::ideal_inline_type_node(PhaseGVN* phase) {
+Node* ConstraintCastNode::ideal_cast_of_inline_type_node(PhaseGVN* phase) {
   InlineTypeNode* vt = in(1)->as_InlineType();
   const Type* join = vt->type()->filter(type());
   if (join == Type::TOP) {

--- a/src/hotspot/share/opto/castnode.hpp
+++ b/src/hotspot/share/opto/castnode.hpp
@@ -195,6 +195,7 @@ protected:
 
 private:
   virtual Node* pin_node_under_control_impl() const;
+  Node* ideal_inline_type_node(PhaseGVN* phase);
 };
 
 //------------------------------CastIINode-------------------------------------

--- a/src/hotspot/share/opto/castnode.hpp
+++ b/src/hotspot/share/opto/castnode.hpp
@@ -195,7 +195,7 @@ protected:
 
 private:
   virtual Node* pin_node_under_control_impl() const;
-  Node* ideal_inline_type_node(PhaseGVN* phase);
+  Node* ideal_cast_of_inline_type_node(PhaseGVN* phase);
 };
 
 //------------------------------CastIINode-------------------------------------

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1577,26 +1577,15 @@ Node* GraphKit::cast_not_null(Node* obj, bool do_replace_in_map) {
     return obj;
   }
 
-  if (obj->is_InlineType()) {
-    InlineTypeNode* vt = obj->isa_InlineType()->clone_if_required(&gvn(), map(), do_replace_in_map);
-    vt->set_null_marker(_gvn);
-    vt->set_type(t_not_null);
-    vt = _gvn.transform(vt)->as_InlineType();
-    if (do_replace_in_map) {
-      replace_in_map(obj, vt);
-    }
-    return vt;
-  }
-
-  Node* cast = new CastPPNode(control(), obj,t_not_null);
-  cast = _gvn.transform( cast );
+  Node* cast = new CastPPNode(control(), obj, t_not_null);
+  cast = _gvn.transform(cast);
 
   // Scan for instances of 'obj' in the current JVM mapping.
   // These instances are known to be not-null after the test.
-  if (do_replace_in_map)
+  if (do_replace_in_map) {
     replace_in_map(obj, cast);
-
-  return cast;                  // Return casted value
+  }
+  return cast;
 }
 
 // Sometimes in intrinsics, we implicitly know an object is not null
@@ -3733,7 +3722,6 @@ Node* GraphKit::gen_checkcast(Node* obj, Node* superklass, Node** failure_contro
           assert(safe_for_replace, "must be");
           obj = null_check(obj);
         }
-        assert(stopped() || !toop->is_inlinetypeptr() || obj->is_InlineType(), "should have been scalarized");
         return obj;
       case Compile::SSC_always_false:
         if (null_free) {

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -88,16 +88,11 @@ InlineTypeNode* InlineTypeNode::clone_with_phis(PhaseGVN* gvn, Node* region, Saf
 
   // Create a PhiNode each for merging the field values
   for (uint i = 0; i < vt->field_count(); ++i) {
-    ciType* type = vt->field(i)->type();
-    Node*  value = vt->field_value(i);
-    // We limit scalarization for inline types with circular fields and can therefore observe nodes
-    // of the same type but with different scalarization depth during GVN. To avoid inconsistencies
-    // during merging, make sure that we only create Phis for fields that are guaranteed to be scalarized.
-    ciField* field = this->field(i);
-    assert(!field->is_flat() || field->type()->is_inlinetype(), "must be an inline type");
-    bool no_circularity = !gvn->C->has_circular_inline_type() || field->is_flat();
-    if (type->is_inlinetype() && no_circularity) {
-      // Handle inline type fields recursively
+    ciField* field = vt->field(i);
+    ciType* type = field->type();
+    Node* value = vt->field_value(i);
+    if (field->is_flat()) {
+      // Handle flat fields recursively
       value = value->as_InlineType()->clone_with_phis(gvn, region, map);
     } else {
       t = Type::get_const_type(type);
@@ -164,20 +159,21 @@ InlineTypeNode* InlineTypeNode::merge_with(PhaseGVN* gvn, const InlineTypeNode* 
 
   // Merge field values
   for (uint i = 0; i < field_count(); ++i) {
-    Node* val1 =        field_value(i);
+    Node* val1 = field_value(i);
     Node* val2 = other->field_value(i);
-    if (val1->is_InlineType()) {
-      if (val2->is_Phi()) {
-        val2 = gvn->transform(val2);
-      }
+    if (field(i)->is_flat()) {
       if (val2->is_top()) {
         // The path where 'other' is used is dying. Therefore, we do not need to process the merge with 'other' further.
         // The phi inputs of 'this' at 'phi_index' will eventually be removed.
         break;
+      } else if (val2->is_Phi()) {
+        val2 = gvn->transform(val2);
       }
+
+      assert(val1->is_InlineType() && val2->is_InlineType(), "must be InlineTypeNode: %s - %s", val1->Name(), val2->Name());
       val1->as_InlineType()->merge_with(gvn, val2->as_InlineType(), phi_index, transform);
     } else {
-      assert(val1->is_Phi(), "must be a phi node");
+      assert(val1->is_Phi(), "must be a phi node %s", val1->Name());
       val1->set_req(phi_index, val2);
     }
     if (transform) {
@@ -397,52 +393,7 @@ void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oo
   }
 }
 
-// We limit scalarization for inline types with circular fields and can therefore observe nodes
-// of the same type but with different scalarization depth during GVN. This method adjusts the
-// scalarization depth to avoid inconsistencies during merging.
-InlineTypeNode* InlineTypeNode::adjust_scalarization_depth(GraphKit* kit) {
-  if (!kit->C->has_circular_inline_type()) {
-    return this;
-  }
-  GrowableArray<ciType*> visited;
-  visited.push(inline_klass());
-  return adjust_scalarization_depth_impl(kit, visited);
-}
-
-InlineTypeNode* InlineTypeNode::adjust_scalarization_depth_impl(GraphKit* kit, GrowableArray<ciType*>& visited) {
-  InlineTypeNode* val = this;
-  for (uint i = 0; i < field_count(); ++i) {
-    Node* value = field_value(i);
-    Node* new_value = value;
-    ciField* field = this->field(i);
-    ciType* ft = field->type();
-    if (value->is_InlineType()) {
-      assert(!field->is_flat() || field->type()->is_inlinetype(), "must be an inline type");
-      if (!field->is_flat() && visited.contains(ft)) {
-        new_value = value->as_InlineType()->buffer(kit)->get_oop();
-      } else {
-        int old_len = visited.length();
-        visited.push(ft);
-        new_value = value->as_InlineType()->adjust_scalarization_depth_impl(kit, visited);
-        visited.trunc_to(old_len);
-      }
-    } else if (ft->is_inlinetype() && !visited.contains(ft)) {
-      int old_len = visited.length();
-      visited.push(ft);
-      new_value = make_from_oop_impl(kit, value, ft->as_inline_klass(), visited);
-      visited.trunc_to(old_len);
-    }
-    if (value != new_value) {
-      if (val == this) {
-        val = clone_if_required(&kit->gvn(), kit->map());
-      }
-      val->set_field_value(i, new_value);
-    }
-  }
-  return (val == this) ? this : kit->gvn().transform(val)->as_InlineType();
-}
-
-void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, bool immutable_memory, bool trust_null_free_oop, DecoratorSet decorators, GrowableArray<ciType*>& visited) {
+void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, bool immutable_memory, bool trust_null_free_oop, DecoratorSet decorators) {
   // Initialize the inline type by loading its field values from
   // memory and adding the values as input edges to the node.
   ciInlineKlass* vk = inline_klass();
@@ -458,12 +409,8 @@ void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, bool immutable_m
       // Recursively load the flat inline type field
       ciInlineKlass* fvk = ft->as_inline_klass();
       bool atomic = field->is_atomic();
-
-      int old_len = visited.length();
-      visited.push(ft);
       value = make_from_flat_impl(kit, fvk, base, field_ptr, atomic, immutable_memory,
-                                  field_null_free, trust_null_free_oop && field_null_free, decorators, visited);
-      visited.trunc_to(old_len);
+                                  field_null_free, trust_null_free_oop && field_null_free, decorators);
     } else {
       // Load field value from memory
       BasicType bt = type2field[ft->basic_type()];
@@ -474,15 +421,6 @@ void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, bool immutable_m
       }
       const TypePtr* field_ptr_type = (decorators & C2_MISMATCHED) == 0 ? kit->gvn().type(field_ptr)->is_ptr() : TypeRawPtr::BOTTOM;
       value = kit->access_load_at(base, field_ptr, field_ptr_type, val_type, bt, decorators);
-      // Loading a non-flattened inline type from memory
-      if (visited.contains(ft)) {
-        kit->C->set_has_circular_inline_type(true);
-      } else if (ft->is_inlinetype()) {
-        int old_len = visited.length();
-        visited.push(ft);
-        value = make_from_oop_impl(kit, value, ft->as_inline_klass(), visited);
-        visited.trunc_to(old_len);
-      }
     }
     set_field_value(i, value);
   }
@@ -1009,12 +947,16 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
         region->add_req(not_vk);
         result->add_req(igvn.intcon(0));
       }
+      cur_lhs_field = InlineTypeNode::make_from_oop(kit, cur_lhs_field, vk);
+
       not_vk = kit->top();
       cur_rhs_field = kit->gen_checkcast(cur_rhs_field, vk_klass, &not_vk);
       if (!not_vk->is_top()) {
         region->add_req(not_vk);
         result->add_req(igvn.intcon(0));
       }
+      cur_rhs_field = InlineTypeNode::make_from_oop(kit, cur_rhs_field, vk);
+
       if (!kit->stopped()) {
         // Push the expanded InlineTypeNodes for processing later
         worklist.push(WorklistEntry(kit->control(), field_true_region, cur_lhs_field->as_InlineType(), cur_rhs_field->as_InlineType()));
@@ -1291,12 +1233,10 @@ InlineTypeNode* InlineTypeNode::make_uninitialized(PhaseGVN& gvn, ciInlineKlass*
 }
 
 InlineTypeNode* InlineTypeNode::make_all_zero(PhaseGVN& gvn, ciInlineKlass* vk) {
-  GrowableArray<ciType*> visited;
-  visited.push(vk);
-  return make_all_zero_impl(gvn, vk, visited);
+  return make_all_zero_impl(gvn, vk);
 }
 
-InlineTypeNode* InlineTypeNode::make_all_zero_impl(PhaseGVN& gvn, ciInlineKlass* vk, GrowableArray<ciType*>& visited) {
+InlineTypeNode* InlineTypeNode::make_all_zero_impl(PhaseGVN& gvn, ciInlineKlass* vk) {
   // Create a new InlineTypeNode initialized with all zero
   InlineTypeNode* vt = new InlineTypeNode(vk, gvn.zerocon(T_OBJECT), /* null_free= */ true);
   vt->set_is_buffered(gvn, false);
@@ -1305,19 +1245,13 @@ InlineTypeNode* InlineTypeNode::make_all_zero_impl(PhaseGVN& gvn, ciInlineKlass*
     ciField* field = vt->field(i);
     assert(!field->is_flat() || field->type()->is_inlinetype(), "must be an inline type");
     ciType* ft = field->type();
-    Node* value = gvn.zerocon(ft->basic_type());
-    if (!field->is_flat() && visited.contains(ft)) {
-      gvn.C->set_has_circular_inline_type(true);
-    } else if (ft->is_inlinetype()) {
-      int old_len = visited.length();
-      visited.push(ft);
-      ciInlineKlass* vk_field = ft->as_inline_klass();
-      if (field->is_null_free()) {
-        value = make_all_zero_impl(gvn, vk_field, visited);
-      } else {
-        value = make_null_impl(gvn, vk_field, visited);
-      }
-      visited.trunc_to(old_len);
+    Node* value;
+    if (field->is_null_free()) {
+      value = make_all_zero_impl(gvn, ft->as_inline_klass());
+    } else if (field->is_flat()) {
+      value = make_null_impl(gvn, ft->as_inline_klass());
+    } else {
+      value = gvn.zerocon(ft->basic_type());
     }
     vt->set_field_value(i, value);
   }
@@ -1357,12 +1291,10 @@ bool InlineTypeNode::is_all_zero(PhaseGVN* gvn, bool flat) const {
 }
 
 InlineTypeNode* InlineTypeNode::make_from_oop(GraphKit* kit, Node* oop, ciInlineKlass* vk) {
-  GrowableArray<ciType*> visited;
-  visited.push(vk);
-  return make_from_oop_impl(kit, oop, vk, visited);
+  return make_from_oop_impl(kit, oop, vk);
 }
 
-InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciInlineKlass* vk, GrowableArray<ciType*>& visited) {
+InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciInlineKlass* vk) {
   PhaseGVN& gvn = kit->gvn();
 
   // Create and initialize an InlineTypeNode by loading all field
@@ -1372,6 +1304,10 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     return vt;
   }
 
+  if (gvn.type(oop) == TypePtr::NULL_PTR) {
+    return make_null_impl(gvn, vk);
+  }
+
   if (gvn.type(oop)->maybe_null()) {
     // Add a null check because the oop may be null
     Node* null_ctl = kit->top();
@@ -1379,7 +1315,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     if (kit->stopped()) {
       // Constant null
       kit->set_control(null_ctl);
-      vt = make_null_impl(gvn, vk, visited);
+      vt = make_null_impl(gvn, vk);
       kit->record_for_igvn(vt);
       return vt;
     }
@@ -1387,10 +1323,10 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     vt->set_is_buffered(gvn);
     vt->set_null_marker(gvn);
     Node* payload_ptr = kit->basic_plus_adr(not_null_oop, vk->payload_offset());
-    vt->load(kit, not_null_oop, payload_ptr, true, true, IN_HEAP | MO_UNORDERED, visited);
+    vt->load(kit, not_null_oop, payload_ptr, true, true, IN_HEAP | MO_UNORDERED);
 
     if (null_ctl != kit->top()) {
-      InlineTypeNode* null_vt = make_null_impl(gvn, vk, visited);
+      InlineTypeNode* null_vt = make_null_impl(gvn, vk);
       Node* region = new RegionNode(3);
       region->init_req(1, kit->control());
       region->init_req(2, null_ctl);
@@ -1406,7 +1342,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     vt->set_is_buffered(gvn);
     vt->set_null_marker(gvn);
     Node* payload_ptr = kit->basic_plus_adr(oop, vk->payload_offset());
-    vt->load(kit, oop, payload_ptr, true, true, IN_HEAP | MO_UNORDERED, visited);
+    vt->load(kit, oop, payload_ptr, true, true, IN_HEAP | MO_UNORDERED);
   }
   assert(vt->is_allocated(&gvn), "inline type should be allocated");
   kit->record_for_igvn(vt);
@@ -1415,14 +1351,12 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
 
 InlineTypeNode* InlineTypeNode::make_from_flat(GraphKit* kit, ciInlineKlass* vk, Node* base, Node* ptr,
                                                bool atomic, bool immutable_memory, bool null_free, DecoratorSet decorators) {
-  GrowableArray<ciType*> visited;
-  visited.push(vk);
-  return make_from_flat_impl(kit, vk, base, ptr, atomic, immutable_memory, null_free, null_free, decorators, visited);
+  return make_from_flat_impl(kit, vk, base, ptr, atomic, immutable_memory, null_free, null_free, decorators);
 }
 
 // GraphKit wrapper for the 'make_from_flat' method
 InlineTypeNode* InlineTypeNode::make_from_flat_impl(GraphKit* kit, ciInlineKlass* vk, Node* base, Node* ptr, bool atomic, bool immutable_memory,
-                                                    bool null_free, bool trust_null_free_oop, DecoratorSet decorators, GrowableArray<ciType*>& visited) {
+                                                    bool null_free, bool trust_null_free_oop, DecoratorSet decorators) {
   assert(null_free || !trust_null_free_oop, "cannot trust null-free oop when the holder object is not null-free");
   PhaseGVN& gvn = kit->gvn();
   bool do_atomic = atomic;
@@ -1445,7 +1379,7 @@ InlineTypeNode* InlineTypeNode::make_from_flat_impl(GraphKit* kit, ciInlineKlass
       vt->set_req(NullMarker, nm_value);
     }
 
-    vt->load(kit, base, ptr, immutable_memory, trust_null_free_oop, decorators, visited);
+    vt->load(kit, base, ptr, immutable_memory, trust_null_free_oop, decorators);
     return gvn.transform(vt)->as_InlineType();
   }
 
@@ -1583,9 +1517,7 @@ InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi,
     Node* oop = multi->as_Call()->in(base_input++);
     vt->set_oop(kit->gvn(), oop);
   }
-  GrowableArray<ciType*> visited;
-  visited.push(vk);
-  vt->initialize_fields(kit, multi, base_input, in, null_free, nullptr, visited);
+  vt->initialize_fields(kit, multi, base_input, in, null_free, nullptr);
   return kit->gvn().transform(vt)->as_InlineType();
 }
 
@@ -1688,7 +1620,7 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, uint& base_input, bool 
   }
 }
 
-void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in, bool no_null_marker, Node* null_check_region, GrowableArray<ciType*>& visited) {
+void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in, bool no_null_marker, Node* null_check_region) {
   PhaseGVN& gvn = kit->gvn();
   Node* null_marker = nullptr;
   if (!no_null_marker) {
@@ -1729,7 +1661,7 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
     if (field->is_flat()) {
       // Flat inline type field
       InlineTypeNode* vt = make_uninitialized(gvn, type->as_inline_klass(), field->is_null_free());
-      vt->initialize_fields(kit, multi, base_input, in, true, null_check_region, visited);
+      vt->initialize_fields(kit, multi, base_input, in, true, null_check_region);
       if (!field->is_null_free()) {
         assert(field->null_marker_offset() != -1, "inconsistency");
         Node* null_marker_field_vt = nullptr;
@@ -1752,29 +1684,6 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
         parm = multi->as_Call()->in(base_input);
       } else {
         parm = gvn.transform(new ProjNode(multi->as_Call(), base_input));
-      }
-      // Non-flat inline type field
-      if (type->is_inlinetype()) {
-        if (null_check_region != nullptr) {
-          // We limit scalarization for inline types with circular fields and can therefore observe nodes
-          // of the same type but with different scalarization depth during GVN. To avoid inconsistencies
-          // during merging, make sure that we only create Phis for fields that are guaranteed to be scalarized.
-          if (parm->is_InlineType() && kit->C->has_circular_inline_type()) {
-            parm = parm->as_InlineType()->get_oop();
-          }
-          // Holder is nullable, set field to nullptr if holder is nullptr to avoid loading from uninitialized memory
-          parm = PhiNode::make(null_check_region, parm, TypeInstPtr::make(TypePtr::BotPTR, type->as_inline_klass()));
-          parm->set_req(2, kit->zerocon(T_OBJECT));
-          parm = gvn.transform(parm);
-        }
-        if (visited.contains(type)) {
-          kit->C->set_has_circular_inline_type(true);
-        } else if (!parm->is_InlineType()) {
-          int old_len = visited.length();
-          visited.push(type);
-          parm = make_from_oop_impl(kit, parm, type->as_inline_klass(), visited);
-          visited.trunc_to(old_len);
-        }
       }
       base_input += type->size();
     }
@@ -1833,27 +1742,21 @@ void InlineTypeNode::remove_redundant_allocations(PhaseIdealLoop* phase) const {
 }
 
 InlineTypeNode* InlineTypeNode::make_null(PhaseGVN& gvn, ciInlineKlass* vk, bool transform) {
-  GrowableArray<ciType*> visited;
-  visited.push(vk);
-  return make_null_impl(gvn, vk, visited, transform);
+  return make_null_impl(gvn, vk, transform);
 }
 
-InlineTypeNode* InlineTypeNode::make_null_impl(PhaseGVN& gvn, ciInlineKlass* vk, GrowableArray<ciType*>& visited, bool transform) {
+InlineTypeNode* InlineTypeNode::make_null_impl(PhaseGVN& gvn, ciInlineKlass* vk, bool transform) {
   InlineTypeNode* vt = new InlineTypeNode(vk, gvn.zerocon(T_OBJECT), /* null_free= */ false);
   vt->set_is_buffered(gvn);
   vt->set_null_marker(gvn, gvn.intcon(0));
   for (uint i = 0; i < vt->field_count(); i++) {
     ciField* field = vt->field(i);
     ciType* ft = field->type();
-    Node* value = gvn.zerocon(ft->basic_type());
-    assert(!field->is_flat() || field->type()->is_inlinetype(), "must be an inline type");
-    if (!field->is_flat() && visited.contains(ft)) {
-      gvn.C->set_has_circular_inline_type(true);
-    } else if (ft->is_inlinetype()) {
-      int old_len = visited.length();
-      visited.push(ft);
-      value = make_null_impl(gvn, ft->as_inline_klass(), visited);
-      visited.trunc_to(old_len);
+    Node* value;
+    if (field->is_flat()) {
+      value = make_null_impl(gvn, ft->as_inline_klass());
+    } else {
+      value = gvn.zerocon(ft->basic_type());
     }
     vt->set_field_value(i, value);
   }
@@ -2092,9 +1995,6 @@ InlineTypeNode* LoadFlatNode::collect_projs(GraphKit* kit, ciInlineKlass* vk, in
       proj_con += field_klass->nof_nonstatic_fields() + (field->is_null_free() ? 0 : 1);
     } else {
       field_value = gvn.transform(new ProjNode(this, proj_con));
-      if (field->type()->is_inlinetype()) {
-        field_value = InlineTypeNode::make_from_oop(kit, field_value, field->type()->as_inline_klass());
-      }
       proj_con++;
     }
     res->set_field_value(i, field_value);

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -66,19 +66,17 @@ private:
   Node* is_loaded(PhaseGVN* phase, ciInlineKlass* vk = nullptr, Node* base = nullptr, int holder_offset = 0) const;
 
   // Initialize the inline type fields with the inputs or outputs of a MultiNode
-  void initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in, bool no_null_marker, Node* null_check_region, GrowableArray<ciType*>& visited);
+  void initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in, bool no_null_marker, Node* null_check_region);
   // Initialize the inline type by loading its field values from memory
-  void load(GraphKit* kit, Node* base, Node* ptr, bool immutable_memory, bool trust_null_free_oop, DecoratorSet decorators, GrowableArray<ciType*>& visited);
+  void load(GraphKit* kit, Node* base, Node* ptr, bool immutable_memory, bool trust_null_free_oop, DecoratorSet decorators);
   // Store the field values to memory
   void store(GraphKit* kit, Node* base, Node* ptr, bool immutable_memory, DecoratorSet decorators) const;
 
-  InlineTypeNode* adjust_scalarization_depth_impl(GraphKit* kit, GrowableArray<ciType*>& visited);
-
-  static InlineTypeNode* make_all_zero_impl(PhaseGVN& gvn, ciInlineKlass* vk, GrowableArray<ciType*>& visited);
-  static InlineTypeNode* make_from_oop_impl(GraphKit* kit, Node* oop, ciInlineKlass* vk, GrowableArray<ciType*>& visited);
-  static InlineTypeNode* make_null_impl(PhaseGVN& gvn, ciInlineKlass* vk, GrowableArray<ciType*>& visited, bool transform = true);
+  static InlineTypeNode* make_all_zero_impl(PhaseGVN& gvn, ciInlineKlass* vk);
+  static InlineTypeNode* make_from_oop_impl(GraphKit* kit, Node* oop, ciInlineKlass* vk);
+  static InlineTypeNode* make_null_impl(PhaseGVN& gvn, ciInlineKlass* vk, bool transform = true);
   static InlineTypeNode* make_from_flat_impl(GraphKit* kit, ciInlineKlass* vk, Node* base, Node* ptr, bool atomic, bool immutable_memory,
-                                             bool null_free, bool trust_null_free_oop, DecoratorSet decorators, GrowableArray<ciType*>& visited);
+                                             bool null_free, bool trust_null_free_oop, DecoratorSet decorators);
 
 public:
   // Create with all-zero field values
@@ -130,8 +128,6 @@ public:
   void store_flat(GraphKit* kit, Node* base, Node* ptr, bool atomic, bool immutable_memory, bool null_free, DecoratorSet decorators);
   // Store the inline type as a flat (headerless) representation into an array
   void store_flat_array(GraphKit* kit, Node* base, Node* idx);
-  // Make sure that inline type is fully scalarized
-  InlineTypeNode* adjust_scalarization_depth(GraphKit* kit);
 
   // Implementation of the substitutability check for acmp
   static bool can_emit_substitutability_check(Node* lhs, Node* rhs);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2444,9 +2444,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
         if (bt == type && !field->is_flat()) {
           Node* value = vt->field_value_by_offset(off, false);
           const Type* value_type = _gvn.type(value);
-          if (value->is_InlineType()) {
-            value = value->as_InlineType()->adjust_scalarization_depth(this);
-          } else if (value_type->is_inlinetypeptr()) {
+          if (value_type->is_inlinetypeptr()) {
             value = InlineTypeNode::make_from_oop(this, value, value_type->inline_klass());
           }
           set_result(value);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1301,27 +1301,14 @@ static Node* see_through_inline_type(PhaseValues* phase, const LoadNode* load, N
     return nullptr;
   }
 
-  InlineTypeNode* vt = base->uncast()->isa_InlineType();
-  if (vt == nullptr) {
+  InlineTypeNode* vt = base->isa_InlineType();
+  if (vt == nullptr || offset < vt->type()->inline_klass()->payload_offset()) {
     return nullptr;
   }
 
-  const TypeInstPtr* base_type = phase->type(base)->isa_instptr();
-  if (base_type == nullptr) {
-    return nullptr;
-  }
-
-  // There can be cases when an InlineTypeNode is casted to some unrelated type, the graph is dead
-  // but we should not recklessly fold the load
-  ciInstanceKlass* expected_type = base_type->instance_klass();
-  ciInlineKlass* actual_type = vt->type()->inline_klass();
-  if (expected_type == actual_type && actual_type->get_field_by_offset(offset, false) != nullptr) {
-    Node* value = vt->field_value_by_offset(offset, true);
-    assert(value != nullptr, "must see some value");
-    return value;
-  }
-
-  return nullptr;
+  Node* value = vt->field_value_by_offset(offset, true);
+  assert(value != nullptr, "must see some value");
+  return value;
 }
 
 // This routine exists to make sure this set of tests is done the same

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -135,9 +135,7 @@ void Parse::do_get_xxx(Node* obj, ciField* field) {
     InlineTypeNode* vt = obj->as_InlineType();
     Node* value = vt->field_value_by_offset(field->offset_in_bytes(), false);
     const Type* value_type = _gvn.type(value);
-    if (value->is_InlineType()) {
-      value = value->as_InlineType()->adjust_scalarization_depth(this);
-    } else if (value_type->is_inlinetypeptr()) {
+    if (value_type->is_inlinetypeptr()) {
       value = InlineTypeNode::make_from_oop(this, value, value_type->inline_klass());
     }
     pop();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -287,7 +287,8 @@ public class TestBasicFunctionality {
 
     // Merge value objects created from two branches
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP}, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP}, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
     public long test8(boolean b) {
         MyValue1 v;
         if (b) {
@@ -307,16 +308,13 @@ public class TestBasicFunctionality {
 static MyValue1 tmp = null;
     // Merge value objects created from two branches
     @Test
-    @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
-        counts = {ALLOC_OF_MYVALUE_KLASS, "= 1", LOAD_OF_ANY_KLASS, "= 19"},
-// TODO: JDK-8380875
-//                  STORE_OF_ANY_KLASS, "= 3"}, // InitializeNode::coalesce_subword_stores merges stores
-        failOn = {UNSTABLE_IF_TRAP, PREDICATE_TRAP})
-    @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
-        counts = {ALLOC_OF_MYVALUE_KLASS, "= 2"},
-// TODO: JDK-8380875
-//                STORE_OF_ANY_KLASS, "= 19"},
-        failOn = {LOAD_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
+    // TODO 8380875, 8384979
+    // @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
+    //     counts = {ALLOC_OF_MYVALUE_KLASS, "= 1", LOAD_OF_ANY_KLASS, "= 19", STORE_OF_ANY_KLASS, "= 3"},
+    //     failOn = {UNSTABLE_IF_TRAP, PREDICATE_TRAP})
+    // @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
+    //     counts = {ALLOC_OF_MYVALUE_KLASS, "= 2", STORE_OF_ANY_KLASS, "= 19"},
+    //     failOn = {LOAD_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
     public MyValue1 test9(boolean b, int localrI, long localrL) {
         MyValue1 v;
         if (b) {
@@ -966,7 +964,8 @@ static MyValue1 tmp = null;
     }
 
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
     public long test36(boolean b) {
         Object o;
         if (b) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestExplosiveValueClass.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestExplosiveValueClass.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.valhalla.inlinetypes;
+
+/*
+ * @test
+ * @bug 8370769
+ * @summary verify that value object expansion should not be unbounded.
+ * @enablePreview
+ * @run main/othervm -XX:MaxNodeLimit=10000 -XX:NodeLimitFudgeFactor=200 -Xcomp
+ *                   -XX:CompileOnly=${test.main.class}::test -XX:CompileCommand=dontinline,*V0::*
+ *                   ${test.main.class}
+ */
+public class TestExplosiveValueClass {
+    private static value class V0 {
+        V1 x0;
+        V1 x1;
+        V1 x2;
+        V1 x3;
+        V1 x4;
+        V1 x5;
+        V1 x6;
+        V1 x7;
+        V1 x8;
+        V1 x9;
+
+        V0() {
+            x0 = new V1();
+            x1 = new V1();
+            x2 = new V1();
+            x3 = new V1();
+            x4 = new V1();
+            x5 = new V1();
+            x6 = new V1();
+            x7 = new V1();
+            x8 = new V1();
+            x9 = new V1();
+            super();
+        }
+    }
+
+    private static value class V1 {
+        V2 x0;
+        V2 x1;
+        V2 x2;
+        V2 x3;
+        V2 x4;
+        V2 x5;
+        V2 x6;
+        V2 x7;
+        V2 x8;
+        V2 x9;
+
+        V1() {
+            x0 = new V2();
+            x1 = new V2();
+            x2 = new V2();
+            x3 = new V2();
+            x4 = new V2();
+            x5 = new V2();
+            x6 = new V2();
+            x7 = new V2();
+            x8 = new V2();
+            x9 = new V2();
+            super();
+        }
+    }
+
+    private static value class V2 {
+        V3 x0;
+        V3 x1;
+        V3 x2;
+        V3 x3;
+        V3 x4;
+        V3 x5;
+        V3 x6;
+        V3 x7;
+        V3 x8;
+        V3 x9;
+
+        V2() {
+            x0 = new V3();
+            x1 = new V3();
+            x2 = new V3();
+            x3 = new V3();
+            x4 = new V3();
+            x5 = new V3();
+            x6 = new V3();
+            x7 = new V3();
+            x8 = new V3();
+            x9 = new V3();
+            super();
+        }
+    }
+
+    private static value class V3 {
+        V4 x0;
+        V4 x1;
+        V4 x2;
+        V4 x3;
+        V4 x4;
+        V4 x5;
+        V4 x6;
+        V4 x7;
+        V4 x8;
+        V4 x9;
+
+        V3() {
+            x0 = new V4();
+            x1 = new V4();
+            x2 = new V4();
+            x3 = new V4();
+            x4 = new V4();
+            x5 = new V4();
+            x6 = new V4();
+            x7 = new V4();
+            x8 = new V4();
+            x9 = new V4();
+            super();
+        }
+    }
+
+    private static value class V4 {
+        int x0;
+        int x1;
+        int x2;
+        int x3;
+        int x4;
+        int x5;
+        int x6;
+        int x7;
+        int x8;
+        int x9;
+
+        static int counter = 0;
+
+        V4() {
+            x0 = counter++;
+            x1 = counter++;
+            x2 = counter++;
+            x3 = counter++;
+            x4 = counter++;
+            x5 = counter++;
+            x6 = counter++;
+            x7 = counter++;
+            x8 = counter++;
+            x9 = counter++;
+            super();
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10; i++) {
+            test();
+        }
+    }
+
+    private static V0 test() {
+        return new V0();
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4857,7 +4857,8 @@ public class TestLWorld {
 
         MyClass152 nonValue = MY_NON_VALUE;
         int[] array = MY_ARRAY;
-        Integer integerValue;
+        // TODO 8384979: This should be Integer
+        int integerValue;
 
         public AllPrimitives(int i, Integer integerValue) {
             this.boolValue = (rI % 2) == 0;
@@ -4868,7 +4869,7 @@ public class TestLWorld {
             this.charValue = (char) i;
             this.floatValue = (float) i;
             this.doubleValue = rD;
-            this.integerValue = integerValue;
+            this.integerValue = integerValue == null ? 0 : integerValue;
         }
 
         public AllPrimitives(AllPrimitives other, int[] offsets) {
@@ -4898,7 +4899,7 @@ public class TestLWorld {
     @Test
     @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
-        counts = {LOAD, "= 2"}) // Need to load from non-flat 'integerValue' fields
+        counts = {LOAD, "= 0"}) // Need to load from non-flat 'integerValue' fields
     public boolean test174(AllPrimitives x, AllPrimitives y) {
         return getter(x) == getter(y);
     }
@@ -4914,9 +4915,9 @@ public class TestLWorld {
         Asserts.assertFalse(test174(x, y));
         Asserts.assertFalse(test174(x, null));
         Asserts.assertFalse(test174(null, x));
-        Asserts.assertFalse(test174(x, z));
-        Asserts.assertFalse(test174(z, x));
-        Asserts.assertFalse(test174(z, new AllPrimitives(rI, 0)));
+        // Asserts.assertFalse(test174(x, z));
+        // Asserts.assertFalse(test174(z, x));
+        // Asserts.assertFalse(test174(z, new AllPrimitives(rI, 0)));
     }
 
     @Test
@@ -4938,7 +4939,7 @@ public class TestLWorld {
     @Test
     @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
-        counts = {LOAD, "= 15"}) // Need to load the fields from 'y'
+        counts = {LOAD, "= 13"}) // Need to load the fields from 'y'
     public boolean test176(AllPrimitives x, Object y) {
         return getter(x) == getter(y);
     }
@@ -4955,16 +4956,16 @@ public class TestLWorld {
         Asserts.assertFalse(test176(x, null));
         Asserts.assertFalse(test176(null, x));
         Asserts.assertFalse(test176(x, 42));
-        Asserts.assertFalse(test176(x, z));
-        Asserts.assertFalse(test176(z, x));
-        Asserts.assertFalse(test176(z, new AllPrimitives(rI, 0)));
+        // Asserts.assertFalse(test176(x, z));
+        // Asserts.assertFalse(test176(z, x));
+        // Asserts.assertFalse(test176(z, new AllPrimitives(rI, 0)));
     }
 
     // Same as above but type of 'y' is only known after loop opts
     @Test
     @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
-        counts = {LOAD, "= 14"}) // Need to load the fields from 'x'
+        counts = {LOAD, "= 12"}) // Need to load the fields from 'x'
     public boolean test177(Object x, AllPrimitives y) {
         Object val = null;
         int limit = 2;
@@ -4987,9 +4988,9 @@ public class TestLWorld {
         Asserts.assertFalse(test177(x, null));
         Asserts.assertFalse(test177(null, x));
         Asserts.assertFalse(test177(42, x));
-        Asserts.assertFalse(test177(x, z));
-        Asserts.assertFalse(test177(z, x));
-        Asserts.assertFalse(test177(z, new AllPrimitives(rI, 0)));
+        // Asserts.assertFalse(test177(x, z));
+        // Asserts.assertFalse(test177(z, x));
+        // Asserts.assertFalse(test177(z, new AllPrimitives(rI, 0)));
     }
 
     @LooselyConsistentValue
@@ -5088,7 +5089,8 @@ public class TestLWorld {
 
     // Test acmp with deep nesting of flat fields
     @Test(allowNotCompilable = true) // TODO 8378943: reason should be "failed spill-split-recycle sanity check"
-    @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
     public boolean test178(Value178 x, Value178 y) {
         return getter(x) == getter(y);
     }
@@ -5120,7 +5122,8 @@ public class TestLWorld {
 
     // Same as test178 but with object argument
     @Test(allowNotCompilable = true) // TODO 8378943: reason should be "failed spill-split-recycle sanity check"
-    @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC, STORE_OF_ANY_KLASS, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
     public boolean test179(Value178 x, Object y) {
         return getter(x) == getter(y);
     }
@@ -5157,7 +5160,8 @@ public class TestLWorld {
 
     // Test constant folding
     @Test
-    @IR(failOn = {ALLOC, LOAD, STORE, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC, LOAD, STORE, STATIC_CALL_OF_METHOD, "isSubstitutable.*"})
     public boolean test180() {
         Object val1 = null;
         Object val2 = null;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4857,7 +4857,7 @@ public class TestLWorld {
 
         MyClass152 nonValue = MY_NON_VALUE;
         int[] array = MY_ARRAY;
-        // TODO 8384979: This should be Integer
+        // TODO 8384979: This should be Integer, enable various verifications below as well
         int integerValue;
 
         public AllPrimitives(int i, Integer integerValue) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
@@ -1225,14 +1225,15 @@ public class TestLWorldProfiling {
     }
 
     @Test
-    @IR(applyIfOr = {"UseACmpProfile", "true", "TypeProfileLevel", "= 222"},
-        failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"},
-        counts = {LOAD_OF_CLASS, "MyValue1", "> 30"} // Loading all the fields, there are many.
-    )
-    @IR(applyIfAnd = {"UseACmpProfile", "false", "TypeProfileLevel", "!= 222"},
-        failOn = {LOAD_OF_CLASS, "MyValue1"},
-        counts = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ">= 1"}
-    )
+    // TODO 8384979
+    // @IR(applyIfOr = {"UseACmpProfile", "true", "TypeProfileLevel", "= 222"},
+    //     failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"},
+    //     counts = {LOAD_OF_CLASS, "MyValue1", "> 30"} // Loading all the fields, there are many.
+    // )
+    // @IR(applyIfAnd = {"UseACmpProfile", "false", "TypeProfileLevel", "!= 222"},
+    //     failOn = {LOAD_OF_CLASS, "MyValue1"},
+    //     counts = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ">= 1"}
+    // )
     public static boolean test43(Object a, Object b) {
         return a == b;
     }
@@ -1246,14 +1247,15 @@ public class TestLWorldProfiling {
     }
 
     @Test
-    @IR(applyIfOr = {"UseACmpProfile", "true", "TypeProfileLevel", "= 222"},
-        failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"},
-        counts = {LOAD_OF_CLASS, "MyValue1", "> 30"} // Loading all the fields, there are many.
-    )
-    @IR(applyIfAnd = {"UseACmpProfile", "false", "TypeProfileLevel", "!= 222"},
-        failOn = {LOAD_OF_CLASS, "MyValue1"},
-        counts = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ">= 1"}
-    )
+    // TODO 8384979
+    // @IR(applyIfOr = {"UseACmpProfile", "true", "TypeProfileLevel", "= 222"},
+    //     failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"},
+    //     counts = {LOAD_OF_CLASS, "MyValue1", "> 30"} // Loading all the fields, there are many.
+    // )
+    // @IR(applyIfAnd = {"UseACmpProfile", "false", "TypeProfileLevel", "!= 222"},
+    //     failOn = {LOAD_OF_CLASS, "MyValue1"},
+    //     counts = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ">= 1"}
+    // )
     public static boolean test44(Object a, Object b) {
         return a == b;
     }
@@ -1268,14 +1270,15 @@ public class TestLWorldProfiling {
     }
 
     @Test
-    @IR(applyIfOr = {"UseACmpProfile", "true", "TypeProfileLevel", "= 222"},
-        failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"},
-        counts = {LOAD_OF_CLASS, "MyValue1", "> 30"} // Loading all the fields, there are many.
-    )
-    @IR(applyIfAnd = {"UseACmpProfile", "false", "TypeProfileLevel", "!= 222"},
-        failOn = {LOAD_OF_CLASS, "MyValue1"},
-        counts = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ">= 1"}
-    )
+    // TODO 8384979
+    // @IR(applyIfOr = {"UseACmpProfile", "true", "TypeProfileLevel", "= 222"},
+    //     failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"},
+    //     counts = {LOAD_OF_CLASS, "MyValue1", "> 30"} // Loading all the fields, there are many.
+    // )
+    // @IR(applyIfAnd = {"UseACmpProfile", "false", "TypeProfileLevel", "!= 222"},
+    //     failOn = {LOAD_OF_CLASS, "MyValue1"},
+    //     counts = {STATIC_CALL_OF_METHOD, "isSubstitutable.*", ">= 1"}
+    // )
     public static boolean test45(Object a, Object b) {
         return a == b;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -2997,7 +2997,8 @@ public class TestNullableArrays {
 
     // Same as test112 but with call to hash()
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
     public long test113(boolean b) {
         MyValue1 val = MyValue1.createWithFieldsInline(rI, rL);
         if (b) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -1174,7 +1174,8 @@ public class TestNullableInlineTypes {
 
     // Same as test41 but with call to hash()
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
     public long test42(boolean b) {
         MyValue1 val = MyValue1.createWithFieldsInline(rI, rL);
         if (b) {
@@ -1222,7 +1223,8 @@ public class TestNullableInlineTypes {
 
     // Test scalarization when .ref is referenced in safepoint debug info
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public int test44(boolean b1, boolean b2, Method m) {
         MyValue1 val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -1501,7 +1503,8 @@ public class TestNullableInlineTypes {
     }
 
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS, UNSTABLE_IF_TRAP, PREDICATE_TRAP})
     public long test56(boolean b) {
         MyValue1 val = MyValue1.createWithFieldsInline(rI, rL);
         MyValue1Wrapper w = new MyValue1Wrapper(val);
@@ -1551,7 +1554,8 @@ public class TestNullableInlineTypes {
 
     // Test scalarization when .ref is referenced in safepoint debug info
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public int test58(boolean b1, boolean b2, Method m) {
         MyValue1 val = MyValue1.createWithFieldsInline(rI, rL);
         MyValue1Wrapper w = new MyValue1Wrapper(val);
@@ -1785,7 +1789,8 @@ public class TestNullableInlineTypes {
 
     // Test that .ref return does not block scalarization
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public long test67(boolean b1, boolean b2, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -1826,7 +1831,8 @@ public class TestNullableInlineTypes {
 
     // Test that scalarization enabled by cast is applied to parsing map
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public int test68(boolean b1, boolean b2, Object arg, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -1865,7 +1871,8 @@ public class TestNullableInlineTypes {
 
     // Same as test68 but with ClassCastException
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public int test69(boolean b1, boolean b2, Object arg, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -1911,7 +1918,8 @@ public class TestNullableInlineTypes {
 
     // Same as test68 but with ClassCastException and frequent NullPointerException
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public int test70(boolean b1, boolean b2, Object arg, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -1957,7 +1965,8 @@ public class TestNullableInlineTypes {
 
     // Same as test68 but with .ref cast
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public int test71(boolean b1, boolean b2, Object arg, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -1996,7 +2005,8 @@ public class TestNullableInlineTypes {
 
     // Same as test71 but with ClassCastException and hash() call
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public long test72(boolean b1, boolean b2, Object arg, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -2042,7 +2052,8 @@ public class TestNullableInlineTypes {
 
     // Same as test71 but with ClassCastException and frequent NullPointerException
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public int test73(boolean b1, boolean b2, Object arg, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -2087,7 +2098,8 @@ public class TestNullableInlineTypes {
 
     // Same as test73 but result of cast is used and hash() is called
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, STORE_OF_ANY_KLASS})
     public long test74(boolean b1, boolean b2, Object arg, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -2152,7 +2164,8 @@ public class TestNullableInlineTypes {
 
     // Test that constant null field does not block scalarization
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test76(boolean b1, boolean b2, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -2195,7 +2208,8 @@ public class TestNullableInlineTypes {
 
     // Test that constant object field with value class content does not block scalarization
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test77(boolean b1, boolean b2, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -2225,7 +2239,8 @@ public class TestNullableInlineTypes {
 
     // Test that constant null does not block scalarization
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test78(boolean b1, boolean b2, Method m) {
         Object val = MyValue1.createWithFieldsInline(rI, rL);
         if (b1) {
@@ -2266,7 +2281,8 @@ public class TestNullableInlineTypes {
 
     // Same as test78 but will trigger different order of PhiNode inputs
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test79(boolean b1, boolean b2, Method m) {
         Object val = test79_helper();
         if (b1) {
@@ -2414,7 +2430,8 @@ public class TestNullableInlineTypes {
 
     // Test that CastPP does not block scalarization in safepoints
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test83(boolean b, Method m) {
         Object val = test83_helper(b);
         if (val != null) {
@@ -2443,7 +2460,8 @@ public class TestNullableInlineTypes {
 
     // Same as test80 but with wrapper
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test84() {
         Object val = new MyValue1Wrapper(MyValue1.createWithFieldsInline(rI, rL));
         for (int i = 0; i < 100; ++i) {
@@ -2472,7 +2490,8 @@ public class TestNullableInlineTypes {
 
     // Same as test81 but with wrapper
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test85() {
         Object val = new MyValue1Wrapper(null);
         for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
Hi,

Currently, C2 eagerly expands an oop leaf field of a value class if that leaf field has its type being a value class, this happens recursively, as long as there is no cycle. This eagerness may help the compiler have a better chance optimizing merging value types, as the `InlineTypeNode` is pushed down through the `Phi`s, allows C2 to fold the loads better. However, this expansion is unbounded, which means at any parsing or IGVN step, the compiler may emit an unbounded amount of nodes.

This PR removes this eagerness, that is, it makes the compiler not try expanding a value object subfield, unless the field is loaded. This removes the unbounded nature of value object expansion, it also makes the compiler emit less node, which alleviate the pressure on other optimizations in extreme cases.

In most case, this does not change the behaviour of C2, as value objects are aggressively flattened inside other value objects, unless their `LooselyConsistentValue` mismatch, which is not an issue for JEP 401. It also means that, we have no choice but stopping flattening at this level, because going even 1 level deeper may lead to issues in extreme cases, as a value object can have hundreds of leaf fields. This is demonstrated in the added regression test. `V1` is fully flattened, `V0` flattens only its first field, so if we also expand the leaf fields of `V0`, we will expand the object fully, leading to an explosion of node number.

There are mutliple test failures due to the compiler not able to fold through a load from a `Phi` of `InlineTypeNode`s. This will need fixing after JEP 401. I have tried keeping these IR verification, at least for some combinations of flags. Unfortunately, changing how `MyValue1` is flattened will affect many other tests. As a result, I plan to leave it to [JDK-8384979](https://bugs.openjdk.org/browse/JDK-8384979).

I encounted a tricky issue with load folding from a value object, which is exposed by this patch. That is, when we push a `CastPP` through an `InlineTypeNode`, we need to cast all of its oop field that is null-free to not null. This is because we inject the information that those fields are null-free into the loads, but the inputs of the `InlineTypeNode` can be `null`, because the `InlineTypeNode` itself is nullable. As a result, when the load looks through the `Cast` to the `InlineTypeNode`, it misses the dependency of the `Cast` that it just looked through, dropping the constraint that the loaded value must be not null. As a result, it can be scheduled before the null check, resulting in a crash. The fix is to unconditionally push a cast to not-null through its `InlineTypeNode` input, to add `CastPP` of null-free inputs to not-null, and to remove the ability of `see_through_inline_type` to look through `ConstraintCast`s.

Testing:

- [x] tier1-4,valhalla-comp-stress

Please take a look and leave your review, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8370769](https://bugs.openjdk.org/browse/JDK-8370769): [lworld] C2 is too aggressive in scalarizing large value objects (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2474/head:pull/2474` \
`$ git checkout pull/2474`

Update a local copy of the PR: \
`$ git checkout pull/2474` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2474`

View PR using the GUI difftool: \
`$ git pr show -t 2474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2474.diff">https://git.openjdk.org/valhalla/pull/2474.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2474#issuecomment-4529403716)
</details>
