### PR TITLE
8386513: [lworld] Trivial review cleanups for runtime

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -794,9 +794,7 @@ class InterpreterFrameClosure : public OffsetClosure {
     if (offset < _max_locals) {
       addr = (oop*) _fr->interpreter_frame_local_at(offset);
       assert((intptr_t*)addr >= _fr->sp(), "must be inside the frame");
-      if (_f != nullptr) {
-        _f->do_oop(addr);
-      }
+      _f->do_oop(addr);
     } else {
       addr = (oop*) _fr->interpreter_frame_expression_stack_at((offset - _max_locals));
       // In case of exceptions, the expression stack is invalid and the esp will be reset to express
@@ -808,9 +806,7 @@ class InterpreterFrameClosure : public OffsetClosure {
         in_stack = (intptr_t*)addr >= _fr->interpreter_frame_tos_address();
       }
       if (in_stack) {
-        if (_f != nullptr) {
-          _f->do_oop(addr);
-        }
+        _f->do_oop(addr);
       }
     }
   }

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -83,7 +83,7 @@ typedef struct {
   jint name_offset;       // offset of the data item name
   jint vector_length;     // length of the vector. If 0, then scalar
   jbyte data_type;        // type of the data item -
-                          // 'B','Z','J','I','S','C','D','F','V','L','Q','['
+                          // 'B','Z','J','I','S','C','D','F','V','L','['
   jbyte flags;            // flags indicating misc attributes
   jbyte data_units;       // unit of measure for the data type
   jbyte data_variability; // variability classification of data type

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -769,7 +769,8 @@ static Handle new_type(Symbol* signature, Klass* k, TRAPS) {
 
 oop Reflection::new_method(const methodHandle& method, bool for_constant_pool_access, TRAPS) {
   // Allow jdk.internal.reflect.ConstantPool to refer to <clinit> methods as java.lang.reflect.Methods.
-  assert(!method()->name()->starts_with('<') || for_constant_pool_access,
+  assert(!method()->is_object_constructor() ||
+         (for_constant_pool_access || !method()->is_class_initializer()),
          "should call new_constructor instead");
   InstanceKlass* holder = method->method_holder();
   int slot = method->method_idnum();
@@ -1171,6 +1172,7 @@ oop Reflection::invoke_constructor(oop constructor_mirror, objArrayHandle args, 
     THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "invoke");
   }
   methodHandle method(THREAD, m);
+  assert(method->name() == vmSymbols::object_initializer_name(), "invalid constructor");
 
   // Make sure klass gets initialize
   klass->initialize(CHECK_NULL);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3309,10 +3309,10 @@ bool AdapterHandlerLibrary::generate_adapter_code(AdapterHandlerEntry* handler,
 
   if (ces.has_scalarized_args()) {
     // Save a C heap allocated version of the scalarized signature and store it in the adapter
-    GrowableArray<SigEntry>* heap_sig = new (mtInternal) GrowableArray<SigEntry>(ces.sig_cc()->length(), mtInternal);
+    GrowableArray<SigEntry>* heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc()->length(), mtCode);
     heap_sig->appendAll(ces.sig_cc());
     handler->set_sig_cc(heap_sig);
-    heap_sig = new (mtInternal) GrowableArray<SigEntry>(ces.sig_cc_ro()->length(), mtInternal);
+    heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc_ro()->length(), mtCode);
     heap_sig->appendAll(ces.sig_cc_ro());
     handler->set_sig_cc_ro(heap_sig);
   }
@@ -3473,10 +3473,10 @@ void AdapterHandlerEntry::link() {
       ces.initialize_from_fingerprint(_fingerprint);
       if (ces.has_scalarized_args()) {
         // Save a C heap allocated version of the scalarized signature and store it in the adapter
-        GrowableArray<SigEntry>* heap_sig = new (mtInternal) GrowableArray<SigEntry>(ces.sig_cc()->length(), mtInternal);
+        GrowableArray<SigEntry>* heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc()->length(), mtCode);
         heap_sig->appendAll(ces.sig_cc());
         set_sig_cc(heap_sig);
-        heap_sig = new (mtInternal) GrowableArray<SigEntry>(ces.sig_cc_ro()->length(), mtInternal);
+        heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc_ro()->length(), mtCode);
         heap_sig->appendAll(ces.sig_cc_ro());
         set_sig_cc_ro(heap_sig);
       }

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -366,6 +366,7 @@ public:
   static void arrayof_jlong_copy     (HeapWord* src, HeapWord* dest, size_t count);
   static void arrayof_oop_copy       (HeapWord* src, HeapWord* dest, size_t count);
   static void arrayof_oop_copy_uninit(HeapWord* src, HeapWord* dest, size_t count);
+
 };
 
 #endif // SHARE_RUNTIME_STUBROUTINES_HPP

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1264,8 +1264,8 @@ void DumperSupport::dump_static_fields(AbstractDumpWriter* writer, Klass* k) {
 }
 
 // dump the raw values of the instance fields of the given object, fills flat_fields
-void DumperSupport:: dump_instance_fields(AbstractDumpWriter* writer, oop o, int offset,
-                                          DumperClassCacheTableEntry* class_cache_entry, DumperFlatObjectList* flat_fields) {
+void DumperSupport::dump_instance_fields(AbstractDumpWriter* writer, oop o, int offset,
+                                         DumperClassCacheTableEntry* class_cache_entry, DumperFlatObjectList* flat_fields) {
   assert(class_cache_entry != nullptr, "Pre-condition: must be provided");
   for (int idx = 0; idx < class_cache_entry->field_count(); idx++) {
     const DumperClassCacheTableEntry::FieldDescriptor& field = class_cache_entry->field(idx);

--- a/src/hotspot/share/utilities/constantTag.cpp
+++ b/src/hotspot/share/utilities/constantTag.cpp
@@ -34,7 +34,7 @@ void constantTag::print_on(outputStream* st) const {
 #endif // PRODUCT
 
 BasicType constantTag::basic_type() const {
-  switch (value()) {
+  switch (_tag) {
     case JVM_CONSTANT_Integer :
       return T_INT;
     case JVM_CONSTANT_Float :
@@ -68,7 +68,7 @@ BasicType constantTag::basic_type() const {
 
 
 jbyte constantTag::non_error_value() const {
-  switch (value()) {
+  switch (_tag) {
   case JVM_CONSTANT_UnresolvedClassInError:
     return JVM_CONSTANT_UnresolvedClass;
   case JVM_CONSTANT_MethodHandleInError:
@@ -78,13 +78,13 @@ jbyte constantTag::non_error_value() const {
   case JVM_CONSTANT_DynamicInError:
     return JVM_CONSTANT_Dynamic;
   default:
-    return value();
+    return _tag;
   }
 }
 
 
 jbyte constantTag::error_value() const {
-  switch (value()) {
+  switch (_tag) {
   case JVM_CONSTANT_UnresolvedClass:
     return JVM_CONSTANT_UnresolvedClassInError;
   case JVM_CONSTANT_MethodHandle:
@@ -100,7 +100,7 @@ jbyte constantTag::error_value() const {
 }
 
 const char* constantTag::internal_name() const {
-  switch (value()) {
+  switch (_tag) {
     case JVM_CONSTANT_Invalid :
       return "Invalid index";
     case JVM_CONSTANT_Class :

--- a/src/hotspot/share/utilities/constantTag.hpp
+++ b/src/hotspot/share/utilities/constantTag.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ enum {
   JVM_CONSTANT_Invalid                  = 0,    // For bad value initialization
   JVM_CONSTANT_InternalMin              = 100,  // First implementation tag (aside from bad value of course)
   JVM_CONSTANT_UnresolvedClass          = 100,  // Temporary tag until actual use
-  JVM_CONSTANT_ClassIndex               = 101,  // Temporary tag while constructing constant pool, class redefinition
-  JVM_CONSTANT_StringIndex              = 102,  // Temporary tag while constructing constant pool, class redefinition
+  JVM_CONSTANT_ClassIndex               = 101,  // Temporary tag while constructing constant pool
+  JVM_CONSTANT_StringIndex              = 102,  // Temporary tag while constructing constant pool
   JVM_CONSTANT_UnresolvedClassInError   = 103,  // Error tag due to resolution error
   JVM_CONSTANT_MethodHandleInError      = 104,  // Error tag due to resolution error
   JVM_CONSTANT_MethodTypeInError        = 105,  // Error tag due to resolution error
@@ -53,7 +53,7 @@ class constantTag {
  private:
   jbyte _tag;
  public:
-  bool is_klass() const             { return value() == JVM_CONSTANT_Class; }
+  bool is_klass() const             { return _tag == JVM_CONSTANT_Class; }
   bool is_field () const            { return _tag == JVM_CONSTANT_Fieldref; }
   bool is_method() const            { return _tag == JVM_CONSTANT_Methodref; }
   bool is_interface_method() const  { return _tag == JVM_CONSTANT_InterfaceMethodref; }
@@ -68,11 +68,11 @@ class constantTag {
   bool is_invalid() const           { return _tag == JVM_CONSTANT_Invalid; }
 
   bool is_unresolved_klass() const {
-    return value() == JVM_CONSTANT_UnresolvedClass || value() == JVM_CONSTANT_UnresolvedClassInError;
+    return _tag == JVM_CONSTANT_UnresolvedClass || _tag == JVM_CONSTANT_UnresolvedClassInError;
   }
 
   bool is_unresolved_klass_in_error() const {
-    return value() == JVM_CONSTANT_UnresolvedClassInError;
+    return _tag == JVM_CONSTANT_UnresolvedClassInError;
   }
 
   bool is_method_handle_in_error() const {
@@ -149,7 +149,6 @@ class constantTag {
   }
 
   jbyte value() const                { return _tag; }
-  jbyte tag() const                  { return _tag; }
   jbyte error_value() const;
   jbyte non_error_value() const;
 


### PR DESCRIPTION
Please review these trivial changes for the runtime, services and utilities folders.
Ran tier1-4 and valhalla tests locally.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386513](https://bugs.openjdk.org/browse/JDK-8386513): [lworld] Trivial review cleanups for runtime (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2539/head:pull/2539` \
`$ git checkout pull/2539`

Update a local copy of the PR: \
`$ git checkout pull/2539` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2539`

View PR using the GUI difftool: \
`$ git pr show -t 2539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2539.diff">https://git.openjdk.org/valhalla/pull/2539.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2539#issuecomment-4684152101)
</details>
