### PR TITLE
8385170: [lworld] Serialization spec needs to allow abstract value classes like Number

### DIFF
--- a/src/java.base/share/classes/java/io/Externalizable.java
+++ b/src/java.base/share/classes/java/io/Externalizable.java
@@ -29,31 +29,54 @@ import java.io.ObjectOutput;
 import java.io.ObjectInput;
 
 /**
- * Only the identity of the class of an Externalizable instance is
+ * A {@code Serializable} class that fully implements its own protocol
+ * for reading and writing to a serialization stream.
+ * <p>
+ * Only the identity of the class of an {@code Externalizable} instance is
  * written in the serialization stream and it is the responsibility
  * of the class to save and restore the contents of its instances.
- *
- * The writeExternal and readExternal methods of the Externalizable
- * interface are implemented by a class to give the class complete
- * control over the format and contents of the stream for an object
- * and its supertypes. These methods must explicitly
+ * The {@code writeExternal} and {@code readExternal} methods give the
+ * class complete control over the format and contents of the stream
+ * for an object and its supertypes. These methods must explicitly
  * coordinate with the supertype to save its state. These methods supersede
- * customized implementations of writeObject and readObject methods.<br>
- *
- * Object Serialization uses the Serializable and Externalizable
+ * customized implementations of {@code writeObject} and {@code readObject}
+ * methods.
+ * <p>
+ * Object Serialization uses the {@code Serializable} and {@code Externalizable}
  * interfaces.  Object persistence mechanisms can use them as well.  Each
- * object to be stored is tested for the Externalizable interface. If
- * the object supports Externalizable, the writeExternal method is called. If the
- * object does not support Externalizable and does implement
- * Serializable, the object is saved using
- * ObjectOutputStream. <br> When an Externalizable object is
- * reconstructed, an instance is created using the public no-arg
- * constructor, then the readExternal method called.  Serializable
- * objects are restored by reading them from an ObjectInputStream.<br>
+ * object to be stored is tested for the {@code Externalizable} interface. If
+ * the object supports {@code Externalizable}, the {@code writeExternal} method
+ * is called. If the object does not support {@code Externalizable} and does
+ * implement {@code Serializable}, the object is saved using
+ * {@code ObjectOutputStream}.
+ * <p>
+ * When an {@code Externalizable} object is reconstructed, an instance is
+ * created using the public no-arg constructor, then the
+ * {@code readExternal} method called.
+* <p>
+ * An {@code Externalizable} instance can designate a substitution object via
+ * the {@code writeReplace} and {@code readResolve} methods documented in the
+ * {@link Serializable} interface.
+ * <p>
+ * Record classes can implement {@code Externalizable}, but it is ignored:
+ * instances will receive the same treatment as other {@code Serializable}
+ * instances, as defined by the
+ * <a href="{@docRoot}/../specs/serialization/serial-arch.html#serialization-of-records">
+ * <cite>Java Object Serialization Specification,</cite> Section 1.13,
+ * "Serialization of Records"</a>.
  *
- * An Externalizable instance can designate a substitution object via
- * the writeReplace and readResolve methods documented in the Serializable
- * interface.<br>
+ * <div class="preview-block">
+ *      <div class="preview-comment">
+ *          <p>{@linkplain Class#isValue Value classes} that are not records are
+ *          permitted to implement {@code Externalizable}, but the class has no
+ *          mutable fields, and so is unlikely to be able to properly implement
+ *          the {@code readExternal} method. Instead, the {@code writeReplace}
+ *          method should be used to designate an alternative object for
+ *          serialization. At deserialization time, the alternative object can
+ *          implement {@code readResolve} to construct the expected value class
+ *          instance.
+ *      </div>
+ * </div>
  *
  * @see java.io.ObjectOutputStream
  * @see java.io.ObjectInputStream

--- a/src/java.base/share/classes/java/io/Externalizable.java
+++ b/src/java.base/share/classes/java/io/Externalizable.java
@@ -53,7 +53,7 @@ import java.io.ObjectInput;
  * When an {@code Externalizable} object is reconstructed, an instance is
  * created using the public no-arg constructor, then the
  * {@code readExternal} method called.
-* <p>
+ * <p>
  * An {@code Externalizable} instance can designate a substitution object via
  * the {@code writeReplace} and {@code readResolve} methods documented in the
  * {@link Serializable} interface.

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -443,10 +443,12 @@ public class ObjectInputStream
      *
      * <div class="preview-block">
      *      <div class="preview-comment">
-     *          <p>An object in the stream that instantiates or extends a Serializable
-     *          {@linkplain Class#isValue value class} can only be deserialized if
-     *          it is a record or a boxed primitive value.  Otherwise,
-     *          {@code readObject} throws an {@code InvalidClassException}.
+     *          <p>An object in the stream that instantiates a concrete
+     *          {@linkplain Class#isValue value class}, or that extends a
+     *          Serializable abstract value class that declares instance fields,
+     *          can only be deserialized if it is a record or a boxed primitive
+     *          value. Otherwise, {@code readObject} throws an
+     *          {@code InvalidClassException}.
      *      </div>
      * </div>
      *

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -328,7 +328,7 @@ public class ObjectOutputStream
      *          {@linkplain Class#isValue value class}, or that extends a
      *          Serializable abstract value class that declares instance fields,
      *          can only be serialized if it is a record, or it implements
-     *          {@code writeReplace}, or it is a boxed primitive value. 
+     *          {@code writeReplace}, or it is a boxed primitive value.
      *          Otherwise, {@code writeObject} throws an
      *          {@code InvalidClassException}.
      *      </div>

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -324,10 +324,12 @@ public class ObjectOutputStream
      *
      * <div class="preview-block">
      *      <div class="preview-comment">
-     *          <p>An object that instantiates or extends a Serializable
-     *          {@linkplain Class#isValue value class} can only be serialized if
-     *          it is a record, or it implements {@code writeReplace}, or it is
-     *          a boxed primitive value. Otherwise, {@code writeObject} throws an
+     *          <p>An object that instantiates a concrete
+     *          {@linkplain Class#isValue value class}, or that extends a
+     *          Serializable abstract value class that declares instance fields,
+     *          can only be serialized if it is a record, or it implements
+     *          {@code writeReplace}, or it is a boxed primitive value. 
+     *          Otherwise, {@code writeObject} throws an
      *          {@code InvalidClassException}.
      *      </div>
      * </div>


### PR DESCRIPTION
Serialization javadoc updates to address handling of abstract value classes, and to clean up spec for Externalizable.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385170](https://bugs.openjdk.org/browse/JDK-8385170): [lworld] Serialization spec needs to allow abstract value classes like Number (**Bug** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer) ⚠️ Review applies to [65544fd6](https://git.openjdk.org/valhalla/pull/2522/files/65544fd609b6b3b5e2883d851949784e531a5e06)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2522/head:pull/2522` \
`$ git checkout pull/2522`

Update a local copy of the PR: \
`$ git checkout pull/2522` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2522`

View PR using the GUI difftool: \
`$ git pr show -t 2522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2522.diff">https://git.openjdk.org/valhalla/pull/2522.diff</a>

</details>
