### PR TITLE
8384871: [lworld] C1's conditional expression elimination does not preserve substitutability at acmp

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -724,7 +724,9 @@ void Canonicalizer::do_If(If* x) {
     return;
   }
 
-  if (lt->is_constant() && rt->is_constant()) {
+  // Simplify further when we have two constants. However, if we have a substitutability check
+  // we must not constant fold as this would loose the substitutability semantics.
+  if (lt->is_constant() && rt->is_constant() && !x->substitutability_check()) {
     if (x->x()->as_Constant() != nullptr) {
       // pattern: If (lc cond rc) => simplify to: Goto
       BlockBegin* sux = x->x()->as_Constant()->compare(x->cond(), x->y(),

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -289,7 +289,8 @@ Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Va
   y = y->subst();
 
   Constant* y_const = y->as_Constant();
-  if (y_const != nullptr) {
+  // We must not optimize a substitutability check to a pointer comparison.
+  if (!substitutability_check && y_const != nullptr) {
     IfOp* x_ifop = x->as_IfOp();
     if (x_ifop != nullptr) {                 // x is an ifop, y is a constant
       Constant* x_tval_const = x_ifop->tval()->subst()->as_Constant();
@@ -310,7 +311,7 @@ Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Va
           if (new_tval == new_fval) {
             return new_tval;
           } else {
-            return new IfOp(x_ifop->x(), x_ifop_cond, x_ifop->y(), new_tval, new_fval, state_before, substitutability_check);
+            return new IfOp(x_ifop->x(), x_ifop_cond, x_ifop->y(), new_tval, new_fval, x_ifop->state_before(), x_ifop->substitutability_check());
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1AcmpCEE.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1AcmpCEE.java
@@ -1,0 +1,90 @@
+
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test that C1's conditional folding preserves acmp substitutability.
+ * @enablePreview
+ * @library /test/lib
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   -XX:CompileCommand=inline,${test.main.class}::helper*
+ *                   ${test.main.class}
+ * @run main/othervm ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.test.lib.Asserts;
+
+public class TestC1AcmpCEE {
+    private static final Integer CONSTANT = Integer.MAX_VALUE;
+    private static final Integer CONSTANT_EQUAL = 2147483647;
+
+    // Prevent javac from constant folding for constant `b`.
+    public static int helper(boolean b) {
+        if (b) {
+            return 42;
+        } else {
+            return 0;
+        }
+    }
+
+    // Test for fix (1)
+    public static int testDirectIntegerConstantCompareEqual() {
+        if (CONSTANT == CONSTANT_EQUAL) {
+            return 42;
+        } else {
+            return 0;
+        }
+    }
+
+    // Test for fix (2)
+    public static int testDirectIntegerConstantCEEEqual() {
+        return (CONSTANT == CONSTANT_EQUAL) ? 42 : 0;
+    }
+
+    // Test for fix (3)
+    public static int testNestedIfOp(Integer left, Integer right) {
+        // After inlining helper(), the code looks like this:
+        //
+        //   b      = IfOp(left == right ? true : false) // substitutability check
+        //   result = IfOp(b == true ? 42 : 0)
+        //
+        // CEE collapses this into one conditional expression. The new IfOp
+        // represents the original acmp and must keep its substitutability state.
+        boolean b = (left == right);
+        return helper(b);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            Asserts.assertEQ(42, testDirectIntegerConstantCompareEqual(), "failed testDirectConstantCompareEqual");
+            Asserts.assertEQ(42, testDirectIntegerConstantCEEEqual(), "failed testDirectIntegerConstantCEEEqual");
+            Asserts.assertEQ(42, testNestedIfOp(Integer.MAX_VALUE, Integer.MAX_VALUE), "failed testNestedIfOp true");
+            Asserts.assertEQ(0,  testNestedIfOp(Integer.MAX_VALUE, Integer.MAX_VALUE + 1), "failed testNestedIfOp false");
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1AcmpCEE.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1AcmpCEE.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -24,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8384871
  * @summary Test that C1's conditional folding preserves acmp substitutability.
  * @enablePreview
  * @library /test/lib
@@ -31,7 +31,7 @@
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
  *                   -XX:CompileCommand=inline,${test.main.class}::helper*
  *                   ${test.main.class}
- * @run main/othervm ${test.main.class}
+ * @run main ${test.main.class}
  */
 
 package compiler.valhalla.inlinetypes;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1AcmpCEE.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1AcmpCEE.java
@@ -51,7 +51,6 @@ public class TestC1AcmpCEE {
         }
     }
 
-    // Test for fix (1)
     public static int testDirectIntegerConstantCompareEqual() {
         if (CONSTANT == CONSTANT_EQUAL) {
             return 42;
@@ -60,12 +59,10 @@ public class TestC1AcmpCEE {
         }
     }
 
-    // Test for fix (2)
     public static int testDirectIntegerConstantCEEEqual() {
         return (CONSTANT == CONSTANT_EQUAL) ? 42 : 0;
     }
 
-    // Test for fix (3)
     public static int testNestedIfOp(Integer left, Integer right) {
         // After inlining helper(), the code looks like this:
         //


### PR DESCRIPTION
C1 has rudimentary conditional expression elimination and graph canonicalization. However, those optimizations on If nodes currently fold substitutability checks to pointer comparisons loosing value object semantics for acmp. This PR fixes this.

Testing:
 - [x] tier1,tier2,tier3,valhalla-comp-stress with `--enable-preview`

A lot of credit for this PR goes to @TobiHartmann who developed the inital fix.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8384871](https://bugs.openjdk.org/browse/JDK-8384871): [lworld] C1's conditional expression elimination does not preserve substitutability at acmp (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Contributors
 * Tobias Hartmann `<thartmann@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2500/head:pull/2500` \
`$ git checkout pull/2500`

Update a local copy of the PR: \
`$ git checkout pull/2500` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2500`

View PR using the GUI difftool: \
`$ git pr show -t 2500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2500.diff">https://git.openjdk.org/valhalla/pull/2500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2500#issuecomment-4600604500)
</details>
