### PR TITLE
8385469: [lworld] compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test failed with invalid class initialization state for invoke_static

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1243,7 +1243,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
       }
     } else {
       assert(attached_method->has_scalarized_args(), "invalid use of attached method");
-      if (!attached_method->method_holder()->is_inline_klass()) {
+      if (!attached_method->method_holder()->is_inline_klass() || attached_method->is_static()) {
         // Ignore the attached method in this case to not confuse below code
         attached_method = methodHandle(current, nullptr);
       }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueInvokeStaticDuringClinit.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueInvokeStaticDuringClinit.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8385469
+ * @summary Test static call resolution of a value class method with inline arguments while the class is being initialized
+ * @enablePreview
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.TestValueInvokeStaticDuringClinit::test
+ *                   compiler.valhalla.inlinetypes.TestValueInvokeStaticDuringClinit
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestValueInvokeStaticDuringClinit {
+    static value class MyValueClass {
+        int x;
+
+        static {
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+            }
+        }
+
+        MyValueClass(int x) {
+            this.x = x;
+        }
+
+        static void verify(MyValueClass val, int expected) {
+            if (val != null && val.x != expected) {
+                throw new RuntimeException("bad value");
+            }
+        }
+    }
+
+    public static void test() {
+        MyValueClass.verify(null, 0);
+        return;
+    }
+
+    public static void main(String[] args) throws Exception {
+        Thread initThread = Thread.ofPlatform().start(() -> MyValueClass.verify(null, 0));
+
+        Thread.sleep(1000); // wait for initThread to reach MyValueClass.<clinit>
+        test();
+        initThread.join();
+    }
+}


### PR DESCRIPTION
For calls where value type arguments are passed in scalarized form, the c2 compiler adds the `Method*` to the relocation metadata [[1]](https://github.com/openjdk/valhalla/blob/4c23f0ed5d6a89cd1e7ab8550b367bca296a9f30/src/hotspot/share/opto/graphKit.cpp#L2059), so it can later be recovered in `SharedRuntime::resolve_xxx_call_C` as `attached_method` instead of resolving normally through the constant pool (but only if the callee holder is an inline klass [[2]](https://github.com/openjdk/valhalla/blob/4c23f0ed5d6a89cd1e7ab8550b367bca296a9f30/src/hotspot/share/runtime/sharedRuntime.cpp#L1297)).

When resolving static calls, before the thread returns back to Java either the holder class should be already initialized or the thread should be the one currently initializing it. But the `LinkResolver` path we take for the `attached_method` case doesn’t try to initialize the holder klass, i.e. there is an assumption that it’s already initialized. Since c2 doesn’t generate an uncommon trap in the caller if the callee holder class is being initialized, a thread can reach the static resolution case of a method from an inline klass as described above while the class is still being initialized, leading to the reported assert failure.

The attached method is needed when the receiver may be scalarized as no receiver oop might be available to resolve against. Since that doesn’t apply to static calls the proposed fix is to also ignore the attached method in those cases.

I added a reproducer test that crashes with the same assert failure without this fix. Also tested the patch in mach5 tier1-3 and valhalla-comp-stress.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385469](https://bugs.openjdk.org/browse/JDK-8385469): [lworld] compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test failed with invalid class initialization state for invoke_static (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2490/head:pull/2490` \
`$ git checkout pull/2490`

Update a local copy of the PR: \
`$ git checkout pull/2490` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2490`

View PR using the GUI difftool: \
`$ git pr show -t 2490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2490.diff">https://git.openjdk.org/valhalla/pull/2490.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2490#issuecomment-4577852485)
</details>
