### PR TITLE
8385932: [lworld] Preview compilation of modules ignores existing module class files

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -148,6 +148,7 @@ ifneq ($(MODULE_PREVIEW_SRC_DIRS),)
   # We cannot compile directly into the desired directory because it's the
   # compiler which creates the original '<module>/<classpath>/...' hierarchy.
   PREVIEW_OUTPUTDIR := $(SUPPORT_OUTPUTDIR)/$(PREVIEW_CLASSES_LABEL)
+  PATCH_COMMAND := $(MODULE)=$(call strip, $(COMPILATION_OUTPUTDIR)/$(MODULE))
 
   $(eval $(call SetupJavaCompilation, $(MODULE)-$(PREVIEW_CLASSES_LABEL), \
       SMALL_JAVA := false, \
@@ -166,6 +167,7 @@ ifneq ($(MODULE_PREVIEW_SRC_DIRS),)
           $(JAVAC_FLAGS) \
           --module-source-path $(MODULE_PREVIEW_SOURCEPATH) \
           --module-path $(MODULEPATH) \
+          --patch-module $(PATCH_COMMAND) \
           --system none \
           --enable-preview -source $(JDK_SOURCE_TARGET_VERSION), \
   ))

--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -66,7 +66,6 @@ endif
 MODULESOURCEPATH := $(call GetModuleSrcPath)
 
 # Add imported modules to the modulepath
-# This path usually includes class files without source files
 MODULEPATH := $(call PathList, $(IMPORT_MODULES_CLASSES))
 
 ################################################################################

--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -66,6 +66,7 @@ endif
 MODULESOURCEPATH := $(call GetModuleSrcPath)
 
 # Add imported modules to the modulepath
+# This path usually includes class files without source files
 MODULEPATH := $(call PathList, $(IMPORT_MODULES_CLASSES))
 
 ################################################################################
@@ -139,56 +140,54 @@ PREVIEW_CLASSES_LABEL := preview
 # Module relative path in which preview classes/resources are placed.
 PREVIEW_PATH := META-INF/preview
 
-ifneq ($(COMPILER), bootjdk)
-  MODULE_PREVIEW_SRC_DIRS := $(call FindModulePreviewSrcDirs, $(MODULE))
-  MODULE_PREVIEW_SOURCEPATH := $(call GetModulePreviewSrcPath)
-  ifneq ($(MODULE_PREVIEW_SRC_DIRS),)
-    # Temporarily compile preview classes into a separate directory, and then
-    # copy into the correct output path location.
-    # We cannot compile directly into the desired directory because it's the
-    # compiler which creates the original '<module>/<classpath>/...' hierarchy.
-    TEMP_OUTPUTDIR := $(SUPPORT_OUTPUTDIR)/$(PREVIEW_CLASSES_LABEL)
+MODULE_PREVIEW_SRC_DIRS := $(call FindModulePreviewSrcDirs, $(MODULE))
+MODULE_PREVIEW_SOURCEPATH := $(call GetModulePreviewSrcPath)
+ifneq ($(MODULE_PREVIEW_SRC_DIRS),)
+  # Temporarily compile preview classes into a separate directory, and then
+  # copy into the correct output path location.
+  # We cannot compile directly into the desired directory because it's the
+  # compiler which creates the original '<module>/<classpath>/...' hierarchy.
+  PREVIEW_OUTPUTDIR := $(SUPPORT_OUTPUTDIR)/$(PREVIEW_CLASSES_LABEL)
 
-    $(eval $(call SetupJavaCompilation, $(MODULE)-$(PREVIEW_CLASSES_LABEL), \
-        SMALL_JAVA := false, \
-        MODULE := $(MODULE), \
-        SRC := $(wildcard $(MODULE_PREVIEW_SRC_DIRS)), \
-        INCLUDES := $(JDK_USER_DEFINED_FILTER), \
-        FAIL_NO_SRC := $(FAIL_NO_SRC), \
-        BIN := $(TEMP_OUTPUTDIR)/, \
-        HEADERS := $(SUPPORT_OUTPUTDIR)/headers, \
-        DISABLED_WARNINGS := $(DISABLED_WARNINGS_java) preview, \
-        EXCLUDES := $(EXCLUDES), \
-        EXCLUDE_FILES := $(EXCLUDE_FILES), \
-        KEEP_ALL_TRANSLATIONS := $(KEEP_ALL_TRANSLATIONS), \
-        DEPENDS := $($(MODULE)), \
-        JAVAC_FLAGS := \
-            $(JAVAC_FLAGS) \
-            --module-source-path $(MODULE_PREVIEW_SOURCEPATH) \
-            --module-path $(JDK_OUTPUTDIR)/modules \
-            --system none \
-            --enable-preview -source $(JDK_SOURCE_TARGET_VERSION), \
-    ))
+  $(eval $(call SetupJavaCompilation, $(MODULE)-$(PREVIEW_CLASSES_LABEL), \
+      SMALL_JAVA := false, \
+      MODULE := $(MODULE), \
+      SRC := $(wildcard $(MODULE_PREVIEW_SRC_DIRS)), \
+      INCLUDES := $(JDK_USER_DEFINED_FILTER), \
+      FAIL_NO_SRC := $(FAIL_NO_SRC), \
+      BIN := $(PREVIEW_OUTPUTDIR)/, \
+      HEADERS := $(SUPPORT_OUTPUTDIR)/headers, \
+      DISABLED_WARNINGS := $(DISABLED_WARNINGS_java) preview, \
+      EXCLUDES := $(EXCLUDES), \
+      EXCLUDE_FILES := $(EXCLUDE_FILES), \
+      KEEP_ALL_TRANSLATIONS := $(KEEP_ALL_TRANSLATIONS), \
+      DEPENDS := $($(MODULE)), \
+      JAVAC_FLAGS := \
+          $(JAVAC_FLAGS) \
+          --module-source-path $(MODULE_PREVIEW_SOURCEPATH) \
+          --module-path $(MODULEPATH) \
+          --system none \
+          --enable-preview -source $(JDK_SOURCE_TARGET_VERSION), \
+  ))
 
-    # Don't add '$($(MODULE)-$(PREVIEW_CLASSES_LABEL))' to TARGETS (it's transient).
-    # The 'preview' target below depends on it, and that's the non-transient
-    # result we care about.
+  # Don't add '$($(MODULE)-$(PREVIEW_CLASSES_LABEL))' to TARGETS (it's transient).
+  # The 'preview' target below depends on it, and that's the non-transient
+  # result we care about.
 
-    # Copy compiled output from "$TEMP_OUTPUTDIR/$MODULE/<classpath>/..."
-    # to "$COMPILATION_OUTPUTDIR/$MODULE/$PREVIEW_PATH/<classpath>/...".
-    MOD_SRC := $(TEMP_OUTPUTDIR)/$(MODULE)
-    MOD_DST := $(COMPILATION_OUTPUTDIR)/$(MODULE)
+  # Copy compiled output from "$(PREVIEW_OUTPUTDIR)/$(MODULE)/<classpath>/..."
+  # to "$(COMPILATION_OUTPUTDIR)/$(MODULE)/$(PREVIEW_PATH)/<classpath>/...".
+  MOD_SRC := $(PREVIEW_OUTPUTDIR)/$(MODULE)
+  MOD_DST := $(COMPILATION_OUTPUTDIR)/$(MODULE)
 
-    # NOTE: We cannot use '$(CP) -R $(MOD_SRC)/*/ ...' to select sub-directories (it
-    # does not work on MacOS/BSD). Use 'filter-out' to explicitly exclude marker files.
-    $(MOD_DST)/_the.$(MODULE).preview: $($(MODULE)-$(PREVIEW_CLASSES_LABEL))
+  # NOTE: We cannot use '$(CP) -R $(MOD_SRC)/*/ ...' to select sub-directories (it
+  # does not work on MacOS/BSD). Use 'filter-out' to explicitly exclude marker files.
+  $(MOD_DST)/_the.$(MODULE).preview: $($(MODULE)-$(PREVIEW_CLASSES_LABEL))
 		$(RM) -r $(@D)/$(PREVIEW_PATH)
 		$(MKDIR) -p $(@D)/$(PREVIEW_PATH)
 		$(CP) -R $(filter-out $(MOD_SRC)/_%, $(wildcard $(MOD_SRC)/*)) $(@D)/$(PREVIEW_PATH)
 		$(TOUCH) $@
 
-    TARGETS += $(MOD_DST)/_the.$(MODULE).preview
-  endif
+  TARGETS += $(MOD_DST)/_the.$(MODULE).preview
 endif
 
 # Declare dependencies between java compilations of different modules.

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,7 @@ define Clean-java
 	@$(PRINTF) "Cleaning java %s..." "$(if $1,for $(strip $1) )"
 	@$(ECHO) "" $(LOG_DEBUG)
 	$(RM) -r $(JDK_OUTPUTDIR)/modules/$(strip $1)
+	$(RM) -r $(SUPPORT_OUTPUTDIR)/preview/$(strip $1)
 	$(RM) -r $(SUPPORT_OUTPUTDIR)/special_classes/$(strip $1)
 	$(ECHO) " done"
 	$(PRINTF) "Cleaning headers %s..." "$(if $1,for $(strip $1) )"


### PR DESCRIPTION
The preview compilation of modules ignore class files supplied to module path of normal compilation of modules. This introduces spurious errors when a module has preview files and compiles against external class files at the same time.

Also removed a useless `ifneq ($(COMPILER), bootjdk)` condition, please review the diff without whitespace.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385932](https://bugs.openjdk.org/browse/JDK-8385932): [lworld] Preview compilation of modules ignores existing module class files (**Bug** - P2)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2506/head:pull/2506` \
`$ git checkout pull/2506`

Update a local copy of the PR: \
`$ git checkout pull/2506` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2506`

View PR using the GUI difftool: \
`$ git pr show -t 2506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2506.diff">https://git.openjdk.org/valhalla/pull/2506.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2506#issuecomment-4617162704)
</details>
