### PR TITLE
8386702: [lworld] Reflection APIs should not allow strictly-initialized final fields to be mutated

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3445,6 +3445,11 @@ return mh1;
                                                   : "final field has no write access";
                     throw field.makeAccessException(msg, this);
                 }
+                // strictly-initialized finals not trusted finals at this time
+                if (field.isStrictInit()) {
+                    throw field.makeAccessException("strictly-initialized final field has no write access", this);
+                }
+
                 // check if write access to final field allowed
                 if (!field.isStatic() && isAccessible) {
                     SharedSecrets.getJavaLangReflectAccess().checkAllowedToUnreflectFinalSetter(lookupClass, f);

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -1523,12 +1523,6 @@ class Field extends AccessibleObject implements Member {
     private void preSetFinal(Class<?> caller, boolean unreflect) throws IllegalAccessException {
         assert isFinalInstanceInNormalClass();
 
-        // strictly-initialized final fields cannot be mutated
-        if (isStrictInit()) {
-            throw new IllegalAccessException(cannotSetFieldMessage("Can not", unreflect)
-                    + " (strictly-initialized field)");
-        }
-
         if (caller != null) {
             // check if declaring class in package that is open to caller, or public field
             // and declaring class is public in package exported to caller

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -190,6 +190,7 @@ class Field extends AccessibleObject implements Member {
      * <li>static final fields declared in any class or interface</li>
      * <li>final fields declared in a {@linkplain Class#isRecord() record}</li>
      * <li>final fields declared in a {@linkplain Class#isHidden() hidden class}</li>
+     * <li>{@linkplain #isStrictInit() strictly-initialized} final fields</li>
      * </ul>
      * <p>If this reflected object represents a non-static final field in a class that
      * is not a record class or hidden class, then enabling access will enable read
@@ -841,6 +842,7 @@ class Field extends AccessibleObject implements Member {
      * <li>{@code D} is not a {@linkplain Class#isHidden() hidden class}.</li>
      * <li>{@code D} is not a {@linkplain Class#isValue() value class}.</li>
      * <li>The field is non-static.</li>
+     * <li>The field is not a {@linkplain #isStrictInit() strictly-initialized} field. </li>
      * </ul>
      *
      * <p>If any of the above conditions is not met, this method throws an
@@ -870,6 +872,7 @@ class Field extends AccessibleObject implements Member {
      * <li>{@code D} is not a {@linkplain Class#isRecord() record class}.</li>
      * <li>{@code D} is not a {@linkplain Class#isHidden() hidden class}.</li>
      * <li>The field is non-static.</li>
+     * <li>The field is not a {@linkplain #isStrictInit() strictly-initialized} field. </li>
      * </ul>
      *
      * <p>If any of the above conditions is not met, this method throws an

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -190,12 +190,12 @@ class Field extends AccessibleObject implements Member {
      * <li>static final fields declared in any class or interface</li>
      * <li>final fields declared in a {@linkplain Class#isRecord() record}</li>
      * <li>final fields declared in a {@linkplain Class#isHidden() hidden class}</li>
+     * <li>fields declared in a {@linkplain Class#isValue() value class}</li>
      * <li>{@linkplain #isStrictInit() strictly-initialized} final fields</li>
      * </ul>
-     * <p>If this reflected object represents a non-static final field in a class that
-     * is not a record class or hidden class, then enabling access will enable read
-     * access. Whether write access is allowed or not is checked when attempting to
-     * {@linkplain #set(Object, Object) set} the field value.
+     * <p>Final fields that are not covered by this list may be <em>modifiable</em>.
+     * Enabling access will enable read access. Whether write access is allowed is
+     * checked when attempting to {@linkplain #set(Object, Object) set} the field value.
      *
      * @throws InaccessibleObjectException {@inheritDoc}
      */
@@ -871,6 +871,7 @@ class Field extends AccessibleObject implements Member {
      *     is {@linkplain Module#isExported(String) exported} to all modules.</li>
      * <li>{@code D} is not a {@linkplain Class#isRecord() record class}.</li>
      * <li>{@code D} is not a {@linkplain Class#isHidden() hidden class}.</li>
+     * <li>{@code D} is not a {@linkplain Class#isValue() value class}.</li>
      * <li>The field is non-static.</li>
      * <li>The field is not a {@linkplain #isStrictInit() strictly-initialized} field. </li>
      * </ul>

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -1520,6 +1520,12 @@ class Field extends AccessibleObject implements Member {
     private void preSetFinal(Class<?> caller, boolean unreflect) throws IllegalAccessException {
         assert isFinalInstanceInNormalClass();
 
+        // strictly-initialized final fields cannot be mutated
+        if (isStrictInit()) {
+            throw new IllegalAccessException(cannotSetFieldMessage("Can not", unreflect)
+                    + " (strictly-initialized field)");
+        }
+
         if (caller != null) {
             // check if declaring class in package that is open to caller, or public field
             // and declaring class is public in package exported to caller

--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -105,7 +105,7 @@ public class ReflectionFactory {
             }
         }
         boolean isFinal = Modifier.isFinal(field.getModifiers());
-        boolean isReadOnly = isFinal && (!override || langReflectAccess.isTrustedFinalField(field));
+        boolean isReadOnly = isFinal && (!override || langReflectAccess.isTrustedFinalField(field) || field.isStrictInit());
         return MethodHandleAccessorFactory.newFieldAccessor(field, isReadOnly);
     }
 

--- a/test/jdk/java/lang/reflect/Field/StrictInitFinalFields.java
+++ b/test/jdk/java/lang/reflect/Field/StrictInitFinalFields.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test Field access to strictly-initialized final fields
+ * @enablePreview
+ * @library /test/lib
+ * @build ${test.main.class}
+ * @run driver jdk.test.lib.helpers.StrictProcessor StrictInitFinalFields$TestClass
+ * @run junit/othervm --enable-final-field-mutation=ALL-UNNAMED ${test.main.class}
+ * @run junit/othervm --illegal-final-field-mutation=allow ${test.main.class}
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import jdk.test.lib.helpers.StrictInit;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class StrictInitFinalFields {
+
+    /**
+     * Test class with strictly-initialized final fields.
+     */
+    static class TestClass {
+        @StrictInit
+        private static final int DEFAULT_VALUE;
+        static {
+            DEFAULT_VALUE = 100;
+        }
+
+        @StrictInit
+        private final int value;
+
+        TestClass() {
+            this.value = DEFAULT_VALUE;
+            super();
+        }
+
+        TestClass(int i) {
+            this.value = i;
+            super();
+        }
+    }
+
+    /**
+     * Get/set strictly initialized static field.
+     */
+    @Test
+    void testStaticField() throws Throwable {
+        Field field = TestClass.class.getDeclaredField("DEFAULT_VALUE");
+        assertTrue(field.isStrictInit());
+        field.setAccessible(true);
+
+        int initialValue = TestClass.DEFAULT_VALUE;
+        int newValue = initialValue + 100;
+
+        // Field.get/set
+        assertEquals(initialValue, field.get(null));
+        assertThrows(IllegalAccessException.class, () -> field.set(null, newValue));
+
+        // VarHandle produced from reflected field
+        var lookup = MethodHandles.lookup();
+        VarHandle vh = lookup.unreflectVarHandle(field);
+        assertEquals(initialValue, vh.get());
+        assertThrows(UnsupportedOperationException.class, () -> vh.set(newValue));
+
+        // Method handles produced from reflected field
+        assertEquals(initialValue, (int) lookup.unreflectGetter(field).invokeExact());
+        assertThrows(IllegalAccessException.class, () -> lookup.unreflectSetter(field));
+
+        MethodHandle mh = lookup.findStaticGetter(TestClass.class, "DEFAULT_VALUE", int.class);
+        assertEquals(initialValue, (int) mh.invokeExact());
+        assertThrows(IllegalAccessException.class,
+                () -> lookup.findStaticSetter(TestClass.class, "DEFAULT_VALUE", int.class));
+
+        assertEquals(initialValue, TestClass.DEFAULT_VALUE);  // check unchanged
+    }
+
+    /**
+     * Get/set strictly initialized instance field.
+     */
+    @Test
+    void testInstanceField() throws Throwable {
+        Field field = TestClass.class.getDeclaredField("value");
+        assertTrue(field.isStrictInit());
+        field.setAccessible(true);
+
+        var obj = new TestClass(150);
+        int initialValue = obj.value;
+        int newValue = initialValue + 100;
+
+        // Field.get/set
+        assertEquals(initialValue, field.get(obj));
+        assertThrows(IllegalAccessException.class, () -> field.set(obj, newValue));
+
+        // VarHandle produced from reflected field
+        var lookup = MethodHandles.lookup();
+        VarHandle vh = lookup.unreflectVarHandle(field);
+        assertEquals(initialValue, vh.get(obj));
+        assertThrows(UnsupportedOperationException.class, () -> vh.set(obj, newValue));
+
+        // Method handles produced from reflected field
+        assertEquals(initialValue, (int) lookup.unreflectGetter(field).invokeExact(obj));
+        assertThrows(IllegalAccessException.class, () -> lookup.unreflectSetter(field));
+
+        MethodHandle mh = lookup.findGetter(TestClass.class, "value", int.class);
+        assertEquals(initialValue, (int) mh.invokeExact(obj));
+        assertThrows(IllegalAccessException.class,
+                () -> lookup.findSetter(TestClass.class, "value", int.class));
+
+        assertEquals(initialValue, obj.value);  // check unchanged
+    }
+}

--- a/test/jdk/java/lang/reflect/Field/StrictInitFinalFields.java
+++ b/test/jdk/java/lang/reflect/Field/StrictInitFinalFields.java
@@ -75,12 +75,17 @@ class StrictInitFinalFields {
     void testStaticField() throws Throwable {
         Field field = TestClass.class.getDeclaredField("DEFAULT_VALUE");
         assertTrue(field.isStrictInit());
-        field.setAccessible(true);
 
         int initialValue = TestClass.DEFAULT_VALUE;
         int newValue = initialValue + 100;
 
-        // Field.get/set
+        // Field.get/set before setAccessible
+        assertEquals(initialValue, field.get(null));
+        assertThrows(IllegalAccessException.class, () -> field.set(null, newValue));
+
+        field.setAccessible(true);
+
+        // Field.get/set after setAccessible
         assertEquals(initialValue, field.get(null));
         assertThrows(IllegalAccessException.class, () -> field.set(null, newValue));
 
@@ -109,13 +114,17 @@ class StrictInitFinalFields {
     void testInstanceField() throws Throwable {
         Field field = TestClass.class.getDeclaredField("value");
         assertTrue(field.isStrictInit());
-        field.setAccessible(true);
 
         var obj = new TestClass(150);
         int initialValue = obj.value;
         int newValue = initialValue + 100;
 
-        // Field.get/set
+        // Field.get/set before setAccessible
+        assertEquals(initialValue, field.get(obj));
+        assertThrows(IllegalAccessException.class, () -> field.set(obj, newValue));
+
+        // Field.get/set after setAccessible
+        field.setAccessible(true);
         assertEquals(initialValue, field.get(obj));
         assertThrows(IllegalAccessException.class, () -> field.set(obj, newValue));
 


### PR DESCRIPTION
Using the reflection APIs to mutate a strictly-initialized final instance field should fail with IllegalAccessException.

The list of conditions in Field.set and setAccessible are also updated.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386702](https://bugs.openjdk.org/browse/JDK-8386702): [lworld] Reflection APIs should not allow strictly-initialized final fields to be mutated (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2548/head:pull/2548` \
`$ git checkout pull/2548`

Update a local copy of the PR: \
`$ git checkout pull/2548` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2548`

View PR using the GUI difftool: \
`$ git pr show -t 2548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2548.diff">https://git.openjdk.org/valhalla/pull/2548.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2548#issuecomment-4718207085)
</details>
