### PR TITLE
8386239: [lworld] Update jdk/java/util/Arrays/ArraysEqCmpTest.java

### DIFF
--- a/test/jdk/java/util/Arrays/ArraysEqCmpTest.java
+++ b/test/jdk/java/util/Arrays/ArraysEqCmpTest.java
@@ -68,6 +68,15 @@ public class ArraysEqCmpTest {
         }
     }
 
+    @AsValueClass
+    record BoxedPoint(Integer x, Integer y) implements Comparable<BoxedPoint> {
+        @Override
+        public int compareTo(BoxedPoint o) {
+            int r = Integer.compare(this.x, o.x);
+            return (r != 0) ? r : Integer.compare(this.y, o.y);
+        }
+    }
+
     static {
         typeToWidth = new HashMap<>();
         typeToWidth.put(boolean.class, Byte.SIZE);
@@ -617,6 +626,24 @@ public class ArraysEqCmpTest {
                 } else throw new IllegalStateException();
             }
         }
+
+        static class ValueBoxedPoints extends ArrayType<BoxedPoint[]> {
+            public ValueBoxedPoints() {
+                super(BoxedPoint[].class);
+            }
+
+            @Override
+            void set(Object a, int i, Object v) {
+                if (v == null) {
+                    ((BoxedPoint[]) a)[i] = null;
+                } else if (v instanceof BoxedPoint) {
+                    ((BoxedPoint[]) a)[i] = (BoxedPoint) v;
+                } else if (v instanceof Integer) {
+                    int val = (Integer) v;
+                    ((BoxedPoint[]) a)[i] = new BoxedPoint(val, val);
+                } else throw new IllegalStateException();
+            }
+        }
     }
 
     static Object[][] arrayTypes;
@@ -638,7 +665,8 @@ public class ArraysEqCmpTest {
                     new Object[]{new ArrayType.Longs(true)},
                     new Object[]{new ArrayType.Floats()},
                     new Object[]{new ArrayType.Doubles()},
-                    new Object[]{new ArrayType.ValuePoints()}
+                    new Object[]{new ArrayType.ValuePoints()},
+                    new Object[]{new ArrayType.ValueBoxedPoints()}
             };
         }
         return arrayTypes;
@@ -670,6 +698,7 @@ public class ArraysEqCmpTest {
                     new Object[]{new ArrayType.BoxedIntegers()},
                     new Object[]{new ArrayType.BoxedIntegersWithReverseComparator()},
                     new Object[]{new ArrayType.ValuePoints()},
+                    new Object[]{new ArrayType.ValueBoxedPoints()},
             };
         }
         return objectArrayTypes;


### PR DESCRIPTION
Update test  to use Point with 2 Integers.

It start crashing with 
make test JTREG=VALUE_CLASS_PLUGIN=true TEST=java/util/Arrays/ArraysEqCmpTest.java

So it makes sense to integrate it to reproduce fix and as a regression test

hs_err 
```

#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/Users/lmesnik/ws/valhalla/main/open/src/hotspot/share/opto/library_call.cpp:2699), pid=45037, tid=36871
#  assert(layout == LayoutKind::REFERENCE || layout == LayoutKind::NULL_FREE_NON_ATOMIC_FLAT || layout == LayoutKind::NULL_FREE_ATOMIC_FLAT || layout == LayoutKind::NULLABLE_ATOMIC_FLAT) failed: unexpected layoutKind 5
#
# JRE version: OpenJDK Runtime Environment (28.0) (fastdebug build 28-internal-adhoc.lmesnik.open)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 28-internal-adhoc.lmesnik.open, mixed mode, tiered, compressed oops, compact obj headers, g1 gc, bsd-aarch64)
# Core dump will be written. Default location: core.45037
#
# An error report file with more information is saved as:
# /Users/lmesnik/ws/valhalla/main/open/build/macosx-aarch64-server-fastdebug/test-support/jtreg_test_jdk_java_util_Arrays_ArraysEqCmpTest_java/scratch/0/hs_err_pid45037.log
[thread 42243 also had an error]
[thread 29187 also had an error]
#
# Compiler replay data is saved as:
# /Users/lmesnik/ws/valhalla/main/open/build/macosx-aarch64-server-fastdebug/test-support/jtreg_test_jdk_java_util_Arrays_ArraysEqCmpTest_java/scratch/0/replay_pid45037.log
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386239](https://bugs.openjdk.org/browse/JDK-8386239): [lworld] Update jdk/java/util/Arrays/ArraysEqCmpTest.java (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2529/head:pull/2529` \
`$ git checkout pull/2529`

Update a local copy of the PR: \
`$ git checkout pull/2529` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2529`

View PR using the GUI difftool: \
`$ git pr show -t 2529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2529.diff">https://git.openjdk.org/valhalla/pull/2529.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2529#issuecomment-4656074475)
</details>
