### PR TITLE
8373598: [lworld] C2 asserts with "excessive live node increase in single iteration of IGVN"

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1732,7 +1732,7 @@ Node *SafePointNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     for (uint i = jvms()->debug_start(); i < jvms()->debug_end(); i++) {
       Node* n = in(i)->uncast();
       if (n->is_InlineType()) {
-        n->as_InlineType()->make_scalar_in_safepoints(phase->is_IterGVN());
+        n->as_InlineType()->make_scalar_in_safepoints(phase->is_IterGVN(), true, this);
       }
     }
   }

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -362,6 +362,7 @@ void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oo
   ResourceMark rm;
   Unique_Node_List safepoints;
   if (safepoint == nullptr) {
+    // Gathering all SafePoint users of `this`...
     Unique_Node_List worklist;
     worklist.push(this);
     while (worklist.size() > 0) {
@@ -376,6 +377,7 @@ void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oo
       }
     }
   } else {
+    // ...or just the provided one if given.
     safepoints.push(safepoint);
   }
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -328,6 +328,10 @@ void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_Li
 }
 
 void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop) {
+  make_scalar_in_safepoints(igvn, allow_oop, nullptr);
+}
+
+void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop, SafePointNode* safepoint) {
   // If the inline type has a constant or loaded oop, use the oop instead of scalarization
   // in the safepoint to avoid keeping field loads live just for the debug info.
   Node* oop = get_oop();
@@ -357,21 +361,25 @@ void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oo
 
   ResourceMark rm;
   Unique_Node_List safepoints;
-  Unique_Node_List vt_worklist;
-  Unique_Node_List worklist;
-  worklist.push(this);
-  while (worklist.size() > 0) {
-    Node* n = worklist.pop();
-    for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
-      Node* use = n->fast_out(i);
-      if (use->is_SafePoint() && !use->is_CallLeaf() && (!use->is_Call() || use->as_Call()->has_debug_use(n))) {
-        safepoints.push(use);
-      } else if (use->is_ConstraintCast()) {
-        worklist.push(use);
+  if (safepoint == nullptr) {
+    Unique_Node_List worklist;
+    worklist.push(this);
+    while (worklist.size() > 0) {
+      Node* n = worklist.pop();
+      for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+        Node* use = n->fast_out(i);
+        if (use->is_SafePoint() && !use->is_CallLeaf() && (!use->is_Call() || use->as_Call()->has_debug_use(n))) {
+          safepoints.push(use);
+        } else if (use->is_ConstraintCast()) {
+          worklist.push(use);
+        }
       }
     }
+  } else {
+    safepoints.push(safepoint);
   }
 
+  Unique_Node_List vt_worklist;
   // Process all safepoint uses and scalarize inline type
   while (safepoints.size() > 0) {
     SafePointNode* sfpt = safepoints.pop()->as_SafePoint();

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -125,6 +125,8 @@ public:
 
   // Replace InlineTypeNodes in debug info at safepoints with SafePointScalarObjectNodes
   void make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop = true);
+  // Variant that allows to limit to a single safepoint. If nullptr is given, all safepoint uses will be considered.
+  void make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop, SafePointNode* safepoint);
 
   // Store the inline type as a flat (headerless) representation
   void store_flat(GraphKit* kit, Node* base, Node* ptr, bool atomic, bool immutable_memory, bool null_free, DecoratorSet decorators);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -156,8 +156,6 @@ import static compiler.lib.ir_framework.IRNode.UNSTABLE_IF_TRAP;
  * @run main compiler.valhalla.inlinetypes.TestLWorld 6
  */
 
-// TODO 8373598 Re-enable
-//@ForceCompileClassInitialize
 public class TestLWorld {
 
     public TestLWorld() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSafepointScalarizationNodeGrowth.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSafepointScalarizationNodeGrowth.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test that safepoint debug-info scalarization does not create too many nodes in a single IGVN iteration.
+ * @bug 8373598
+ * @enablePreview
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysIncrementalInline -XX:-UseFieldFlattening
+ *                   -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestSafepointScalarizationNodeGrowth {
+    static int counter;
+    static RootValue result;
+
+    static value class NestedValue {
+        Integer boxed1;
+        Integer boxed2;
+        Integer boxed3;
+        Integer boxed4;
+        Integer boxed5;
+        Integer boxed6;
+        Integer boxed7;
+
+        NestedValue(int i) {
+            this.boxed1 = i;
+            this.boxed2 = i;
+            this.boxed3 = i;
+            this.boxed4 = i;
+            this.boxed5 = i;
+            this.boxed6 = i;
+            this.boxed7 = i;
+        }
+
+        NestedValue(NestedValue other) {
+            this.boxed1 = ((counter++ & 1) == 0) ? other.boxed1 + counter++ : null;
+            this.boxed2 = ((counter++ & 1) == 0) ? other.boxed2 + counter++ : null;
+            this.boxed3 = ((counter++ & 1) == 0) ? other.boxed3 + counter++ : null;
+            this.boxed4 = ((counter++ & 1) == 0) ? other.boxed4 + counter++ : null;
+            this.boxed5 = ((counter++ & 1) == 0) ? other.boxed5 + counter++ : null;
+            this.boxed6 = ((counter++ & 1) == 0) ? other.boxed6 + counter++ : null;
+            this.boxed7 = ((counter++ & 1) == 0) ? other.boxed7 + counter++ : null;
+        }
+    }
+
+    static value class RootValue {
+        NestedValue nested1;
+        NestedValue nested2;
+        NestedValue nested3;
+        NestedValue nested4;
+        NestedValue nested5;
+
+        RootValue(int i) {
+            this.nested1 = new NestedValue(i);
+            this.nested2 = new NestedValue(i);
+            this.nested3 = new NestedValue(i);
+            this.nested4 = new NestedValue(i);
+            this.nested5 = new NestedValue(i);
+        }
+
+        RootValue(RootValue other) {
+            this.nested1 = ((counter++ & 1) == 0) ? new NestedValue(other.nested1) : null;
+            this.nested2 = ((counter++ & 1) == 0) ? new NestedValue(other.nested2) : null;
+            this.nested3 = ((counter++ & 1) == 0) ? new NestedValue(other.nested3) : null;
+            this.nested4 = ((counter++ & 1) == 0) ? new NestedValue(other.nested4) : null;
+            this.nested5 = ((counter++ & 1) == 0) ? new NestedValue(other.nested5) : null;
+        }
+    }
+
+    static void test(int val) {
+        RootValue defaultValue = new RootValue(val);
+        result = new RootValue(defaultValue);
+        for (int i = 0; i < 20; ++i) {
+            result = new RootValue(defaultValue);
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; ++i) {
+            test(i);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSafepointScalarizationNodeGrowth.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSafepointScalarizationNodeGrowth.java
@@ -28,6 +28,7 @@
  * @enablePreview
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+AlwaysIncrementalInline -XX:-UseFieldFlattening
+ *                   -XX:-AbortVMOnCompilationFailure
  *                   -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::test
  *                   ${test.main.class}
  */


### PR DESCRIPTION
The point is not really to limit the amount of nodes, but rather to limit how fast they come.

As suggested on JBS, I've made `make_scalar_in_safepoints` able to process a single safepoint, and `SafePointNode::Ideal` is just taking care of itself. I have added an overload for compatibility. The name is a bit awkward, especially the plural, since if the new last argument is provided, it doesn't work on multiple safepoints. Yet it does the same, and we can argue it still works on all the safepoints contained in a singleton set. Besides, `make_scalar_in_safepoint` exists, and is a helper of `make_scalar_in_safepoints`, so I'd rather not mess with names too much. Similar semantics get the same name.

Conceptually, it also sounds nicer to me that idealizing a safepoint is not touching all the other cousin safepoints at the same time.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8373598](https://bugs.openjdk.org/browse/JDK-8373598): [lworld] C2 asserts with "excessive live node increase in single iteration of IGVN" (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2480/head:pull/2480` \
`$ git checkout pull/2480`

Update a local copy of the PR: \
`$ git checkout pull/2480` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2480`

View PR using the GUI difftool: \
`$ git pr show -t 2480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2480.diff">https://git.openjdk.org/valhalla/pull/2480.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2480#issuecomment-4563468838)
</details>
