### PR TITLE
8386086: [lworld] sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java should be removed from problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -718,9 +718,5 @@ tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java 83
 
 java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java 8375778 macosx-aarch64
 
-# The following test failures DID NOT reproduce during Tier[1-8] testing
-# done for 8377828. Further analysis is being done with 8376235:
-sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java 8378881 windows-x64
-
 sun/tools/jhsdb/JStackStressTest.java 8247940 macosx-aarch64
 


### PR DESCRIPTION
[JDK-8378881](https://bugs.openjdk.org/browse/JDK-8378881) no longer reproduces. It has been closed as a dup of [JDK-8367748](https://bugs.openjdk.org/browse/JDK-8367748), which is still open, but should be closed as a dup of [JDK-8380896](https://bugs.openjdk.org/browse/JDK-8380896), which is fixed and seems to have addressed this issue.

Cleaning this up now in valhalla will prevent jcheck problem list complaints when integrated into mainline.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386086](https://bugs.openjdk.org/browse/JDK-8386086): [lworld] sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java should be removed from problem list (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2519/head:pull/2519` \
`$ git checkout pull/2519`

Update a local copy of the PR: \
`$ git checkout pull/2519` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2519`

View PR using the GUI difftool: \
`$ git pr show -t 2519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2519.diff">https://git.openjdk.org/valhalla/pull/2519.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2519#issuecomment-4634767060)
</details>
