### PR TITLE
8385966: [lworld] Remove ThreadInVMfromUnknown from get_supers

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2900,6 +2900,7 @@ bool CompiledEntrySignature::check_supers_and_deoptimize(int arg_num) {
 // Iterate over arguments and compute scalarized and non-scalarized signatures
 void CompiledEntrySignature::compute_calling_conventions(bool link_time) {
   assert(JavaThread::current()->thread_state() != _thread_in_native, "must not be in native");
+  assert(link_time || (_method != nullptr && _method->adapter() != nullptr), "invariant");
   bool has_scalarized = false;
   if (_method != nullptr) {
     InstanceKlass* holder = _method->method_holder();
@@ -2921,7 +2922,7 @@ void CompiledEntrySignature::compute_calling_conventions(bool link_time) {
       arg_num++;
     }
     for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
-      BasicType bt = ss.type();
+      const BasicType bt = ss.type();
       if (InlineTypePassFieldsAsArgs && bt == T_OBJECT) {
         InlineKlass* vk = ss.as_inline_klass(holder);
         if (vk != nullptr && vk->can_be_passed_as_fields() && (link_time || _method->is_scalarized_arg(arg_num))) {
@@ -2948,7 +2949,6 @@ void CompiledEntrySignature::compute_calling_conventions(bool link_time) {
           SigEntry::add_entry(_sig_cc, T_OBJECT, ss.as_symbol());
           SigEntry::add_entry(_sig_cc_ro, T_OBJECT, ss.as_symbol());
         }
-        bt = T_OBJECT;
       } else {
         SigEntry::add_entry(_sig_cc, ss.type(), ss.as_symbol());
         SigEntry::add_entry(_sig_cc_ro, ss.type(), ss.as_symbol());

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2816,7 +2816,6 @@ GrowableArray<Method*>* CompiledEntrySignature::get_supers() {
   Symbol* signature = _method->signature();
   const Klass* holder = _method->method_holder()->super();
   Symbol* holder_name = holder->name();
-  ThreadInVMfromUnknown tiv;
   JavaThread* current = JavaThread::current();
   HandleMark hm(current);
   Handle loader(current, _method->method_holder()->class_loader());
@@ -2845,8 +2844,60 @@ GrowableArray<Method*>* CompiledEntrySignature::get_supers() {
   return _supers;
 }
 
+bool CompiledEntrySignature::check_supers_and_deoptimize(int arg_num) {
+  bool scalar_super = false;
+  bool non_scalar_super = false;
+
+  GrowableArray<Method*>* supers = get_supers();
+  for (int i = 0; i < supers->length(); ++i) {
+    Method* super_method = supers->at(i);
+    if (super_method->is_scalarized_arg(arg_num)) {
+      scalar_super = true;
+    } else {
+      non_scalar_super = true;
+    }
+  }
+#ifdef ASSERT
+  // Randomly enable below code paths for stress testing
+  bool stress = StressCallingConvention;
+  if (stress && (os::random() & 1) == 1) {
+    non_scalar_super = true;
+    if ((os::random() & 1) == 1) {
+      scalar_super = true;
+    }
+  }
+#endif
+  if (non_scalar_super) {
+    // Found a super method with a non-scalarized argument. Fall back to the non-scalarized calling convention.
+    if (scalar_super) {
+      // Found non-scalar *and* scalar super methods. We can't handle both.
+      // Mark the scalar method as mismatch and re-compile call sites to use non-scalarized calling convention.
+      for (int i = 0; i < supers->length(); ++i) {
+        Method* super_method = supers->at(i);
+        if (super_method->is_scalarized_arg(arg_num) DEBUG_ONLY(|| (stress && (os::random() & 1) == 1))) {
+          JavaThread* thread = JavaThread::current();
+          HandleMark hm(thread);
+          methodHandle mh(thread, super_method);
+          DeoptimizationScope deopt_scope;
+          {
+            // Keep the lock scope minimal. Prevent interference with other
+            // dependency checks by setting mismatch and marking within the lock.
+            MutexLocker ml(Compile_lock, Mutex::_safepoint_check_flag);
+            super_method->set_mismatch();
+            CodeCache::mark_for_deoptimization(&deopt_scope, mh());
+          }
+          deopt_scope.deoptimize_marked();
+        }
+      }
+    }
+  }
+
+  return non_scalar_super;
+}
+
 // Iterate over arguments and compute scalarized and non-scalarized signatures
-void CompiledEntrySignature::compute_calling_conventions(bool init) {
+void CompiledEntrySignature::compute_calling_conventions(bool link_time) {
+  assert(!link_time || JavaThread::current()->thread_state() == _thread_in_vm, "must be in vm state");
   bool has_scalarized = false;
   if (_method != nullptr) {
     InstanceKlass* holder = _method->method_holder();
@@ -2854,7 +2905,7 @@ void CompiledEntrySignature::compute_calling_conventions(bool init) {
     if (!_method->is_static()) {
       // We shouldn't scalarize 'this' in a value class constructor
       if (holder->is_inline_klass() && InlineKlass::cast(holder)->can_be_passed_as_fields() &&
-          !_method->is_object_constructor() && (init || _method->is_scalarized_arg(arg_num))) {
+          !_method->is_object_constructor() && (link_time || _method->is_scalarized_arg(arg_num))) {
         _sig_cc->appendAll(InlineKlass::cast(holder)->extended_sig());
         _sig_cc->insert_before(1, SigEntry(T_OBJECT, 0, nullptr, false, true)); // buffer argument
         has_scalarized = true;
@@ -2871,55 +2922,12 @@ void CompiledEntrySignature::compute_calling_conventions(bool init) {
       BasicType bt = ss.type();
       if (InlineTypePassFieldsAsArgs && bt == T_OBJECT) {
         InlineKlass* vk = ss.as_inline_klass(holder);
-        if (vk != nullptr && vk->can_be_passed_as_fields() && (init || _method->is_scalarized_arg(arg_num))) {
+        if (vk != nullptr && vk->can_be_passed_as_fields() && (link_time || _method->is_scalarized_arg(arg_num))) {
           // Check for a calling convention mismatch with super method(s)
-          bool scalar_super = false;
-          bool non_scalar_super = false;
-          GrowableArray<Method*>* supers = get_supers();
-          for (int i = 0; i < supers->length(); ++i) {
-            Method* super_method = supers->at(i);
-            if (super_method->is_scalarized_arg(arg_num)) {
-              scalar_super = true;
-            } else {
-              non_scalar_super = true;
-            }
-          }
-#ifdef ASSERT
-          // Randomly enable below code paths for stress testing
-          bool stress = init && StressCallingConvention;
-          if (stress && (os::random() & 1) == 1) {
-            non_scalar_super = true;
-            if ((os::random() & 1) == 1) {
-              scalar_super = true;
-            }
-          }
-#endif
-          if (non_scalar_super) {
-            // Found a super method with a non-scalarized argument. Fall back to the non-scalarized calling convention.
-            if (scalar_super) {
-              // Found non-scalar *and* scalar super methods. We can't handle both.
-              // Mark the scalar method as mismatch and re-compile call sites to use non-scalarized calling convention.
-              for (int i = 0; i < supers->length(); ++i) {
-                Method* super_method = supers->at(i);
-                if (super_method->is_scalarized_arg(arg_num) DEBUG_ONLY(|| (stress && (os::random() & 1) == 1))) {
-                  JavaThread* thread = JavaThread::current();
-                  HandleMark hm(thread);
-                  methodHandle mh(thread, super_method);
-                  DeoptimizationScope deopt_scope;
-                  {
-                    // Keep the lock scope minimal. Prevent interference with other
-                    // dependency checks by setting mismatch and marking within the lock.
-                    MutexLocker ml(Compile_lock, Mutex::_safepoint_check_flag);
-                    super_method->set_mismatch();
-                    CodeCache::mark_for_deoptimization(&deopt_scope, mh());
-                  }
-                  deopt_scope.deoptimize_marked();
-                }
-              }
-            }
-            // Fall back to non-scalarized calling convention
-            SigEntry::add_entry(_sig_cc, T_OBJECT, ss.as_symbol());
-            SigEntry::add_entry(_sig_cc_ro, T_OBJECT, ss.as_symbol());
+          if (link_time && check_supers_and_deoptimize(arg_num)) {
+             // Fall back to non-scalarized calling convention
+             SigEntry::add_entry(_sig_cc, T_OBJECT, ss.as_symbol());
+             SigEntry::add_entry(_sig_cc_ro, T_OBJECT, ss.as_symbol());
           } else {
             _num_inline_args++;
             has_scalarized = true;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2845,6 +2845,8 @@ GrowableArray<Method*>* CompiledEntrySignature::get_supers() {
 }
 
 bool CompiledEntrySignature::check_supers_and_deoptimize(int arg_num) {
+  assert(JavaThread::current()->thread_state() == _thread_in_vm, "must be in vm state");
+
   bool scalar_super = false;
   bool non_scalar_super = false;
 
@@ -2897,7 +2899,7 @@ bool CompiledEntrySignature::check_supers_and_deoptimize(int arg_num) {
 
 // Iterate over arguments and compute scalarized and non-scalarized signatures
 void CompiledEntrySignature::compute_calling_conventions(bool link_time) {
-  assert(!link_time || JavaThread::current()->thread_state() == _thread_in_vm, "must be in vm state");
+  assert(JavaThread::current()->thread_state() != _thread_in_native, "must not be in native");
   bool has_scalarized = false;
   if (_method != nullptr) {
     InstanceKlass* holder = _method->method_holder();

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -968,6 +968,7 @@ private:
 
   GrowableArray<Method*>* _supers;
   GrowableArray<Method*>* get_supers();
+  bool check_supers_and_deoptimize(int arg_num);
 
 public:
   Method* method()                     const { return _method; }
@@ -998,7 +999,7 @@ public:
   CodeOffsets::Entries c1_inline_ro_entry_type() const;
 
   CompiledEntrySignature(Method* method = nullptr);
-  void compute_calling_conventions(bool init = true);
+  void compute_calling_conventions(bool link_time = true);
   void initialize_from_fingerprint(AdapterFingerPrint* fingerprint);
 };
 


### PR DESCRIPTION
This change refactors the super class scalar argument checking code and deoptimization so that it is only called at link time and not for frame::describe() and other places that are only retrieving the calling convention.  The only time that we detect a mismatch is during class linking, before the overriding subclass method can run.

This avoids running vm code while thread_in_Java, which is unsafe, and removes the ThreadInVMfromUnknown, which was even more unsafe.

Tested with tier1-4.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385966](https://bugs.openjdk.org/browse/JDK-8385966): [lworld] Remove ThreadInVMfromUnknown from get_supers (**Enhancement** - P4)


### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role) ⚠️ Review applies to [df36a6c9](https://git.openjdk.org/valhalla/pull/2517/files/df36a6c9843106fc7b7a2a2503de96df23f897b0)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - no project role) ⚠️ Review applies to [959ca7d0](https://git.openjdk.org/valhalla/pull/2517/files/959ca7d03353ecfb5702e0a158b1aec03fc4e3f4)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2517/head:pull/2517` \
`$ git checkout pull/2517`

Update a local copy of the PR: \
`$ git checkout pull/2517` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2517`

View PR using the GUI difftool: \
`$ git pr show -t 2517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2517.diff">https://git.openjdk.org/valhalla/pull/2517.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2517#issuecomment-4632938101)
</details>
