### PR TITLE
8385886: [lworld] C2 VectorAPI/value type: bad deopt state leads to wrong result

### DIFF
--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -207,19 +207,9 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
       uint in_idx = TypeFunc::Parms;
       for (uint parm_idx = 0; parm_idx < nargs; parm_idx++) {
         if (call->method()->is_scalarized_arg(static_cast<int>(parm_idx))) {
-          bool nullable = call->tf()->domain_sig()->field_at(in_idx)->maybe_null();
-          ciInlineKlass* vk = call->tf()->domain_sig()->field_at(in_idx)->inline_klass();
-          InlineTypeNode* it = InlineTypeNode::make_uninitialized(gvn, vk, !nullable);
-          it->set_oop(gvn, call->in(in_idx));
-          in_idx++;
-          if (nullable) {
-            it->set_null_marker(gvn, call->in(in_idx));
-            in_idx++;
-          }
-          for (int field_idx = 0; field_idx < vk->nof_nonstatic_fields(); field_idx++) {
-            it->set_field_value(field_idx, call->in(in_idx));
-            in_idx++;
-          }
+          bool nullable = call->tf()->domain_sig()->field_at(TypeFunc::Parms + parm_idx)->maybe_null();
+          ciInlineKlass* vk = call->tf()->domain_sig()->field_at(TypeFunc::Parms + parm_idx)->inline_klass();
+          InlineTypeNode* it = InlineTypeNode::make_from_multi(&kit, call, vk, in_idx, true, !nullable);
           kit.push(gvn.transform(it));
         } else {
           kit.push(call->in(in_idx));

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -204,9 +204,29 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
       // Adjust JVMS from post-call to pre-call state: put args on stack
       uint nargs = call->method()->arg_size();
       kit.ensure_stack(kit.sp() + nargs);
-      for (uint i = TypeFunc::Parms; i < call->tf()->domain_sig()->cnt(); i++) {
-        kit.push(call->in(i));
+      uint in_idx = TypeFunc::Parms;
+      for (uint parm_idx = 0; parm_idx < nargs; parm_idx++) {
+        if (call->method()->is_scalarized_arg(static_cast<int>(parm_idx))) {
+          bool nullable = call->tf()->domain_sig()->field_at(in_idx)->maybe_null();
+          ciInlineKlass* vk = call->tf()->domain_sig()->field_at(in_idx)->inline_klass();
+          InlineTypeNode* it = InlineTypeNode::make_uninitialized(gvn, vk, !nullable);
+          it->set_oop(gvn, call->in(in_idx));
+          in_idx++;
+          if (nullable) {
+            it->set_null_marker(gvn, call->in(in_idx));
+            in_idx++;
+          }
+          for (int field_idx = 0; field_idx < vk->nof_nonstatic_fields(); field_idx++) {
+            it->set_field_value(field_idx, call->in(in_idx));
+            in_idx++;
+          }
+          kit.push(gvn.transform(it));
+        } else {
+          kit.push(call->in(in_idx));
+          in_idx++;
+        }
       }
+      assert(in_idx == call->tf()->domain_cc()->cnt(), "should have processed exactly as many input as the scalarized calling convention; %d vs %d", in_idx, call->tf()->domain_cc()->cnt());
       jvms = kit.sync_jvms();
 
       Node* new_vbox = nullptr;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValues.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValues.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test that scalarize_vbox_node treats correctly scalarized value class locals
+ * @bug 8385886
+ * @enablePreview
+ * @modules jdk.incubator.vector
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+EnableVectorSupport
+ *                   -XX:+EnableVectorReboxing
+ *                   -XX:+EnableVectorAggressiveReboxing
+ *                   -XX:+DeoptimizeALot -XX:DeoptimizeALotInterval=1 -XX:DeoptimizeOnlyAt=54
+ *                   -Xbatch
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::dontcompile
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.incubator.vector.*;
+
+public class TestScalarizeVboxWithScalarizedValues {
+    static final VectorSpecies<Integer> SPECIES = IntVector.SPECIES_128;
+    static final int[] array = new int[64];
+
+    static value class MyValue {
+        int a;
+
+        MyValue(int a) {
+            this.a = a;
+        }
+    }
+
+    static int dontcompile(MyValue myVal, IntVector vector) {
+        return myVal.a;
+    }
+
+    static int test(boolean flag, int v) {
+        MyValue myVal = new MyValue(v);
+
+        IntVector v1 = IntVector.fromArray(SPECIES, array, 0);
+        IntVector v2 = IntVector.fromArray(SPECIES, array, SPECIES.length());
+        IntVector vector = flag ? v1 : v2;
+
+        // bci 54 is the invokestatic
+        // and everything C2 needs to do with it (like allocating arrays for vectors with new_array_blob).
+        // myVal is not null, but after deopt, in dontcompile myVal.a throws a NPE.
+        return dontcompile(myVal, vector);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 200_000; i++) {
+            test((i & 1) == 0, i);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValues.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValues.java
@@ -39,6 +39,7 @@
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test
  *                   -XX:CompileCommand=dontinline,${test.main.class}::dontcompile
  *                   ${test.main.class}
+ * @run main ${test.main.class}
  */
 
 package compiler.valhalla.inlinetypes;


### PR DESCRIPTION
The whole problem is there:

https://github.com/openjdk/valhalla/blob/1ca1c8d9301215d43eb0d012cdc42ddbe7549d14/src/hotspot/share/opto/vector.cpp#L204-L210

We are rebuilding the top of the bytecode stack before the call by pushing the arguments. This will end up as the debug inputs for the allocation in `kit.box_vector` (throught the chain `GraphKit::box_vector` -> `GraphKit::set_edges_for_java_call` -> `GraphKit::add_safepoint_edges`). Having the wrong inputs on the allocation means that if it deopts, the bytecode state will be restored wrong.

In a case such as in the test, one of the local is scalarized and takes only one slot on the expression stack (in the bytecode). Meanwhile, for C2, the value is passed scalarized to the call, so we have inputs for the buffer, the null marker, and each field. The current implementation has two issues, the first one is that it iterates with the size of `domain_sig()`, that is the signature as it appears in the Java code. In the example, that will be `MyValue` and `IntVector`, thus a length of 2. But the inputs of `call` will reflect the signature `domain_cc()`, that is with the scalarized calling convention, which will be in the example: oop buffer for `MyValue`, null marker, the integer field, and `IntVector` (length = 4). So, the current code fails to gather all locals entirely. But replacing `domain_sig` with `domain_cc` isn't enough either. If we do that, we do collect everything, but they end up as independent values on the bytecode expression stack. This is visible in the opto assembly:
```
19b     call,static  wrapper for: new_array_blob (C2 runtime)
        # ...::test @ bci:54 (line 45) L[0]=RBP L[1]=rsp + #4 L[2]=#ScObj0 L[3]=#ScObj1 L[4]=#ScObj2 L[5]=#ScObj3 STK[0]=#null STK[1]=#1 STK[2]=rsp + #4 STK[3]=#ScObj3
        # ScObj0 ...$MyValue={ [null marker :-1]=#1 [a :0]=rsp + #4 }
        # ScObj1 jdk/incubator/vector/IntVector128={ [payload :0]=rsp + #32 }
        # ScObj2 jdk/incubator/vector/IntVector128={ [payload :0]=rsp + #16 }
        # ScObj3 jdk/incubator/vector/IntVector128={ [payload :0]=rsp + #48 }
        # OopMap {off=416/0x1a0}
```
Here, it looks like the stack should have 4 slots (instead of 2), and we can recognize the slots 0, 1 and 2 that forms actually the value `myVal`. But as a result, after deoptimization, the interpreter is given a state that is not correct.

So, on top of actually iterating over all the inputs of `call` we also need to group them inside an `InlineType` (that will be scalarized in safepoint later, thanks to `InlineTypeNode` logic). The logic is quite simple: we iterate over the Java arguments, and when it is scalarized, we gather the pieces using the type to know how many fields to get. Otherwise, the next input is the argument by itself. Doing so, we can see that the opto assembly looks more reasonable:
```
19b     call,static  wrapper for: new_array_blob (C2 runtime)
        # ...::test @ bci:54 (line 37) L[0]=RBP L[1]=rsp + #4 L[2]=#ScObj0 L[3]=#ScObj1 L[4]=#ScObj2 L[5]=#ScObj3 STK[0]=#ScObj0 STK[1]=#ScObj3
        # ScObj0 ...$MyValue={ [null marker :-1]=#1 [a :0]=rsp + #4 }
        # ScObj1 jdk/incubator/vector/IntVector128={ [payload :0]=rsp + #32 }
        # ScObj2 jdk/incubator/vector/IntVector128={ [payload :0]=rsp + #16 }
        # ScObj3 jdk/incubator/vector/IntVector128={ [payload :0]=rsp + #48 }
        # OopMap {off=416/0x1a0}
```

The bytecode is given a stack containing the buffered `MyValue` and the `IntVector`: all is fine!

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385886](https://bugs.openjdk.org/browse/JDK-8385886): [lworld] C2 VectorAPI/value type: bad deopt state leads to wrong result (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2547/head:pull/2547` \
`$ git checkout pull/2547`

Update a local copy of the PR: \
`$ git checkout pull/2547` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2547`

View PR using the GUI difftool: \
`$ git pr show -t 2547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2547.diff">https://git.openjdk.org/valhalla/pull/2547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2547#issuecomment-4707682791)
</details>
