### PR TITLE
8385743: [lworld] investigate and address build related comments in the Valhalla PR

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -142,10 +142,10 @@ PREVIEW_PATH := META-INF/preview
 MODULE_PREVIEW_SRC_DIRS := $(call FindModulePreviewSrcDirs, $(MODULE))
 MODULE_PREVIEW_SOURCEPATH := $(call GetModulePreviewSrcPath)
 ifneq ($(MODULE_PREVIEW_SRC_DIRS),)
-  # Temporarily compile preview classes into a separate directory, and then
-  # copy into the correct output path location.
-  # We cannot compile directly into the desired directory because it's the
-  # compiler which creates the original '<module>/<classpath>/...' hierarchy.
+  # Compile preview classes into a separate directory, and then copy into the
+  # correct output path location. We cannot compile directly into the desired
+  # directory because it's the compiler which creates the original
+  # '<module>/<classpath>/...' hierarchy.
   PREVIEW_OUTPUTDIR := $(SUPPORT_OUTPUTDIR)/$(PREVIEW_CLASSES_LABEL)
   PATCH_COMMAND := $(MODULE)=$(call strip, $(COMPILATION_OUTPUTDIR)/$(MODULE))
 

--- a/make/RunTestsPrebuiltSpec.gmk
+++ b/make/RunTestsPrebuiltSpec.gmk
@@ -66,7 +66,7 @@ TEST_JOBS ?= 0
 
 # Use hard-coded values for java flags (one size, fits all!)
 JAVA_FLAGS := -Duser.language=en -Duser.country=US
-JAVA_FLAGS_BIG := -Xms64M -Xmx3200M
+JAVA_FLAGS_BIG := -Xms64M -Xmx2048M
 JAVA_FLAGS_SMALL := -Xms32M -Xmx512M -XX:TieredStopAtLevel=1
 BUILDJDK_JAVA_FLAGS_SMALL := -Xms32M -Xmx512M -XX:TieredStopAtLevel=1
 BUILD_JAVA_FLAGS := $(JAVA_FLAGS_BIG)

--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -444,7 +444,7 @@ AC_DEFUN_ONCE([BOOTJDK_SETUP_BOOT_JDK_ARGUMENTS],
   # Maximum amount of heap memory.
   JVM_HEAP_LIMIT_32="768"
   # Running a 64 bit JVM allows for and requires a bigger heap
-  JVM_HEAP_LIMIT_64="3200"
+  JVM_HEAP_LIMIT_64="2048"
   JVM_HEAP_LIMIT_GLOBAL=`expr $MEMORY_SIZE / 2`
   if test "$JVM_HEAP_LIMIT_GLOBAL" -lt "$JVM_HEAP_LIMIT_32"; then
     JVM_HEAP_LIMIT_32=$JVM_HEAP_LIMIT_GLOBAL

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -51,9 +51,11 @@ endif
 ifeq ($(call check-jvm-feature, zero), true)
   JVM_EXCLUDES += opto libadt
   JVM_EXCLUDE_PATTERNS += c1_ c1/ c2_ runtime_ /c2/
-  JVM_EXCLUDE_FILES += templateInterpreter.cpp templateInterpreterGenerator.cpp \
-                       bcEscapeAnalyzer.cpp ciTypeFlow.cpp macroAssembler_common.cpp
-  JVM_CFLAGS_FEATURES += -DZERO -DZERO_LIBARCH='"$(OPENJDK_TARGET_CPU_LEGACY_LIB)"' $(LIBFFI_CFLAGS)
+  JVM_EXCLUDE_FILES += templateInterpreter.cpp \
+      templateInterpreterGenerator.cpp bcEscapeAnalyzer.cpp ciTypeFlow.cpp \
+      macroAssembler_common.cpp
+  JVM_CFLAGS_FEATURES += -DZERO \
+      -DZERO_LIBARCH='"$(OPENJDK_TARGET_CPU_LEGACY_LIB)"' $(LIBFFI_CFLAGS)
   JVM_LIBS_FEATURES += $(LIBFFI_LIBS)
   ifeq ($(ENABLE_LIBFFI_BUNDLING), true)
     JVM_LDFLAGS_FEATURES += $(call SetExecutableOrigin,/..)

--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -26,7 +26,7 @@
 ################################################################################
 # Generate the value class replacements for selected java.base source files
 
-java.base-VALUE_CLASS-REPLACEMENTS := \
+JAVA_BASE_VALUE_CLASS_REPLACEMENTS := \
     java/lang/Byte.java \
     java/lang/Short.java \
     java/lang/Integer.java \
@@ -60,11 +60,11 @@ java.base-VALUE_CLASS-REPLACEMENTS := \
     java/time/chrono/ThaiBuddhistDate.java \
     #
 
-java.base-VALUE-CLASS-FILES := \
-    $(foreach f, $(java.base-VALUE_CLASS-REPLACEMENTS), $(addprefix $(TOPDIR)/src/java.base/share/classes/, $(f)))
+JAVA_BASE_VALUE_CLASS_SRC_PATHS := \
+    $(foreach f, $(JAVA_BASE_VALUE_CLASS_REPLACEMENTS), $(addprefix $(TOPDIR)/src/java.base/share/classes/, $(f)))
 
-$(eval $(call SetupTextFileProcessing, JAVA_BASE_VALUECLASS_REPLACEMENTS, \
-    SOURCE_FILES := $(java.base-VALUE-CLASS-FILES), \
+$(eval $(call SetupTextFileProcessing, JAVA_BASE_VALUE_CLASS_TARGETS, \
+    SOURCE_FILES := $(JAVA_BASE_VALUE_CLASS_SRC_PATHS), \
     SOURCE_BASE_DIR := $(TOPDIR)/src/java.base/share/classes, \
     OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/gensrc-valueclasses/java.base/, \
     REPLACEMENTS := \
@@ -72,4 +72,4 @@ $(eval $(call SetupTextFileProcessing, JAVA_BASE_VALUECLASS_REPLACEMENTS, \
         /\*value\*/ record => value record ; \
 ))
 
-TARGETS += $(JAVA_BASE_VALUECLASS_REPLACEMENTS)
+TARGETS += $(JAVA_BASE_VALUE_CLASS_TARGETS)

--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -39,9 +39,14 @@ VARHANDLE_OBJECT_TYPES := Reference FlatValue NonAtomicReference NonAtomicFlatVa
 # arg $1: type for this varhandle
 define GenerateVarHandle
   # Underlying erased signature type, Object or a primitive type
-  VARHANDLE_$1_type := $$(strip $$(if $$(filter $(VARHANDLE_OBJECT_TYPES), $1), Object, $1))
-  VARHANDLE_$1_InputType := $$(strip $$(if $$(filter $(VARHANDLE_OBJECT_TYPES), $1), $1, $$(call Conv, $1, Type)))
-  VARHANDLE_$1_Type := $$(strip $$(subst NonAtomicReference, Reference, $$(subst NonAtomicFlatValue, FlatValue, $$(VARHANDLE_$1_InputType))))
+  VARHANDLE_$1_type := \
+      $$(strip $$(if $$(filter $(VARHANDLE_OBJECT_TYPES), $1), Object, $1))
+  VARHANDLE_$1_InputType := \
+      $$(strip $$(if $$(filter $(VARHANDLE_OBJECT_TYPES), $1), $1, \
+      $$(call Conv, $1, Type)))
+  VARHANDLE_$1_Type := \
+      $$(strip $$(subst NonAtomicReference, Reference, \
+      $$(subst NonAtomicFlatValue, FlatValue, $$(VARHANDLE_$1_InputType))))
 
   $1_KEYS := $$(VARHANDLE_$1_type) CAS
   ifneq ($$(filter $(PRIMITIVE_TYPES), $1),)

--- a/make/test/BuildJtregValueClassPlugin.gmk
+++ b/make/test/BuildJtregValueClassPlugin.gmk
@@ -28,12 +28,10 @@ include MakeFileStart.gmk
 ################################################################################
 # Builds one JAR used by jtreg to test value classes (JEP 401):
 #
-#  valueClassPlugin.jar      -- contains ValueClassPlugin (a javac Plugin that
-#                               rewrites @AsValueClass classes to value classes
-#                               at parse time) together with @AsValueClass and
-#                               the META-INF service descriptor, compiled WITH
-#                               --enable-preview and the required internal-API
-#                               exports.
+#  valueClassPlugin.jar -- Contains ValueClassPlugin (a javac Plugin that
+#    rewrites @AsValueClass classes to value classes at parse time) together
+#    with @AsValueClass and the META-INF service descriptor, compiled WITH
+#    --enable-preview and the required internal-API exports.
 #
 # Usage in test runs (via RunTests.gmk):
 #   make test TEST=... JTREG=VALUE_CLASS_PLUGIN=true

--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -63,7 +63,7 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     BIN := $(TEST_LIB_SUPPORT)/test-lib_classes, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
-    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal preview restricted varargs dangling-doc-comments, \
+    DISABLED_WARNINGS := preview, \
     JAVAC_FLAGS := --add-exports java.base/sun.security.util=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.classfile=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.classfile.attribute=ALL-UNNAMED \


### PR DESCRIPTION
I've taken a pass at resolving most of @erikj79's build related comments in the Valhalla PR:

[JDK-8317279](https://bugs.openjdk.org/browse/JDK-8317279) Standard library implementation of value classes and objects
https://github.com/openjdk/jdk/pull/31123

A couple of the comments will be handled by separate issues:
- [JDK-8386451](https://bugs.openjdk.org/browse/JDK-8386451) [lworld] things to delete from lworld just before integrating JEP-401
- [JDK-8386458](https://bugs.openjdk.org/browse/JDK-8386458) [lworld] add support for allowing value classes to declare native methods

In this PR, I have reverted two of @MrSimms' heap sizes of 3200 to the main-line's 2048.
I am testing this change with a Mach5 Tier[1-8]. Mach5 Tier[123458] have completed
and there are no related test or task failures. Mach5 Tier[67] are still executing and
are currently waiting for Mach5 resources.

Update: I have added links to the comments in JDK-8317279 that discuss my analysis
of the original code, where it came from and my proposed fix; gory details as it were.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385743](https://bugs.openjdk.org/browse/JDK-8385743): [lworld] investigate and address build related comments in the Valhalla PR (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2541/head:pull/2541` \
`$ git checkout pull/2541`

Update a local copy of the PR: \
`$ git checkout pull/2541` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2541`

View PR using the GUI difftool: \
`$ git pr show -t 2541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2541.diff">https://git.openjdk.org/valhalla/pull/2541.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2541#issuecomment-4693328382)
</details>
