### PR TITLE
8375563: [lworld] java/util/Collection/IteratorAtEnd.java fails with IllegalStateException

### DIFF
--- a/test/jdk/java/util/Collection/IteratorAtEnd.java
+++ b/test/jdk/java/util/Collection/IteratorAtEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
+import java.util.stream.IntStream;
 
 @SuppressWarnings("unchecked")
 public class IteratorAtEnd {
@@ -96,10 +97,17 @@ public class IteratorAtEnd {
         } catch (Throwable t) { unexpected(t); }
     }
 
+    // A strong list of reference to map keys to avoid
+    // spurious purges in WeakHashMap
+    private static final List<String> MAP_KEYS = IntStream
+            .range(0, 3 * SIZE)
+            .mapToObj(i -> "BASE-" + i)
+            .toList();
+
     static void testMap(Map m) {
         try {
             for (int i = 0; i < 3*SIZE; i++)
-                m.put("BASE-" + i, i);
+                m.put(MAP_KEYS.get(i), i);
             test(m.values());
             test(m.keySet());
             test(m.entrySet());
@@ -108,6 +116,7 @@ public class IteratorAtEnd {
 
     static void test(Collection c) {
         try {
+            assert !c.isEmpty() : "Calling remove on empty iterator will result in IllegalStateException";
             final Iterator it = c.iterator();
             THROWS(NoSuchElementException.class,
                    () -> { while (true) it.next(); });


### PR DESCRIPTION
IteratorAtEnd spuriously failed for `WeakHashMap`. The underlying cause is that with the migration of keys to `String` produced by concatenation, these strings may be eagerly garbage collected, leaving the `WeakHashMap` and its collection views empty, causing their `Iterator` to throw `IllegalStateException` for a call to `remove()` because it never returned any entry ever.

The original failure could be reliably reproduced by adding a `System.gc()` call right after the Map put for loop. I added an assert to prevent such empty iterator to have a confusing error again, and made the keys strongly referenced in a collection to avoid this immediate issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8375563](https://bugs.openjdk.org/browse/JDK-8375563): [lworld] java/util/Collection/IteratorAtEnd.java fails with IllegalStateException (**Bug** - P2)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2509/head:pull/2509` \
`$ git checkout pull/2509`

Update a local copy of the PR: \
`$ git checkout pull/2509` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2509`

View PR using the GUI difftool: \
`$ git pr show -t 2509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2509.diff">https://git.openjdk.org/valhalla/pull/2509.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2509#issuecomment-4618552866)
</details>
