### PR TITLE
8385652: [lworld] RedefineClasses should use stack map frame name

### DIFF
--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -3281,7 +3281,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
     u1 frame_type = *stackmap_p;
     stackmap_p++;
 
-   if (frame_type == 246) {  // EARLY_LARVAL
+   if (frame_type == StackMapReader::EARLY_LARVAL) {
      // rewrite_cp_refs in  unset fields and fall through.
      rewrite_cp_refs_in_early_larval_stackmaps(stackmap_p, stackmap_end, calc_number_of_entries, frame_type);
      // The larval frames point to the next frame, so advance to the next frame and fall through.


### PR DESCRIPTION
jvmtiRedefineClasses has imported stackMapTable.hpp to get these names when rewriting stack map frame constant pool entries.  Please review this very trivial change to use the EARLY_LARVAL name.

Tested locally with redefine classes tests and runtime/valhalla tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385652](https://bugs.openjdk.org/browse/JDK-8385652): [lworld] RedefineClasses should use stack map frame name (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2491/head:pull/2491` \
`$ git checkout pull/2491`

Update a local copy of the PR: \
`$ git checkout pull/2491` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2491`

View PR using the GUI difftool: \
`$ git pr show -t 2491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2491.diff">https://git.openjdk.org/valhalla/pull/2491.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2491#issuecomment-4579680095)
</details>
