### PR TITLE
8386140: [lworld] FieldReflector using wrong Class argument

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1898,11 +1898,11 @@ public final class ObjectStreamClass implements Serializable {
         private final long[] writeKeys;
         /** field data offsets */
         private final int[] offsets;
-        /** field layouts */
+        /** field layouts, only used by reference fields */
         private final int[] layouts;
         /** field type codes */
         private final char[] typeCodes;
-        /** field types */
+        /** reference field types, only fields.length - numPrimFields items */
         private final Class<?>[] types;
 
         /**
@@ -1933,7 +1933,7 @@ public final class ObjectStreamClass implements Serializable {
                 writeKeys[i] = usedKeys.add(key) ?
                     key : Unsafe.INVALID_FIELD_OFFSET;
                 offsets[i] = f.getOffset();
-                layouts[i] = rf != null ? UNSAFE.fieldLayout(rf) : 0;
+                layouts[i] = rf != null && !f.isPrimitive() ? UNSAFE.fieldLayout(rf) : 0;
                 typeCodes[i] = f.getTypeCode();
                 if (!f.isPrimitive()) {
                     typeList.add((rf != null) ? rf.getType() : null);
@@ -2030,7 +2030,7 @@ public final class ObjectStreamClass implements Serializable {
                 vals[offsets[i]] = switch (typeCodes[i]) {
                     case 'L', '[' ->
                             layouts[i] != 0
-                                    ? UNSAFE.getFlatValue(obj, readKeys[i], layouts[i], types[i])
+                                    ? UNSAFE.getFlatValue(obj, readKeys[i], layouts[i], types[i - numPrimFields])
                                     : UNSAFE.getReference(obj, readKeys[i]);
                     default       -> throw new InternalError();
                 };
@@ -2083,7 +2083,7 @@ public final class ObjectStreamClass implements Serializable {
                         }
                         if (!dryRun) {
                             if (layouts[i] != 0) {
-                                UNSAFE.putFlatValue(obj, key, layouts[i], types[i], val);
+                                UNSAFE.putFlatValue(obj, key, layouts[i], types[i - numPrimFields], val);
                             } else {
                                 UNSAFE.putReference(obj, key, val);
                             }


### PR DESCRIPTION
The `types` array indices are not the overall field indices but are just indices among reference fields. We need to fix this indice use; this surfaces only when `--enable-preview` and causes failure in `test/jdk/java/io/Serializable/checkModifiers/CheckModifiers.java`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386140](https://bugs.openjdk.org/browse/JDK-8386140): [lworld] FieldReflector using wrong Class argument (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2525/head:pull/2525` \
`$ git checkout pull/2525`

Update a local copy of the PR: \
`$ git checkout pull/2525` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2525`

View PR using the GUI difftool: \
`$ git pr show -t 2525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2525.diff">https://git.openjdk.org/valhalla/pull/2525.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2525#issuecomment-4651115197)
</details>
