### PR TITLE
8386083: [lworld] Cleanup extra ';' in serviceability/tmtools/jstack/WaitNotifyThreadTest.java

### DIFF
--- a/test/hotspot/jtreg/serviceability/tmtools/jstack/WaitNotifyThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstack/WaitNotifyThreadTest.java
@@ -38,7 +38,7 @@ import utils.*;
 
 public class WaitNotifyThreadTest {
 
-    private Object monitor = new Object();;
+    private Object monitor = new Object();
     private final String OBJECT = "a java.lang.Object";
     private final String OBJECT_WAIT = "java.lang.Object.wait0";
     private final String RUN_METHOD = "WaitNotifyThreadTest$WaitThread.run";


### PR DESCRIPTION
[JDK-8286807](https://bugs.openjdk.org/browse/JDK-8286807) undid the valhalla changes that were previously made to this file, but in doing so introduced an extra ';':

    private Object monitor = new Object();;

This is currently the only diff between mainline and valhalla for this file, so it would be good to clean it up so this file no longer shows up in the valhalla PR.

I am not updating the copyright with this PR as that would result in the copyright change being the only diff between valhalla and mainline.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386083](https://bugs.openjdk.org/browse/JDK-8386083): [lworld] Cleanup extra ';' in serviceability/tmtools/jstack/WaitNotifyThreadTest.java (**Bug** - P5)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2518/head:pull/2518` \
`$ git checkout pull/2518`

Update a local copy of the PR: \
`$ git checkout pull/2518` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2518`

View PR using the GUI difftool: \
`$ git pr show -t 2518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2518.diff">https://git.openjdk.org/valhalla/pull/2518.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2518#issuecomment-4634008999)
</details>
