### PR TITLE
8386316: [lworld] Replace Valhalla since version with 28

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -634,7 +634,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @jls value-objects-8.1.1.5 {@code value} Classes
      * @see AccessFlag#IDENTITY
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     public boolean isValue() {

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -33,7 +33,7 @@ import jdk.internal.javac.PreviewFeature;
  * objects do not have identity and cannot be used for synchronization, locking,
  * or any type of {@link java.lang.ref.Reference}.
  *
- * @since Valhalla
+ * @since 28
  */
 @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 public final class IdentityException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/classfile/Attributes.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attributes.java
@@ -85,7 +85,7 @@ public final class Attributes {
     /**
      * LoadableDescriptors
      *
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective = true)
     public static final String NAME_LOADABLE_DESCRIPTORS = "LoadableDescriptors";
@@ -257,7 +257,7 @@ public final class Attributes {
     /**
      * {@return the mapper for the {@code LoadableDescriptors} attribute}
      *
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective = true)
     public static AttributeMapper<LoadableDescriptorsAttribute> loadableDescriptors() {

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -809,7 +809,7 @@ public sealed interface ClassFile
     /**
      * The bit mask of {@link AccessFlag#IDENTITY} access and property modifier.
      *
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective = true)
     int ACC_IDENTITY = 0x0020;
@@ -850,7 +850,7 @@ public sealed interface ClassFile
     /**
      * The bit mask of {@link AccessFlag#STRICT_INIT} access and property modifier.
      *
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.STRICT_FIELDS, reflective = true)
     int ACC_STRICT_INIT = 0x0800;

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
@@ -57,7 +57,7 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @see Attributes#loadableDescriptors()
  * @jvms value-objects-4.7.32 The {@code LoadableDescriptors} Attribute
- * @since Valhalla
+ * @since 28
  */
 @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective = true)
 public sealed interface LoadableDescriptorsAttribute

--- a/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
@@ -84,7 +84,7 @@ public sealed interface StackMapFrameInfo
      * {@return the expanded unset fields}
      *
      * @jvms strict-fields-4.7.4 The {@code StackMapTable} Attribute
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.STRICT_FIELDS, reflective = true)
     List<NameAndTypeEntry> unsetFields();
@@ -116,7 +116,7 @@ public sealed interface StackMapFrameInfo
      *         {@link java.lang.classfile##u2 u2}; or if unset fields has
      *         elements, but no {@link SimpleVerificationTypeInfo#UNINITIALIZED_THIS
      *         uninitializedThis} is present in {@code locals}
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.STRICT_FIELDS, reflective = true)
     public static StackMapFrameInfo of(Label target,

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -170,7 +170,7 @@ public enum AccessFlag {
      * <code>{@value "0x%04x" ClassFile#ACC_IDENTITY}</code>.
      *
      * @jvms value-objects-4.1 Class access and property modifiers
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     IDENTITY(ACC_IDENTITY, false,
@@ -281,7 +281,7 @@ public enum AccessFlag {
      * <code>{@value "0x%04x" ClassFile#ACC_STRICT_INIT}</code>.
      *
      * @jvms strict-fields-4.5 Field access and property flags
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.STRICT_FIELDS, reflective=true)
     STRICT_INIT(ACC_STRICT_INIT, false,

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -289,7 +289,7 @@ class Field extends AccessibleObject implements Member {
      * @return true if and only if this field is a strictly
      * initialized field as defined by the Java Virtual Machine Specification
      * @jvms strict-fields-4.5 Field access and property flags
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.STRICT_FIELDS, reflective = true)
     public boolean isStrictInit() {

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -206,7 +206,7 @@ public final class Objects {
      *     }
      * }
      * @param obj an object or {@code null}
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     public static boolean hasIdentity(Object obj) {
@@ -221,7 +221,7 @@ public final class Objects {
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
      * @throws IdentityException if {@code obj} is not an identity object
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     @ForceInline
@@ -242,7 +242,7 @@ public final class Objects {
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
      * @throws IdentityException if {@code obj} is not an identity object
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     @ForceInline
@@ -263,7 +263,7 @@ public final class Objects {
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
      * @throws IdentityException if {@code obj} is not an identity object
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     @ForceInline

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1528,7 +1528,6 @@ public final class Unsafe {
      * Return the size of the object in the heap.
      * @param o an object
      * @return the objects's size
-     * @since Valhalla
      */
     public long getObjectSize(Object o) {
         if (o == null)

--- a/src/java.base/share/classes/jdk/internal/value/Deserializer.java
+++ b/src/java.base/share/classes/jdk/internal/value/Deserializer.java
@@ -37,7 +37,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * This is a temporary measure for legacy serialization migration compatibility;
  * future value object persistence would be handled by other mechanisms.
  *
- * @since Valhalla
+ * @since 28
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value={CONSTRUCTOR, METHOD})

--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -172,7 +172,7 @@ public enum Modifier {
      * The modifier {@code value}
      *
      * @jls value-objects-8.1.1.5 {@code value} Classes
-     * @since Valhalla
+     * @since 28
      */
     @PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
     VALUE;

--- a/test/jdk/tools/sincechecker/modules/java.base/JavaBaseCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.base/JavaBaseCheckSince.java
@@ -26,5 +26,5 @@
  * @bug 8331051 8367610
  * @summary Test for `@since` in java.base module
  * @library /test/lib /test/jdk/tools/sincechecker
- * @run main/timeout=480 SinceChecker java.base --ignoreSince Valhalla --exclude java.lang.classfile
+ * @run main/timeout=480 SinceChecker java.base --exclude java.lang.classfile
  */

--- a/test/jdk/tools/sincechecker/modules/java.compiler/JavaCompilerCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.compiler/JavaCompilerCheckSince.java
@@ -26,5 +26,5 @@
  * @bug 8341399
  * @summary Test for `@since` in java.compiler module
  * @library /test/lib /test/jdk/tools/sincechecker
- * @run main SinceChecker java.compiler --ignoreSince Valhalla
+ * @run main SinceChecker java.compiler
  */


### PR DESCRIPTION
Since JEP 401 is targeting 28, we should update the since versions and rollback the checker test changes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386316](https://bugs.openjdk.org/browse/JDK-8386316): [lworld] Replace Valhalla since version with 28 (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2533/head:pull/2533` \
`$ git checkout pull/2533`

Update a local copy of the PR: \
`$ git checkout pull/2533` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2533`

View PR using the GUI difftool: \
`$ git pr show -t 2533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2533.diff">https://git.openjdk.org/valhalla/pull/2533.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2533#issuecomment-4666937564)
</details>
