### PR TITLE
8385674: [lworld] TestNullableInlineTypes.java fails after JDK-8325632

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -2355,7 +2355,8 @@ public class TestNullableInlineTypes {
 
     // Test nested loops
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test81() {
         Object val = null;
         for (int i = 0; i < 10; ++i) {
@@ -2390,7 +2391,8 @@ public class TestNullableInlineTypes {
 
     // Test loops with casts
     @Test
-    @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
+    // TODO 8384979
+    // @IR(failOn = {ALLOC_OF_MYVALUE_KLASS, LOAD_OF_ANY_KLASS, STORE_OF_ANY_KLASS})
     public long test82() {
         Object val = null;
         for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
[JDK-8370769](https://bugs.openjdk.org/browse/JDK-8370769) was pushed at the same time as [JDK-8325632](https://bugs.openjdk.org/browse/JDK-8325632) which re-enabled some testing that should have been excluded by [JDK-8370769](https://bugs.openjdk.org/browse/JDK-8370769). I disabled the IR rules and linked them to the existing tracking bug [JDK-8384979](https://bugs.openjdk.org/browse/JDK-8384979).

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385674](https://bugs.openjdk.org/browse/JDK-8385674): [lworld] TestNullableInlineTypes.java fails after JDK-8325632 (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2493/head:pull/2493` \
`$ git checkout pull/2493`

Update a local copy of the PR: \
`$ git checkout pull/2493` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2493`

View PR using the GUI difftool: \
`$ git pr show -t 2493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2493.diff">https://git.openjdk.org/valhalla/pull/2493.diff</a>

</details>
