### PR TITLE
8385569: [lworld] Apply JDK-8343767 to Valhalla specific StubRoutines

### DIFF
--- a/src/hotspot/share/runtime/stubDeclarations.hpp
+++ b/src/hotspot/share/runtime/stubDeclarations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -681,6 +681,14 @@
   do_entry(initial, dcbrt, dcbrt, dcbrt)                                \
   do_stub(initial, fmod)                                                \
   do_entry(initial, fmod, fmod, fmod)                                   \
+  do_stub(initial, load_inline_type_fields_in_regs)                     \
+  do_entry(initial, load_inline_type_fields_in_regs,                    \
+                    load_inline_type_fields_in_regs,                    \
+                    load_inline_type_fields_in_regs)                    \
+  do_stub(initial, store_inline_type_fields_to_buf)                     \
+  do_entry(initial, store_inline_type_fields_to_buf,                    \
+                    store_inline_type_fields_to_buf,                    \
+                    store_inline_type_fields_to_buf)                    \
   /* merge in stubs and entries declared in arch header */              \
   STUBGEN_INITIAL_BLOBS_ARCH_DO(do_stub, do_arch_blob,                  \
                                 do_arch_entry, do_arch_entry_init,      \

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -100,10 +100,6 @@ BlobId StubRoutines::stub_to_blob(StubId id) {
 
 #endif // ASSERT
 
-// TODO: update with 8343767
-address StubRoutines::_load_inline_type_fields_in_regs = nullptr;
-address StubRoutines::_store_inline_type_fields_to_buf = nullptr;
-
 // Initialization
 
 extern void StubGenerator_generate(CodeBuffer* code, BlobId blob_id, AOTStubData* stub_data); // only interface to generators

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,9 +228,6 @@ public:
 #define DECLARE_BLOB_INIT_METHOD(blob_name)     \
   static void initialize_ ## blob_name ## _stubs();
 
-  static address _load_inline_type_fields_in_regs;
-  static address _store_inline_type_fields_to_buf;
-
   STUBGEN_BLOBS_DO(DECLARE_BLOB_INIT_METHOD)
 
 #undef DECLARE_BLOB_INIT_METHOD
@@ -372,10 +369,6 @@ public:
   static void arrayof_jlong_copy     (HeapWord* src, HeapWord* dest, size_t count);
   static void arrayof_oop_copy       (HeapWord* src, HeapWord* dest, size_t count);
   static void arrayof_oop_copy_uninit(HeapWord* src, HeapWord* dest, size_t count);
-
-  static address load_inline_type_fields_in_regs() { return _load_inline_type_fields_in_regs; }
-  static address store_inline_type_fields_to_buf() { return _store_inline_type_fields_to_buf; }
-
 };
 
 #endif // SHARE_RUNTIME_STUBROUTINES_HPP


### PR DESCRIPTION
Add two new valhalla stubs to the stub macros in stubDeclarations.hpp.
Tested with runtime/valhalla, compiler/valhalla, and jdk/valhalla tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385569](https://bugs.openjdk.org/browse/JDK-8385569): [lworld] Apply JDK-8343767 to Valhalla specific StubRoutines (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2483/head:pull/2483` \
`$ git checkout pull/2483`

Update a local copy of the PR: \
`$ git checkout pull/2483` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2483`

View PR using the GUI difftool: \
`$ git pr show -t 2483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2483.diff">https://git.openjdk.org/valhalla/pull/2483.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2483#issuecomment-4568500055)
</details>
