### PR TITLE
8386097: [lworld] javac does not need to handle MigratedValueClass

### DIFF
--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -326,10 +326,6 @@ public class CreateSymbols {
             "Ljdk/internal/ValueBased;";
     private static final String VALUE_BASED_ANNOTATION_INTERNAL =
             "Ljdk/internal/ValueBased+Annotation;";
-    private static final String MIGRATED_VALUE_CLASS_ANNOTATION =
-            "Ljdk/internal/MigratedValueClass;";
-    private static final String MIGRATED_VALUE_CLASS_ANNOTATION_INTERNAL =
-            "Ljdk/internal/MigratedValueClass+Annotation;";
     private static final String REQUIRES_IDENTITY_ANNOTATION =
             "Ljdk/internal/RequiresIdentity;";
     private static final String REQUIRES_IDENTITY_ANNOTATION_INTERNAL =
@@ -340,7 +336,6 @@ public class CreateSymbols {
                     PREVIEW_FEATURE_ANNOTATION_OLD,
                     PREVIEW_FEATURE_ANNOTATION_NEW,
                     VALUE_BASED_ANNOTATION,
-                    MIGRATED_VALUE_CLASS_ANNOTATION,
                     RESTRICTED_ANNOTATION,
                     REQUIRES_IDENTITY_ANNOTATION));
 
@@ -1060,12 +1055,6 @@ public class CreateSymbols {
             //the non-public ValueBased annotation will not be available in ct.sym,
             //replace with purely synthetic javac-internal annotation:
             annotationType = VALUE_BASED_ANNOTATION_INTERNAL;
-        }
-
-        if (MIGRATED_VALUE_CLASS_ANNOTATION.equals(annotationType)) {
-            //the non-public MigratedValueClass annotation will not be available in ct.sym,
-            //replace with purely synthetic javac-internal annotation:
-            annotationType = MIGRATED_VALUE_CLASS_ANNOTATION_INTERNAL;
         }
 
         if (REQUIRES_IDENTITY_ANNOTATION.equals(annotationType)) {

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -78,6 +78,7 @@ MICROBENCHMARK_MANIFEST := Build: $(FULL_VERSION)\n\
 # requires the use of -processor option during benchmark compilation.
 
 # Build microbenchmark suite for the current JDK
+# Need to patch java.base to include preview classes not found in interim javac
 $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
     SMALL_JAVA := false, \
@@ -103,6 +104,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/sun.security.util.math=ALL-UNNAMED \
         --add-exports java.base/sun.security.util.math.intpoly=ALL-UNNAMED \
         --enable-preview \
+        --patch-module java.base=$(SUPPORT_OUTPUTDIR)/preview/java.base \
         -XDsuppressNotes \
         -processor org.openjdk.jmh.generators.BenchmarkProcessor \
         -s $(MICROBENCHMARK_GENSRC), \

--- a/src/java.base/share/classes/jdk/internal/MigratedValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/MigratedValueClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,16 +31,12 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.TYPE;
 
 /**
- * Indicates the API declaration in question is associated with a migrated value class.
+ * Indicates the annotated class would become a value class when preview
+ * features are enabled.
  *
- * Note this internal annotation is handled specially by the javac compiler.
- * To work properly with {@code --release older-release}, it requires special
- * handling in {@code make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java}
- * and {@code src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java}.
- *
- * @since 23
+ * @since Valhalla
  */
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 @Target(value={TYPE})
 public @interface MigratedValueClass {
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -427,12 +427,6 @@ public class Flags {
     public static final long VALUE_BASED = 1L<<53;
 
     /**
-     * Flag to indicate the given ClassSymbol is a value based.
-     */
-    @Use({FlagTarget.CLASS})
-    public static final long MIGRATED_VALUE_CLASS = 1L<<57; //ClassSymbols only
-
-    /**
      * Flag to indicate the given symbol has a @Deprecated annotation.
      */
     @Use({FlagTarget.CLASS, FlagTarget.METHOD, FlagTarget.MODULE, FlagTarget.PACKAGE, FlagTarget.TYPE_VAR, FlagTarget.VARIABLE})

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -245,8 +245,6 @@ public class Symtab {
     // valhalla
     public final Type valueBasedType;
     public final Type valueBasedInternalType;
-    public final Type migratedValueClassType;
-    public final Type migratedValueClassInternalType;
     /** The symbol representing the finalize method on Object */
     public final MethodSymbol objectFinalize;
     public final Type numberType;
@@ -630,8 +628,6 @@ public class Symtab {
         constantBootstrapsType = enterClass("java.lang.invoke.ConstantBootstraps");
         valueBasedType = enterClass("jdk.internal.ValueBased");
         valueBasedInternalType = enterSyntheticAnnotation("jdk.internal.ValueBased+Annotation");
-        migratedValueClassType = enterClass("jdk.internal.MigratedValueClass");
-        migratedValueClassInternalType = enterSyntheticAnnotation("jdk.internal.MigratedValueClass+Annotation");
         requiresIdentityType = enterClass("jdk.internal.RequiresIdentity");
         requiresIdentityInternalType = enterSyntheticAnnotation(names.requiresIdentityInternal);
         classDescType = enterClass("java.lang.constant.ClassDesc");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -378,12 +378,6 @@ public class Annotate {
             }
 
             if (!c.type.isErroneous()
-                    && toAnnotate.kind == TYP
-                    && types.isSameType(c.type, syms.migratedValueClassType)) {
-                toAnnotate.flags_field |= Flags.MIGRATED_VALUE_CLASS;
-            }
-
-            if (!c.type.isErroneous()
                     && types.isSameType(c.type, syms.restrictedType)) {
                 toAnnotate.flags_field |= Flags.RESTRICTED;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2555,7 +2555,7 @@ public class Check {
 
         Type identitySuper = null;
         Type superType = types.supertype(c);
-        if (superType.isIdentityClass() && (superType.tsym.flags() & MIGRATED_VALUE_CLASS) == 0)
+        if (superType.isIdentityClass())
             identitySuper = superType;
         if (c.isValueClass() && identitySuper != null && identitySuper.tsym != syms.objectType.tsym) { // Object is special
             log.error(pos, Errors.ValueTypeHasIdentitySuperType(c, identitySuper));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1553,9 +1553,6 @@ public class ClassReader {
             } else if (proxy.type.tsym.flatName() == syms.valueBasedInternalType.tsym.flatName()) {
                 Assert.check(sym.kind == TYP);
                 sym.flags_field |= VALUE_BASED;
-            } else if (proxy.type.tsym.flatName() == syms.migratedValueClassInternalType.tsym.flatName()) {
-                Assert.check(sym.kind == TYP);
-                sym.flags_field |= MIGRATED_VALUE_CLASS;
             } else if (proxy.type.tsym.flatName() == syms.restrictedInternalType.tsym.flatName()) {
                 Assert.check(sym.kind == MTH);
                 sym.flags_field |= RESTRICTED;
@@ -1575,8 +1572,6 @@ public class ClassReader {
                     setFlagIfAttributeTrue(proxy, sym, names.reflective, PREVIEW_REFLECTIVE);
                 } else if (proxy.type.tsym == syms.valueBasedType.tsym && sym.kind == TYP) {
                     sym.flags_field |= VALUE_BASED;
-                } else if (proxy.type.tsym == syms.migratedValueClassType.tsym && sym.kind == TYP) {
-                    sym.flags_field |= MIGRATED_VALUE_CLASS;
                 } else if (proxy.type.tsym == syms.restrictedType.tsym) {
                     Assert.check(sym.kind == MTH);
                     sym.flags_field |= RESTRICTED;
@@ -3351,7 +3346,7 @@ public class ClassReader {
             flags &= ~ACC_MODULE;
             flags |= MODULE;
         }
-        if (((flags & ACC_IDENTITY) != 0 && !isMigratedValueClass(flags))
+        if (((flags & ACC_IDENTITY) != 0)
                 || (majorVersion <= Version.MAX().major && minorVersion != PREVIEW_MINOR_VERSION && (flags & INTERFACE) == 0)) {
             flags |= IDENTITY_TYPE;
         } else if (needsValueFlag(c, flags)) {
@@ -3365,16 +3360,11 @@ public class ClassReader {
     private boolean needsValueFlag(Symbol c, long flags) {
         boolean previewClassFile = minorVersion == ClassFile.PREVIEW_MINOR_VERSION;
         if (allowValueClasses) {
-            if (previewClassFile && majorVersion >= Version.MAX().major && (flags & INTERFACE) == 0 ||
-                    majorVersion >= Version.MAX().major && isMigratedValueClass(flags)) {
+            if (previewClassFile && majorVersion >= Version.MAX().major && (flags & INTERFACE) == 0) {
                 return true;
             }
         }
         return false;
-    }
-
-    private boolean isMigratedValueClass(long flags) {
-        return allowValueClasses && ((flags & MIGRATED_VALUE_CLASS) != 0);
     }
 
     /**

--- a/test/jdk/java/io/Serializable/valueObjects/SerializedObjectCombo.java
+++ b/test/jdk/java/io/Serializable/valueObjects/SerializedObjectCombo.java
@@ -114,11 +114,9 @@ public final class SerializedObjectCombo extends ComboInstance<SerializedObjectC
             import java.io.*;
             import java.util.*;
             import jdk.internal.value.Deserializer;
-            import jdk.internal.MigratedValueClass;
 
             #{TOP_FRAGMENTS}
 
-            @MigratedValueClass
             #{CLASSACCESS} #{VALUE} class #{TESTNAME} #{TESTNAME_EXTENDS} #{KIND.IMPLEMENTS} {
                 #{FIELD[0]} f1;
                 #{FIELD[1]} f2;
@@ -885,13 +883,11 @@ public final class SerializedObjectCombo extends ComboInstance<SerializedObjectC
     enum TopFragments implements ComboParameter, CodeShapePredicate {
         NONE(""),
         ABSTRACT_NO_FIELDS("""
-                @MigratedValueClass
                 abstract #{VALUE} class TOP_#{TESTNAME} implements Serializable {
                     #{CLASSACCESS} TOP_#{TESTNAME}() {}
                 }
                 """),
         ABSTRACT_ONE_FIELD("""
-                @MigratedValueClass
                 abstract #{VALUE} class TOP_#{TESTNAME} implements Serializable {
                     private int t1;
                     #{CLASSACCESS} TOP_#{TESTNAME}() {
@@ -900,13 +896,11 @@ public final class SerializedObjectCombo extends ComboInstance<SerializedObjectC
                 }
                 """),
         NO_FIELDS("""
-                @MigratedValueClass
                 #{VALUE} class TOP_#{TESTNAME} implements Serializable {
                     #{CLASSACCESS} TOP_#{TESTNAME}() {}
                 }
                 """),
         ONE_FIELD("""
-                @MigratedValueClass
                 #{VALUE} class TOP_#{TESTNAME} implements Serializable {
                     private int t1;
                     #{CLASSACCESS} TOP_#{TESTNAME}() {

--- a/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
+++ b/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
@@ -51,8 +51,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import jdk.internal.value.Deserializer;
-import jdk.internal.MigratedValueClass;
-
 
 import jdk.test.lib.hexdump.HexPrinter;
 import jdk.test.lib.hexdump.ObjectStreamPrinter;
@@ -309,7 +307,6 @@ public class SimpleValueGraphs implements Serializable {
         }
     }
 
-    @MigratedValueClass
     static value class TreeV implements Tree, Serializable {
 
         @Serial

--- a/test/jdk/java/io/Serializable/valueObjects/ValueSerializationTest.java
+++ b/test/jdk/java/io/Serializable/valueObjects/ValueSerializationTest.java
@@ -52,7 +52,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.stream.Stream;
 
-import jdk.internal.MigratedValueClass;
 import jdk.internal.value.Deserializer;
 
 import jdk.test.lib.helpers.StrictInit;
@@ -179,7 +178,6 @@ public class ValueSerializationTest {
     }
 
     /* A Serializable value class Point */
-    @MigratedValueClass
     static value class SerializablePoint implements Serializable {
         public int x;
         public int y;


### PR DESCRIPTION
MigratedValueClass is only used by source generation to generate preview class files for the JDK. It does not need to be recognized by javac, which already has its own mechanism to handle such preview class files.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386097](https://bugs.openjdk.org/browse/JDK-8386097): [lworld] javac does not need to handle MigratedValueClass (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2523/head:pull/2523` \
`$ git checkout pull/2523`

Update a local copy of the PR: \
`$ git checkout pull/2523` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2523`

View PR using the GUI difftool: \
`$ git pr show -t 2523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2523.diff">https://git.openjdk.org/valhalla/pull/2523.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2523#issuecomment-4637740565)
</details>
