### PR TITLE
8386087: [lworld] Valhalla changes to serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp should be undone

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
@@ -29,7 +29,6 @@ extern "C" {
 
 static const char* EXP_INTERF_SIG = "LP/Q/HCInterf;";
 static const char* SIG_START      = "LP/Q/HiddenClassSig";
-static const char* IDENTITYOBJECT_IF = "Ljava/lang/IdentityObject;";
 static const size_t SIG_START_LEN = strlen(SIG_START);
 static const int    ACC_INTERFACE = 0x0200; // Interface class modifiers bit
 
@@ -197,26 +196,20 @@ check_hidden_class_impl_interf(jvmtiEnv* jvmti, JNIEnv* jni, jclass klass) {
   jclass* interfaces = nullptr;
   jvmtiError err;
 
-  // check that hidden class implements just one interface (or two if IdentityObject has been injected)
+  // check that hidden class implements just one interface
   err = jvmti->GetImplementedInterfaces(klass, &count, &interfaces);
   CHECK_JVMTI_ERROR(jni, err, "check_hidden_class_impl_interf: Error in JVMTI GetImplementedInterfaces");
-  if (count != 1 && count != 2) {
-    LOG1("check_hidden_class_impl_interf: FAIL: implemented interfaces count: %d, expected to be in [1-2] range\n", count);
+  if (count != 1) {
+    LOG1("check_hidden_class_impl_interf: FAIL: implemented interfaces count: %d, expected to be 1\n", count);
     failed = true;
     return;
   }
-  bool found = false;
-  for (int i = 0; i < count; i++) {
-    // get interface signature
-    err = jvmti->GetClassSignature(interfaces[i], &sig, nullptr);
-    CHECK_JVMTI_ERROR(jni, err, "check_hidden_class_impl_interf: Error in JVMTI GetClassSignature for implemented interface");
-    // check the interface signature is matching the expected
-    if (strcmp(sig, EXP_INTERF_SIG) == 0) {
-      found = true;
-    }
-  }
+  // get interface signature
+  err = jvmti->GetClassSignature(interfaces[0], &sig, nullptr);
+  CHECK_JVMTI_ERROR(jni, err, "check_hidden_class_impl_interf: Error in JVMTI GetClassSignature for implemented interface");
 
-  if (!found) {
+  // check the interface signature is matching the expected
+  if (strcmp(sig, EXP_INTERF_SIG) != 0) {
     LOG2("check_hidden_class_impl_interf: FAIL: implemented interface signature: %s, expected to be: %s\n",
            sig, EXP_INTERF_SIG);
     failed = true;


### PR DESCRIPTION
[JDK-8253744](https://bugs.openjdk.org/browse/JDK-8253744) modified this test to deal with the injected java.lang.IndentityObject class. That is no longer done and was rolled back, but changes in this file were missed. Thus this test now has extra logic to deal with two possible interfaces being returned when it is not necessary.

After this change this file is now identical to mainline.

Tested by running test a few times on all supported platforms.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386087](https://bugs.openjdk.org/browse/JDK-8386087): [lworld] Valhalla changes to serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp should be undone (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2520/head:pull/2520` \
`$ git checkout pull/2520`

Update a local copy of the PR: \
`$ git checkout pull/2520` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2520`

View PR using the GUI difftool: \
`$ git pr show -t 2520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2520.diff">https://git.openjdk.org/valhalla/pull/2520.diff</a>

</details>
