### PR TITLE
8386216: [lworld] Rollback meaningless diff in EventClassBuilder

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
@@ -39,9 +39,6 @@ import java.lang.classfile.ClassBuilder;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.Label;
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
-
-import jdk.internal.misc.PreviewFeatures;
-
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.Event;
 import jdk.jfr.ValueDescriptor;
@@ -111,10 +108,9 @@ public final class EventClassBuilder {
         }));
     }
 
-    @SuppressWarnings("preview")
     private void buildClassInfo(ClassBuilder builder) {
         builder.withSuperclass(Bytecode.classDesc(Event.class));
-        builder.withFlags(AccessFlag.FINAL, AccessFlag.PUBLIC, (PreviewFeatures.isEnabled() ? AccessFlag.IDENTITY : AccessFlag.SUPER));
+        builder.withFlags(AccessFlag.FINAL, AccessFlag.PUBLIC, AccessFlag.SUPER);
         List<java.lang.classfile.Annotation> annotations = new ArrayList<>();
         for (jdk.jfr.AnnotationElement a : annotationElements) {
             List<java.lang.classfile.AnnotationElement> list = new ArrayList<>();


### PR DESCRIPTION
Classfile generation changes to EventClassBuilder is no longer necessary in the latest JEP401 model. Remove this noisy change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386216](https://bugs.openjdk.org/browse/JDK-8386216): [lworld] Rollback meaningless diff in EventClassBuilder (**Enhancement** - P4)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2528/head:pull/2528` \
`$ git checkout pull/2528`

Update a local copy of the PR: \
`$ git checkout pull/2528` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2528`

View PR using the GUI difftool: \
`$ git pr show -t 2528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2528.diff">https://git.openjdk.org/valhalla/pull/2528.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2528#issuecomment-4652672508)
</details>
