### PR TITLE
8386626: [lworld] Only enable valhalla IR tests in ScalarReplacementWithGCBarrierTests.java for aarch64 and x86

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
@@ -107,8 +107,10 @@ public class ScalarReplacementWithGCBarrierTests {
     @Test
     @IR(applyIf = {"enable-valhalla", "false"}, phase = { CompilePhase.PHASEIDEAL_BEFORE_EA }, counts = { IRNode.ALLOC, "2" })
     @IR(applyIf = {"enable-valhalla", "false"}, phase = { CompilePhase.ITER_GVN_AFTER_ELIMINATION }, counts = { IRNode.ALLOC, "1"})
-    @IR(applyIf = {"enable-valhalla", "true"}, phase = { CompilePhase.PHASEIDEAL_BEFORE_EA }, counts = { IRNode.ALLOC, "1" })
-    @IR(applyIf = {"enable-valhalla", "true"}, phase = { CompilePhase.ITER_GVN_AFTER_ELIMINATION }, failOn = { IRNode.ALLOC })
+    @IR(applyIf = {"enable-valhalla", "true"}, applyIfPlatformOr = {"x64", "true", "aarch64", "true"},
+        phase = { CompilePhase.PHASEIDEAL_BEFORE_EA }, counts = { IRNode.ALLOC, "1" })
+    @IR(applyIf = {"enable-valhalla", "true"}, applyIfPlatformOr = {"x64", "true", "aarch64", "true"},
+        phase = { CompilePhase.ITER_GVN_AFTER_ELIMINATION }, failOn = { IRNode.ALLOC })
     private int testScalarReplacementWithGCBarrier(List list) {
         Iter iter = list.iter();
         while (true) {


### PR DESCRIPTION
Hi, please consider.

These IR tests seem to depend on calling convention flattening which are only implemented for aarch64 and x86 for now.
I witnessed test failures if `InlineTypePassFieldsAsArgs` & `InlineTypeReturnedAsFields` are set to false.

Testing: verified using the same test on both aarch64 and x86 linux platforms (fastdebug build).


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386626](https://bugs.openjdk.org/browse/JDK-8386626): [lworld] Only enable valhalla IR tests in ScalarReplacementWithGCBarrierTests.java for aarch64 and x86 (**Bug** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - no project role)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2544/head:pull/2544` \
`$ git checkout pull/2544`

Update a local copy of the PR: \
`$ git checkout pull/2544` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2544`

View PR using the GUI difftool: \
`$ git pr show -t 2544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2544.diff">https://git.openjdk.org/valhalla/pull/2544.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2544#issuecomment-4703854374)
</details>
