### PR TITLE
8385474: [lworld] Leftover JVM_IsValhallaEnabled and JVM_IsIdentityClass

### DIFF
--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -178,9 +178,6 @@ JNIEXPORT jboolean JNICALL
 JVM_IsPreviewEnabled(void);
 
 JNIEXPORT jboolean JNICALL
-JVM_IsValhallaEnabled(void);
-
-JNIEXPORT jboolean JNICALL
 JVM_IsContinuationsSupported(void);
 
 JNIEXPORT jboolean JNICALL
@@ -561,9 +558,6 @@ JVM_IsInterface(JNIEnv *env, jclass cls);
 
 JNIEXPORT jboolean JNICALL
 JVM_IsHiddenClass(JNIEnv *env, jclass cls);
-
-JNIEXPORT jboolean JNICALL
-JVM_IsIdentityClass(JNIEnv *env, jclass cls);
 
 JNIEXPORT jobjectArray JNICALL
 JVM_GetDeclaredClasses(JNIEnv *env, jclass ofClass);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3437,10 +3437,6 @@ JVM_LEAF(jboolean, JVM_IsPreviewEnabled(void))
   return Arguments::enable_preview() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 
-JVM_LEAF(jboolean, JVM_IsValhallaEnabled(void))
-  return Arguments::is_valhalla_enabled() ? JNI_TRUE : JNI_FALSE;
-JVM_END
-
 JVM_LEAF(jboolean, JVM_IsContinuationsSupported(void))
   return VMContinuations ? JNI_TRUE : JNI_FALSE;
 JVM_END


### PR DESCRIPTION
These leftover declarations and definition should be removed.  Tested with building.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385474](https://bugs.openjdk.org/browse/JDK-8385474): [lworld] Leftover JVM_IsValhallaEnabled and JVM_IsIdentityClass (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2475/head:pull/2475` \
`$ git checkout pull/2475`

Update a local copy of the PR: \
`$ git checkout pull/2475` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2475`

View PR using the GUI difftool: \
`$ git pr show -t 2475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2475.diff">https://git.openjdk.org/valhalla/pull/2475.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2475#issuecomment-4547995220)
</details>
