### PR TITLE
8386618: [lworld] Remove unused entry_guard_Relocation

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3880,7 +3880,6 @@ const char* nmethod::reloc_string_for(u_char* begin, u_char* end) {
         case relocInfo::poll_type:             return "poll";
         case relocInfo::poll_return_type:      return "poll_return";
         case relocInfo::trampoline_stub_type:  return "trampoline_stub";
-        case relocInfo::entry_guard_type:      return "entry_guard";
         case relocInfo::post_call_nop_type:    return "post_call_nop";
         case relocInfo::barrier_type: {
           barrier_Relocation* const reloc = iter.barrier_reloc();

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,8 +267,7 @@ class relocInfo {
     runtime_call_w_cp_type  = 14, // Runtime call which may load its target from the constant pool
     data_prefix_tag         = 15, // tag for a prefix (carries data arguments)
     post_call_nop_type      = 16, // A tag for post call nop relocations
-    entry_guard_type        = 17, // A tag for an nmethod entry barrier guard value
-    barrier_type            = 18, // GC barrier data
+    barrier_type            = 17, // GC barrier data
     type_mask               = 31  // A mask which selects only the above values
   };
 
@@ -309,7 +308,6 @@ class relocInfo {
     visitor(section_word) \
     visitor(trampoline_stub) \
     visitor(post_call_nop) \
-    visitor(entry_guard) \
     visitor(barrier) \
 
 
@@ -919,19 +917,6 @@ public:
 
   static RelocationHolder spec() {
     return RelocationHolder::construct<post_call_nop_Relocation>();
-  }
-
-  void copy_into(RelocationHolder& holder) const override;
-};
-
-class entry_guard_Relocation : public Relocation {
-  friend class RelocationHolder;
-
-public:
-  entry_guard_Relocation() : Relocation(relocInfo::entry_guard_type) { }
-
-  static RelocationHolder spec() {
-    return RelocationHolder::construct<entry_guard_Relocation>();
   }
 
   void copy_into(RelocationHolder& holder) const override;


### PR DESCRIPTION
Hi, please consider this cleanup change.

`entry_guard_Relocation` is not used anywhere after merge of https://github.com/openjdk/valhalla/pull/2531. We should remove this relocation.

Testing on linux platforms:
- [x] GHA
- [x] `make test TEST="hotspot_valhalla jdk_valhalla valhalla_adopted"` (x86_64, aarch64 and riscv64)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386618](https://bugs.openjdk.org/browse/JDK-8386618): [lworld] Remove unused entry_guard_Relocation (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - no project role)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2542/head:pull/2542` \
`$ git checkout pull/2542`

Update a local copy of the PR: \
`$ git checkout pull/2542` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2542`

View PR using the GUI difftool: \
`$ git pr show -t 2542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2542.diff">https://git.openjdk.org/valhalla/pull/2542.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2542#issuecomment-4697688061)
</details>
