### PR TITLE
8386455: [lworld] Update problem list to reflect fixes for JDK-8375062 and JDK-8375076 being integrated from mainline

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -201,13 +201,8 @@ compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
 compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF 8384262 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id4 8386160 generic-all
 
-vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java 8375062 windows-x64
-vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java 8375076 windows-x64
 vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all
 
 # The following test failures DID NOT reproduce during Tier[1-8] testing
 # done for 8377828. Further analysis is being done with 8376235:
 compiler/codegen/TestRedundantLea.java#RegexFind          8361089 generic-all
-
-# I'm disabling this entry to determine frequency of failure:
-# vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001/TestDescription.java 8375076 windows-x64


### PR DESCRIPTION
 These tests failures were fixed in mainline and now integrated into valhalla. They can be removed from the problem list.

vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java 8375062 windows-x64
vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java 8375076 windows-x64
vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001/TestDescription.java 8375076 windows-x64 

Testing by running all 3 tests an all supported platforms 5 times each.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386455](https://bugs.openjdk.org/browse/JDK-8386455): [lworld] Update problem list to reflect fixes for JDK-8375062 and JDK-8375076 being integrated from mainline (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2535/head:pull/2535` \
`$ git checkout pull/2535`

Update a local copy of the PR: \
`$ git checkout pull/2535` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2535`

View PR using the GUI difftool: \
`$ git pr show -t 2535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2535.diff">https://git.openjdk.org/valhalla/pull/2535.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2535#issuecomment-4674178621)
</details>
