### PR TITLE
8385526: [lworld] Remove unused HotSpot leftovers added in lworld

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2409,11 +2409,6 @@ void MacroAssembler::test_field_is_flat(Register flags, Register temp_reg, Label
   tbnz(flags, ResolvedFieldEntry::is_flat_shift, is_flat);
 }
 
-void MacroAssembler::test_field_has_null_marker(Register flags, Register temp_reg, Label& has_null_marker) {
-  assert(temp_reg == noreg, "not needed"); // keep signature uniform with x86
-  tbnz(flags, ResolvedFieldEntry::has_null_marker_shift, has_null_marker);
-}
-
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label) {
   Label test_mark_word;
   // load mark word
@@ -2453,11 +2448,6 @@ void MacroAssembler::test_non_null_free_array_oop(Register oop, Register temp_re
 void MacroAssembler::test_flat_array_layout(Register lh, Label& is_flat_array) {
   tst(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
   br(Assembler::NE, is_flat_array);
-}
-
-void MacroAssembler::test_non_flat_array_layout(Register lh, Label& is_non_flat_array) {
-  tst(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
-  br(Assembler::EQ, is_non_flat_array);
 }
 
 // MacroAssembler protected routines needed to implement
@@ -5715,24 +5705,6 @@ void MacroAssembler::payload_address(Register oop, Register data, Register inlin
   } else {
     lea(data, Address(oop, offset));
   }
-}
-
-void MacroAssembler::data_for_value_array_index(Register array, Register array_klass,
-                                                Register index, Register data) {
-  assert_different_registers(array, array_klass, index);
-  assert_different_registers(rscratch1, array, index);
-
-  // array->base() + (index << Klass::layout_helper_log2_element_size(lh));
-  ldrw(rscratch1, Address(array_klass, Klass::layout_helper_offset()));
-
-  // Klass::layout_helper_log2_element_size(lh)
-  // (lh >> _lh_log2_element_size_shift) & _lh_log2_element_size_mask;
-  lsr(rscratch1, rscratch1, Klass::_lh_log2_element_size_shift);
-  andr(rscratch1, rscratch1, Klass::_lh_log2_element_size_mask);
-  lslv(index, index, rscratch1);
-
-  add(data, array, index);
-  add(data, data, arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT));
 }
 
 void MacroAssembler::load_heap_oop(Register dst, Address src, Register tmp1,

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -692,7 +692,6 @@ public:
   void test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free);
   void test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free);
   void test_field_is_flat(Register flags, Register temp_reg, Label& is_flat);
-  void test_field_has_null_marker(Register flags, Register temp_reg, Label& has_null_marker);
 
   // Check oops for special arrays, i.e. flat arrays and/or null-free arrays
   void test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label);
@@ -703,7 +702,6 @@ public:
 
   // Check array klass layout helper for flat or null-free arrays...
   void test_flat_array_layout(Register lh, Label& is_flat_array);
-  void test_non_flat_array_layout(Register lh, Label& is_non_flat_array);
 
   static address target_addr_for_insn(address insn_addr);
 
@@ -955,9 +953,6 @@ public:
   // inline type data payload offsets...
   void payload_offset(Register inline_klass, Register offset);
   void payload_address(Register oop, Register data, Register inline_klass);
-  // get data payload ptr a flat value array at index, kills rcx and index
-  void data_for_value_array_index(Register array, Register array_klass,
-                                  Register index, Register data);
 
   void load_heap_oop(Register dst, Address src, Register tmp1,
                      Register tmp2, DecoratorSet decorators = 0);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2421,12 +2421,6 @@ void MacroAssembler::test_field_is_flat(Register flags, Register temp_reg, Label
   jcc(Assembler::notEqual, is_flat);
 }
 
-void MacroAssembler::test_field_has_null_marker(Register flags, Register temp_reg, Label& has_null_marker) {
-  movl(temp_reg, flags);
-  testl(temp_reg, 1 << ResolvedFieldEntry::has_null_marker_shift);
-  jcc(Assembler::notEqual, has_null_marker);
-}
-
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label) {
   Label test_mark_word;
   // load mark word
@@ -2465,11 +2459,6 @@ void MacroAssembler::test_non_null_free_array_oop(Register oop, Register temp_re
 void MacroAssembler::test_flat_array_layout(Register lh, Label& is_flat_array) {
   testl(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
   jcc(Assembler::notZero, is_flat_array);
-}
-
-void MacroAssembler::test_non_flat_array_layout(Register lh, Label& is_non_flat_array) {
-  testl(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
-  jcc(Assembler::zero, is_non_flat_array);
 }
 
 void MacroAssembler::os_breakpoint() {
@@ -5648,24 +5637,6 @@ void MacroAssembler::payload_addr(Register oop, Register data, Register inline_k
   } else {
     lea(data, Address(oop, offset));
   }
-}
-
-void MacroAssembler::data_for_value_array_index(Register array, Register array_klass,
-                                                Register index, Register data) {
-  assert(index != rcx, "index needs to shift by rcx");
-  assert_different_registers(array, array_klass, index);
-  assert_different_registers(rcx, array, index);
-
-  // array->base() + (index << Klass::layout_helper_log2_element_size(lh));
-  movl(rcx, Address(array_klass, Klass::layout_helper_offset()));
-
-  // Klass::layout_helper_log2_element_size(lh)
-  // (lh >> _lh_log2_element_size_shift) & _lh_log2_element_size_mask;
-  shrl(rcx, Klass::_lh_log2_element_size_shift);
-  andl(rcx, Klass::_lh_log2_element_size_mask);
-  shlptr(index); // index << rcx
-
-  lea(data, Address(array, index, Address::times_1, arrayOopDesc::base_offset_in_bytes(T_FLAT_ELEMENT)));
 }
 
 void MacroAssembler::load_heap_oop(Register dst, Address src, Register tmp1, DecoratorSet decorators) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -106,7 +106,6 @@ class MacroAssembler: public Assembler {
   void test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free);
   void test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free);
   void test_field_is_flat(Register flags, Register temp_reg, Label& is_flat);
-  void test_field_has_null_marker(Register flags, Register temp_reg, Label& has_null_marker);
 
   // Check oops for special arrays, i.e. flat arrays and/or null-free arrays
   void test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label);
@@ -117,7 +116,6 @@ class MacroAssembler: public Assembler {
 
   // Check array klass layout helper for flat or null-free arrays...
   void test_flat_array_layout(Register lh, Label& is_flat_array);
-  void test_non_flat_array_layout(Register lh, Label& is_non_flat_array);
 
   // Required platform-specific helpers for Label::patch_instructions.
   // They _shadow_ the declarations in AbstractAssembler, which are undefined.
@@ -398,9 +396,6 @@ class MacroAssembler: public Assembler {
   // inline type data payload offsets...
   void payload_offset(Register inline_klass, Register offset);
   void payload_addr(Register oop, Register data, Register inline_klass);
-  // get data payload ptr a flat value array at index, kills rcx and index
-  void data_for_value_array_index(Register array, Register array_klass,
-                                  Register index, Register data);
 
   void load_heap_oop(Register dst, Address src, Register tmp1 = noreg, DecoratorSet decorators = 0);
   void load_heap_oop_not_null(Register dst, Address src, Register tmp1 = noreg, DecoratorSet decorators = 0);

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -55,15 +55,6 @@ bool MacroAssembler::is_reg_in_unpacked_fields(const GrowableArray<SigEntry>* si
   return false;
 }
 
-void MacroAssembler::mark_reg_writable(const VMRegPair* regs, int num_regs, int reg_index, MacroAssembler::RegState* reg_state) {
-  assert(0 <= reg_index && reg_index < num_regs, "sanity");
-  VMReg from_reg = regs[reg_index].first();
-  if (from_reg->is_valid()) {
-    assert(from_reg->is_stack(), "reserved entries must be stack");
-    reg_state[from_reg->value()] = MacroAssembler::reg_writable;
-  }
-}
-
 MacroAssembler::RegState* MacroAssembler::init_reg_state(VMRegPair* regs, int num_regs, int sp_inc, int max_stack) {
   int max_reg = VMRegImpl::stack2reg(max_stack)->value();
   MacroAssembler::RegState* reg_state = NEW_RESOURCE_ARRAY(MacroAssembler::RegState, max_reg);

--- a/src/hotspot/share/asm/macroAssembler_common.hpp
+++ b/src/hotspot/share/asm/macroAssembler_common.hpp
@@ -39,7 +39,6 @@
                             int regs_from_count, int& from_index);
   bool is_reg_in_unpacked_fields(const GrowableArray<SigEntry>* sig, int sig_index, VMReg to, VMRegPair* regs_from,
                                  int regs_from_count, int from_index);
-  void mark_reg_writable(const VMRegPair* regs, int num_regs, int reg_index, RegState* reg_state);
   RegState* init_reg_state(VMRegPair* regs, int num_regs, int sp_inc, int max_stack);
   int unpack_inline_args(Compile* C, bool receiver_only);
   void shuffle_inline_args(bool is_packing, bool receiver_only,

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -560,9 +560,6 @@ JRT_ENTRY(int, Runtime1::substitutability_check(JavaThread* current, oopDesc* le
   return result.get_jboolean() ? 1 : 0;
 JRT_END
 
-
-extern "C" void ps();
-
 void Runtime1::buffer_inline_args_impl(JavaThread* current, Method* m, bool allocate_receiver) {
   JavaThread* THREAD = current;
   methodHandle method(current, m); // We are inside the verified_entry or verified_inline_ro_entry of this method.

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -98,7 +98,6 @@ public:
 
   // runtime entry points
   static void new_instance    (JavaThread* current, Klass* klass);
-  static void new_instance_no_inline(JavaThread* current, Klass* klass);
   static void new_type_array  (JavaThread* current, Klass* klass, jint length);
   static void new_object_array(JavaThread* current, Klass* klass, jint length);
   static void new_null_free_array(JavaThread* current, Klass* klass, jint length);

--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -220,8 +220,6 @@ class VerificationType {
   bool is_array_array() const { return is_x_array(JVM_SIGNATURE_ARRAY); }
   bool is_reference_array() const
     { return is_object_array() || is_array_array(); }
-  bool is_nonscalar_array() const
-    { return is_object_array() || is_array_array(); }
   bool is_object() const
     { return (is_reference() && !is_null() && name()->utf8_length() >= 1 &&
               name()->char_at(0) != JVM_SIGNATURE_ARRAY); }

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -61,7 +61,6 @@ class InterpreterRuntime: AllStatic {
   static void    anewarray     (JavaThread* current, ConstantPool* pool, int index, jint size);
   static void    multianewarray(JavaThread* current, jint* first_size_address);
   static void    register_finalizer(JavaThread* current, oopDesc* obj);
-  static void    write_heap_copy (JavaThread* current, oopDesc* value, int offset, oopDesc* rcv);
   static void    read_flat_field(JavaThread* current, oopDesc* object, ResolvedFieldEntry* entry);
   static void    write_flat_field(JavaThread* current, oopDesc* object, oopDesc* value, ResolvedFieldEntry* entry);
 

--- a/src/hotspot/share/interpreter/templateTable.cpp
+++ b/src/hotspot/share/interpreter/templateTable.cpp
@@ -434,7 +434,6 @@ void TemplateTable::initialize() {
   def(Bytecodes::_ifnonnull           , ubcp|____|clvm|____, atos, vtos, if_nullcmp          , not_equal    );
   def(Bytecodes::_goto_w              , ubcp|____|clvm|____, vtos, vtos, goto_w              ,  _           );
   def(Bytecodes::_jsr_w               , ubcp|____|____|____, vtos, vtos, jsr_w               ,  _           );
-  def(Bytecodes::_breakpoint          , ubcp|disp|clvm|____, vtos, vtos, _breakpoint         ,  _           );
 
   // wide Java spec bytecodes
   def(Bytecodes::_iload               , ubcp|____|____|iswd, vtos, itos, wide_iload          ,  _           );

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1440,18 +1440,6 @@ class InterfaceVisiterClosure : public StackObj {
   virtual void doit(InstanceKlass* intf, int method_count) = 0;
 };
 
-int count_interface_methods_needing_itable_index(Array<Method*>* methods) {
-  int method_count = 0;
-  if (methods->length() > 0) {
-    for (int i = methods->length(); --i >= 0; ) {
-      if (interface_method_needs_itable_index(methods->at(i))) {
-        method_count++;
-      }
-    }
-  }
-  return method_count;
-}
-
 // Visit all interfaces with at least one itable method
 static void visit_all_interfaces(Array<InstanceKlass*>* transitive_intf, InterfaceVisiterClosure *blk) {
   // Handle array argument

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -471,7 +471,6 @@ class Arguments : AllStatic {
 
   // Set up the underlying pieces of the boot class path
   static void add_patch_mod_prefix(const char *module_name, const char *path);
-  static int finalize_patch_module();
 
   static void set_boot_class_path(const char *value, bool has_jimage) {
     // During start up, set by os::set_boot_path()

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -48,7 +48,6 @@
 #include "memory/iterator.hpp"
 #include "memory/universe.hpp"
 #include "oops/access.inline.hpp"
-#include "oops/inlineKlass.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/oop.inline.hpp"

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -152,7 +152,6 @@ class JavaThread: public Thread {
   // Used to pass back results to the interpreter or generated code running Java code.
   oop           _vm_result_oop;       // oop result is GC-preserved
   Metadata*     _vm_result_metadata;  // non-oop result
-  oop           _return_buffered_value; // buffered value being returned
 
   ObjectMonitor* volatile _current_pending_monitor;     // ObjectMonitor this thread is waiting to lock
   bool           _current_pending_monitor_is_from_java; // locking is from Java code
@@ -836,9 +835,6 @@ public:
 
   void set_vm_result_metadata(Metadata* x)       { _vm_result_metadata = x; }
 
-  oop return_buffered_value() const              { return _return_buffered_value; }
-  void set_return_buffered_value(oop val)        { _return_buffered_value = val; }
-
   // Is thread in scope of an InternalOOMEMark?
   bool is_in_internal_oome_mark() const          { return _is_in_internal_oome_mark; }
   void set_is_in_internal_oome_mark(bool b)      { _is_in_internal_oome_mark = b;    }
@@ -901,7 +897,6 @@ public:
   static ByteSize callee_target_offset()         { return byte_offset_of(JavaThread, _callee_target); }
   static ByteSize vm_result_oop_offset()         { return byte_offset_of(JavaThread, _vm_result_oop); }
   static ByteSize vm_result_metadata_offset()    { return byte_offset_of(JavaThread, _vm_result_metadata); }
-  static ByteSize return_buffered_value_offset() { return byte_offset_of(JavaThread, _return_buffered_value); }
   static ByteSize thread_state_offset()          { return byte_offset_of(JavaThread, _thread_state); }
   static ByteSize saved_exception_pc_offset()    { return byte_offset_of(JavaThread, _saved_exception_pc); }
   static ByteSize osthread_offset()              { return byte_offset_of(JavaThread, _osthread); }

--- a/src/hotspot/share/runtime/stackChunkFrameStream.hpp
+++ b/src/hotspot/share/runtime/stackChunkFrameStream.hpp
@@ -48,7 +48,6 @@ private:
   intptr_t* _unextended_sp; // used only when mixed
   CodeBlob* _cb;
   mutable const ImmutableOopMap* _oopmap;
-  bool _callee_augmented;
 
 #ifndef PRODUCT
   stackChunkOop _chunk;


### PR DESCRIPTION
Hello,

I've been looking through the diff between lworld and mainline and I have noticed several unused pieces of code. Lets get that cleaned up!

Testing:
* Running through Oracle's tier1-3,hs-comp-stress on both linux-x64 and linux-aarch64

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385526](https://bugs.openjdk.org/browse/JDK-8385526): [lworld] Remove unused HotSpot leftovers added in lworld (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2477/head:pull/2477` \
`$ git checkout pull/2477`

Update a local copy of the PR: \
`$ git checkout pull/2477` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2477`

View PR using the GUI difftool: \
`$ git pr show -t 2477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2477.diff">https://git.openjdk.org/valhalla/pull/2477.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2477#issuecomment-4555698092)
</details>
