### PR TITLE
8385673: [lworld] Redundant StoreStore membar in AArch64 TemplateTable::aaload

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -829,9 +829,6 @@ void TemplateTable::aaload()
     __ b(done);
     __ bind(is_flat_array);
     __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::flat_array_load), r0, r1);
-    // Ensure the stores to copy the inline field contents are visible
-    // before any subsequent store that publishes this reference.
-    __ membar(Assembler::StoreStore);
     __ bind(done);
   } else {
     __ add(r1, r1, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);


### PR DESCRIPTION
Hello,

The StoreStore membar in the AArch64 implementation of TemplateTable::aaload is redundant after [JDK-8378862](https://bugs.openjdk.org/browse/JDK-8378862), which calls `OrderAccess::storestore()` in the VM instead.

I suggest we remove it so we don't have a double storestore-membar for this path. I don't think we need a comment here explaining that the VM handles memory ordering for us. 

Testing:
* Oracle's tier1-4 on linux-aarch64 release/fastdebug.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385673](https://bugs.openjdk.org/browse/JDK-8385673): [lworld] Redundant StoreStore membar in AArch64 TemplateTable::aaload (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer)
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2495/head:pull/2495` \
`$ git checkout pull/2495`

Update a local copy of the PR: \
`$ git checkout pull/2495` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2495`

View PR using the GUI difftool: \
`$ git pr show -t 2495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2495.diff">https://git.openjdk.org/valhalla/pull/2495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2495#issuecomment-4590410938)
</details>
