### PR TITLE
8383935: [lworld] Remove commented out @IntrinsicCandidate annotations

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -178,29 +178,28 @@ public final class Objects {
         return o.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(o));
     }
 
-   /**
-    * {@return {@code true} if the input is a non-null reference
-    * to an object with identity, and {@code false} otherwise}
-    *
-    * <p>If the object is an instance of a concrete {@linkplain Class#isValue()
-    * value class}, it does not have identity and the result will be
-    * {@code false}. All other objects, including arrays, are identity objects
-    * and the result will be {@code true}.
-    *
-    * @apiNote
-    * If the parameter is {@code null}, there is no object
-    * and hence no identity; the result is {@code false}.
-    * To test for a value object use:
-    * {@snippet type="java" :
-    *     if (obj != null && !Objects.hasIdentity(obj)) {
-    *         // obj is a non-null value object
-    *     }
-    * }
-    * @param obj an object or {@code null}
-    * @since Valhalla
-    */
-   @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
-//    @IntrinsicCandidate
+    /**
+     * {@return {@code true} if the input is a non-null reference
+     * to an object with identity, and {@code false} otherwise}
+     *
+     * <p>If the object is an instance of a concrete {@linkplain Class#isValue()
+     * value class}, it does not have identity and the result will be
+     * {@code false}. All other objects, including arrays, are identity objects
+     * and the result will be {@code true}.
+     *
+     * @apiNote
+     * If the parameter is {@code null}, there is no object
+     * and hence no identity; the result is {@code false}.
+     * To test for a value object use:
+     * {@snippet type="java" :
+     *     if (obj != null && !Objects.hasIdentity(obj)) {
+     *         // obj is a non-null value object
+     *     }
+     * }
+     * @param obj an object or {@code null}
+     * @since Valhalla
+     */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     public static boolean hasIdentity(Object obj) {
         return (obj == null) ? false : !obj.getClass().isValue();
     }


### PR DESCRIPTION
Remove an outdated comment, and at the same time fix the indentation of the API specs of the changed method `Objects::hasIdentity`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383935](https://bugs.openjdk.org/browse/JDK-8383935): [lworld] Remove commented out @<!---->IntrinsicCandidate annotations (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2476/head:pull/2476` \
`$ git checkout pull/2476`

Update a local copy of the PR: \
`$ git checkout pull/2476` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2476`

View PR using the GUI difftool: \
`$ git pr show -t 2476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2476.diff">https://git.openjdk.org/valhalla/pull/2476.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2476#issuecomment-4555637229)
</details>
