### PR TITLE
8386114: [lworld] Rollback meaningless diff in InnerClassLambdaMetafactory

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -26,7 +26,6 @@
 package java.lang.invoke;
 
 import jdk.internal.constant.ClassOrInterfaceDescImpl;
-import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.misc.CDS;
 import jdk.internal.util.ClassFileDumper;
 import sun.invoke.util.VerifyAccess;
@@ -40,7 +39,6 @@ import java.lang.classfile.Opcode;
 import java.lang.classfile.TypeKind;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
-import java.lang.reflect.ClassFileFormatVersion;
 import java.lang.reflect.Modifier;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -312,8 +310,7 @@ import sun.invoke.util.Wrapper;
         final byte[] classBytes = ClassFile.of().build(lambdaClassEntry, pool, new Consumer<ClassBuilder>() {
             @Override
             public void accept(ClassBuilder clb) {
-                clb.withVersion(ClassFileFormatVersion.latest().major(), (PreviewFeatures.isEnabled() ? ClassFile.PREVIEW_MINOR_VERSION : 0))
-                   .withFlags(ACC_SUPER | ACC_FINAL | ACC_SYNTHETIC)
+                clb.withFlags(ACC_SUPER | ACC_FINAL | ACC_SYNTHETIC)
                    .withInterfaceSymbols(interfaces);
                 // All Classes in the BSM argument method types are loaded; no need for LoadableDescriptors
 


### PR DESCRIPTION
There is some meaningless diff setting preview minor version in ICLMf. We should drop that because we are not making use of strict fields or value classes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386114](https://bugs.openjdk.org/browse/JDK-8386114): [lworld] Rollback meaningless diff in InnerClassLambdaMetafactory (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2524/head:pull/2524` \
`$ git checkout pull/2524`

Update a local copy of the PR: \
`$ git checkout pull/2524` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2524`

View PR using the GUI difftool: \
`$ git pr show -t 2524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2524.diff">https://git.openjdk.org/valhalla/pull/2524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2524#issuecomment-4641227408)
</details>
