### PR TITLE
8386342: [lworld] Large overlapping flat arraycopy overflows payload offset

### DIFF
--- a/src/hotspot/share/oops/valuePayload.inline.hpp
+++ b/src/hotspot/share/oops/valuePayload.inline.hpp
@@ -692,7 +692,7 @@ inline void FlatArrayPayload::set_index(int index) {
 }
 
 inline void FlatArrayPayload::advance_index(int delta) {
-  set_offset(this->offset() + delta * _storage._element_size);
+  set_offset(this->offset() + (ptrdiff_t)delta * (ptrdiff_t)_storage._element_size);
 }
 
 inline void FlatArrayPayload::next_element() {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayLargeOverlapCopyTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayLargeOverlapCopyTest.java
@@ -37,6 +37,8 @@ package runtime.valhalla.inlinetypes;
 import jdk.internal.value.ValueClass;
 
 public class FlatArrayLargeOverlapCopyTest {
+    // Value[] is flattened with 8-byte elements.
+    // Copying 290M elements makes length * elementSize exceed Integer.MAX_VALUE.
     private static final int LENGTH = 290_000_000;
 
     public static value record Value(int value) {}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayLargeOverlapCopyTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayLargeOverlapCopyTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Ensures large overlapping flat array copies do not overflow payload iterator offsets.
+ * @enablePreview
+ * @requires os.maxMemory >= 7G
+ * @modules java.base/jdk.internal.value
+ * @run main/othervm/timeout=240 -Xint -Xmx6G
+ *                               runtime.valhalla.inlinetypes.FlatArrayLargeOverlapCopyTest
+ */
+
+package runtime.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+
+public class FlatArrayLargeOverlapCopyTest {
+    private static final int LENGTH = 290_000_000;
+
+    public static value record Value(int value) {}
+
+    public static void main(String[] args) {
+        Value[] array = new Value[LENGTH + 1];
+        if (!ValueClass.isFlatArray(array)) {
+            throw new RuntimeException("Expected Value[] to be flat");
+        }
+
+        array[0] = new Value(1);
+        array[LENGTH - 1] = new Value(2);
+        array[LENGTH] = new Value(3);
+
+        System.arraycopy(array, 0, array, 1, LENGTH);
+
+        if (array[1].value() != 1) {
+            throw new RuntimeException("array[1]=" + array[1] + ", expected '1'");
+        }
+        if (array[LENGTH].value() != 2) {
+            throw new RuntimeException("array[LENGTH]=" + array[LENGTH] + ", expected '2'");
+        }
+
+        array[1] = new Value(4);
+        array[LENGTH] = new Value(5);
+
+        System.arraycopy(array, 1, array, 0, LENGTH);
+
+        if (array[0].value() != 4) {
+            throw new RuntimeException("array[0]=" + array[0] + ", expected '4'");
+        }
+        if (array[LENGTH - 1].value() != 5) {
+            throw new RuntimeException("array[LENGTH - 1]=" + array[LENGTH - 1] + ", expected '5'");
+        }
+    }
+}


### PR DESCRIPTION
Hi everyone,

This fixes an overflow in `FlatArrayPayload::advance_index`. The method advanced an array payload offset by multiplying two `int` values before adding the result to a `ptrdiff_t`. For large flat arrays, the backward-overlap path in `FlatArrayKlass::copy_array` can call `advance_index(length - 1)`, and that multiplication can overflow before the value is widened.

The fix widens the operands before multiplying, so the offset adjustment is computed in a `ptrdiff_t`.

I also added a regression test that performs large overlapping copies on a flat value array. Before the fix, the backward overlapping copy fails in debug builds with an out-of-bounds assert. With the fix, both backward and forward overlapping copies complete successfully.

Testing:
- New test testing same-array flat copy behavior
- Tiers 1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386342](https://bugs.openjdk.org/browse/JDK-8386342): [lworld] Large overlapping flat arraycopy overflows payload offset (**Bug** - P2)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - no project role) ⚠️ Review applies to [9c158119](https://git.openjdk.org/valhalla/pull/2537/files/9c1581192382f1b31a5df5f03cae3b8b36fbcfef)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2537/head:pull/2537` \
`$ git checkout pull/2537`

Update a local copy of the PR: \
`$ git checkout pull/2537` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2537`

View PR using the GUI difftool: \
`$ git pr show -t 2537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2537.diff">https://git.openjdk.org/valhalla/pull/2537.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2537#issuecomment-4680405607)
</details>
