### PR TITLE
8385601: [lworld] Update testing documentation for the ValueClassPlugin jtreg option

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -467,9 +467,15 @@ compiled during the test image build. The implementation of the Virtual
 class creates a new virtual thread for executing each test class.</p>
 <h4 id="value_class_plugin">VALUE_CLASS_PLUGIN</h4>
 <p>Enables the <code>ValueClassPlugin</code> javac plugin when compiling
-and running JTReg tests. This mode is intended for testing Valhalla value
-classes (JEP 401) with test sources that can also compile and run as
-regular identity classes.</p>
+and running JTReg tests. This is a <strong>temporary mode</strong>
+intended for use while value classes (JEP 401) are a preview feature.
+The long-term plan is to replace classes annotated with
+<code>@jdk.test.lib.valueclass.AsValueClass</code> with plain
+<code>value class</code> declarations once value classes are
+finalized.</p>
+<p>In the meantime, this mode allows test sources to compile and run as
+either value classes or regular identity classes without source-level
+changes.</p>
 <p>When set to any non-empty value, the following options are appended to
 every JTReg invocation:</p>
 <ul>

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -465,6 +465,38 @@ class, named Virtual, is currently part of the JDK build in the
 <code>test/jtreg_test_thread_factory/</code> directory. This class gets
 compiled during the test image build. The implementation of the Virtual
 class creates a new virtual thread for executing each test class.</p>
+<h4 id="value_class_plugin">VALUE_CLASS_PLUGIN</h4>
+<p>Enables the <code>ValueClassPlugin</code> javac plugin when compiling
+and running JTReg tests. This mode is intended for testing Valhalla value
+classes (JEP 401) with test sources that can also compile and run as
+regular identity classes.</p>
+<p>When set to any non-empty value, the following options are appended to
+every JTReg invocation:</p>
+<ul>
+<li><code>-cpa:&lt;valueClassPlugin.jar&gt;</code> — appends the plugin
+JAR to the compile-time classpath (only when the JAR is present in the
+test image under
+<code>jtreg_value_class_plugin/valueClassPlugin.jar</code>).</li>
+<li><code>-vmoption:--enable-preview</code> — enables JVM preview
+features at runtime.</li>
+<li><code>-javacoption:-XDaccessInternalAPI</code> — grants the compiler
+access to internal APIs required by the plugin.</li>
+<li><code>-javacoption:--source &lt;version&gt; --enable-preview</code>
+— enables preview language features at compile time.</li>
+<li><code>-javacoption:-Xplugin:ValueClassPlugin</code> — activates the
+plugin.</li>
+</ul>
+<p>The plugin scans each compilation unit after parsing and converts any
+class annotated with
+<code>@jdk.test.lib.valueclass.AsValueClass</code> into a value class by
+setting the internal <code>VALUE_CLASS</code> modifier flag and clearing
+the <code>IDENTITY_TYPE</code> flag. This transformation only takes
+effect when <code>--enable-preview</code> is active; without it the
+annotation is a no-op and the class compiles as an ordinary identity
+class, so the same test source can exercise both code paths.</p>
+<p>Example:</p>
+<pre><code>$ make test TEST=jdk_lang JTREG="VALUE_CLASS_PLUGIN=true"
+</code></pre>
 <h4 id="jvmti_stress_agent">JVMTI_STRESS_AGENT</h4>
 <p>Executes JTReg tests with JVM TI stress agent. The stress agent is
 the part of test library and located in

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -403,6 +403,37 @@ the `test/jtreg_test_thread_factory/` directory. This class gets compiled
 during the test image build. The implementation of the Virtual class creates a
 new virtual thread for executing each test class.
 
+#### VALUE_CLASS_PLUGIN
+
+Enables the `ValueClassPlugin` javac plugin when compiling and running JTReg
+tests. This mode is intended for testing Valhalla value classes (JEP 401) with
+test sources that can also compile and run as regular identity classes.
+
+When set to any non-empty value, the following options are appended to every
+JTReg invocation:
+
+* `-cpa:<valueClassPlugin.jar>` — appends the plugin JAR to the compile-time
+  classpath (only when the JAR is present in the test image under
+  `jtreg_value_class_plugin/valueClassPlugin.jar`).
+* `-vmoption:--enable-preview` — enables JVM preview features at runtime.
+* `-javacoption:-XDaccessInternalAPI` — grants the compiler access to internal
+  APIs required by the plugin.
+* `-javacoption:--source <version> --enable-preview` — enables preview language
+  features at compile time.
+* `-javacoption:-Xplugin:ValueClassPlugin` — activates the plugin.
+
+The plugin scans each compilation unit after parsing and converts any class
+annotated with `@jdk.test.lib.valueclass.AsValueClass` into a value class by
+setting the internal `VALUE_CLASS` modifier flag and clearing the
+`IDENTITY_TYPE` flag. This transformation only takes effect when
+`--enable-preview` is active; without it the annotation is a no-op and the
+class compiles as an ordinary identity class, so the same test source can
+exercise both code paths.
+
+Example:
+
+    $ make test TEST=jdk_lang JTREG="VALUE_CLASS_PLUGIN=true" 
+
 #### JVMTI_STRESS_AGENT
 
 Executes JTReg tests with JVM TI stress agent. The stress agent is the part of

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -406,8 +406,13 @@ new virtual thread for executing each test class.
 #### VALUE_CLASS_PLUGIN
 
 Enables the `ValueClassPlugin` javac plugin when compiling and running JTReg
-tests. This mode is intended for testing Valhalla value classes (JEP 401) with
-test sources that can also compile and run as regular identity classes.
+tests. This is a **temporary mode** intended for use while value classes
+(JEP 401) are a preview feature. The long-term plan is to replace classes
+annotated with `@jdk.test.lib.valueclass.AsValueClass` with plain
+`value class` declarations once value classes are finalized.
+
+In the meantime, this mode allows test sources to compile and run as either
+value classes or regular identity classes without source-level changes.
 
 When set to any non-empty value, the following options are appended to every
 JTReg invocation:

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -432,7 +432,7 @@ exercise both code paths.
 
 Example:
 
-    $ make test TEST=jdk_lang JTREG="VALUE_CLASS_PLUGIN=true" 
+    $ make test TEST=jdk_lang JTREG="VALUE_CLASS_PLUGIN=true"
 
 #### JVMTI_STRESS_AGENT
 


### PR DESCRIPTION
Update testing documentation for the ValueClassPlugin jtreg option.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385601](https://bugs.openjdk.org/browse/JDK-8385601): [lworld] Update testing documentation for the ValueClassPlugin jtreg option (**Task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2485/head:pull/2485` \
`$ git checkout pull/2485`

Update a local copy of the PR: \
`$ git checkout pull/2485` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2485`

View PR using the GUI difftool: \
`$ git pr show -t 2485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2485.diff">https://git.openjdk.org/valhalla/pull/2485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2485#issuecomment-4569176725)
</details>
