### PR TITLE
8386677: [lworld] VarHandle does not implement strict static checks

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LazyInitializingVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/LazyInitializingVarHandle.java
@@ -1,38 +1,37 @@
 /*
- *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- *  This code is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License version 2 only, as
- *  published by the Free Software Foundation.  Oracle designates this
- *  particular file as subject to the "Classpath" exception as provided
- *  by Oracle in the LICENSE file that accompanied this code.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
- *  This code is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  version 2 for more details (a copy is included in the LICENSE file that
- *  accompanied this code).
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
  *
- *  You should have received a copy of the GNU General Public License version
- *  2 along with this work; if not, write to the Free Software Foundation,
- *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- *  or visit www.oracle.com if you need additional information or have any
- *  questions.
- *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package java.lang.invoke;
 
+import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Stable;
 
 import java.util.Optional;
 
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
-import static java.lang.invoke.MethodHandleStatics.uncaughtException;
 
 /**
  * A lazy initializing var handle. It lazily initializes the referenced class before
@@ -41,17 +40,14 @@ import static java.lang.invoke.MethodHandleStatics.uncaughtException;
  */
 final class LazyInitializingVarHandle extends VarHandle {
 
-    // Implementation notes:
-    // We put a barrier on both target() (for VH form impl direct invocation)
-    // and on getMethodHandle() (for indirect VH invocation, toMethodHandle)
-    private final VarHandle target;
-    private final Class<?> refc;
-    private @Stable boolean initialized;
+    private final VarHandles.StaticFieldVarHandle target;
+    private final boolean strictInit;
+    private @Stable boolean fullyInitialized;
 
-    LazyInitializingVarHandle(VarHandle target, Class<?> refc) {
+    LazyInitializingVarHandle(VarHandles.StaticFieldVarHandle target, boolean strictInit) {
         super(target.vform, target.exact);
         this.target = target;
-        this.refc = refc;
+        this.strictInit = strictInit;
     }
 
     @Override
@@ -61,31 +57,50 @@ final class LazyInitializingVarHandle extends VarHandle {
 
     @Override
     @ForceInline
-    VarHandle asDirect() {
+    VarHandle onStaticFieldAccess(boolean read, boolean write) {
+        if (!fullyInitialized) {
+            initialize(read, write);
+        }
         return target;
     }
 
-    @Override
-    @ForceInline
-    VarHandle target() {
-        ensureInitialized();
-        return target;
+    @DontInline
+    private void initialize(boolean read, boolean write) {
+        var declaringClass = target.declaringClass;
+        UNSAFE.ensureClassInitialized(declaringClass);
+        boolean fullyInitialized = !UNSAFE.shouldBeInitialized(declaringClass);
+        if (fullyInitialized) {
+            this.fullyInitialized = true;
+            this.methodHandleTable = target.methodHandleTable;
+            return;
+        }
+
+        // Not fully initialized - strict static checking
+        if (strictInit) {
+            long offset = target.fieldOffset;
+            if (read) {
+                UNSAFE.notifyStrictStaticAccess(declaringClass, offset, false);
+            }
+            if (write) {
+                UNSAFE.notifyStrictStaticAccess(declaringClass, offset, true);
+            }
+        }
     }
 
     @Override
     public VarHandle withInvokeExactBehavior() {
-        if (!initialized && hasInvokeExactBehavior())
+        if (!fullyInitialized && hasInvokeExactBehavior())
             return this;
         var exactTarget = target.withInvokeExactBehavior();
-        return initialized ? exactTarget : new LazyInitializingVarHandle(exactTarget, refc);
+        return fullyInitialized ? exactTarget : new LazyInitializingVarHandle(exactTarget, strictInit);
     }
 
     @Override
     public VarHandle withInvokeBehavior() {
-        if (!initialized && !hasInvokeExactBehavior())
+        if (!fullyInitialized && !hasInvokeExactBehavior())
             return this;
         var nonExactTarget = target.withInvokeBehavior();
-        return initialized ? nonExactTarget : new LazyInitializingVarHandle(nonExactTarget, refc);
+        return fullyInitialized ? nonExactTarget : new LazyInitializingVarHandle(nonExactTarget, strictInit);
     }
 
     @Override
@@ -95,42 +110,9 @@ final class LazyInitializingVarHandle extends VarHandle {
 
     @Override
     public MethodHandle getMethodHandleUncached(int accessMode) {
-        var mh = target.getMethodHandle(accessMode);
-        if (this.initialized)
-            return mh;
+        if (fullyInitialized)
+            return target.getMethodHandle(accessMode);
 
-        return MethodHandles.collectArguments(mh, 0, ensureInitializedMh()).bindTo(this);
-    }
-
-    @ForceInline
-    private void ensureInitialized() {
-        if (this.initialized)
-            return;
-
-        initialize();
-    }
-
-    private void initialize() {
-        UNSAFE.ensureClassInitialized(refc);
-        this.initialized = true;
-
-        this.methodHandleTable = target.methodHandleTable;
-    }
-
-    private static @Stable MethodHandle MH_ensureInitialized;
-
-    private static MethodHandle ensureInitializedMh() {
-        var mh = MH_ensureInitialized;
-        if (mh != null)
-            return mh;
-
-        try {
-            return MH_ensureInitialized = MethodHandles.lookup().findVirtual(
-                    LazyInitializingVarHandle.class,
-                    "ensureInitialized",
-                    MethodType.methodType(void.class));
-        } catch (Throwable ex) {
-            throw uncaughtException(ex);
-        }
+        return super.getMethodHandleUncached(accessMode);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/LazyInitializingVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/LazyInitializingVarHandle.java
@@ -57,33 +57,31 @@ final class LazyInitializingVarHandle extends VarHandle {
 
     @Override
     @ForceInline
-    VarHandle onStaticFieldAccess(boolean read, boolean write) {
+    VarHandle onStaticFieldAccess(boolean reading) {
         if (!fullyInitialized) {
-            initialize(read, write);
+            initialize(reading);
         }
         return target;
     }
 
     @DontInline
-    private void initialize(boolean read, boolean write) {
+    private void initialize(boolean reading) {
         var declaringClass = target.declaringClass;
         UNSAFE.ensureClassInitialized(declaringClass);
         boolean fullyInitialized = !UNSAFE.shouldBeInitialized(declaringClass);
         if (fullyInitialized) {
             this.fullyInitialized = true;
-            this.methodHandleTable = target.methodHandleTable;
             return;
         }
 
         // Not fully initialized - strict static checking
         if (strictInit) {
             long offset = target.fieldOffset;
-            if (read) {
-                UNSAFE.notifyStrictStaticAccess(declaringClass, offset, false);
-            }
-            if (write) {
-                UNSAFE.notifyStrictStaticAccess(declaringClass, offset, true);
-            }
+            // We only check for reading for CAS because they always access
+            // reads first. We don't need the extra write check for CAS because
+            // that check is only to avoid double writing final fields, and we
+            // never allow creating VarHandle that CAS on final fields.
+            UNSAFE.notifyStrictStaticAccess(declaringClass, offset, !reading);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/LazyInitializingVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/LazyInitializingVarHandle.java
@@ -105,12 +105,4 @@ final class LazyInitializingVarHandle extends VarHandle {
     public Optional<VarHandleDesc> describeConstable() {
         return target.describeConstable();
     }
-
-    @Override
-    public MethodHandle getMethodHandleUncached(int accessMode) {
-        if (fullyInitialized)
-            return target.getMethodHandle(accessMode);
-
-        return super.getMethodHandleUncached(accessMode);
-    }
 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3961,7 +3961,7 @@ return mh1;
                 refc = lookupClass();
             }
             return VarHandles.makeFieldHandle(getField, refc,
-                                              this.allowedModes == TRUSTED && !getField.isTrustedFinalField());
+                                              this.allowedModes == TRUSTED);
         }
         /** Check access and get the requested constructor. */
         private MethodHandle getDirectConstructor(Class<?> refc, MemberName ctor) throws IllegalAccessException {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -473,7 +473,7 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
  */
 public abstract sealed class VarHandle implements Constable
      permits IndirectVarHandle, LazyInitializingVarHandle, SegmentVarHandle,
-             ArrayVarHandle,
+             ArrayVarHandle, VarHandles.StaticFieldVarHandle,
              VarHandleByteArrayAsChars.ByteArrayViewVarHandle,
              VarHandleByteArrayAsDoubles.ByteArrayViewVarHandle,
              VarHandleByteArrayAsFloats.ByteArrayViewVarHandle,
@@ -482,33 +482,23 @@ public abstract sealed class VarHandle implements Constable
              VarHandleByteArrayAsShorts.ByteArrayViewVarHandle,
              VarHandleBooleans.Array,
              VarHandleBooleans.FieldInstanceReadOnly,
-             VarHandleBooleans.FieldStaticReadOnly,
              VarHandleBytes.Array,
              VarHandleBytes.FieldInstanceReadOnly,
-             VarHandleBytes.FieldStaticReadOnly,
              VarHandleChars.Array,
              VarHandleChars.FieldInstanceReadOnly,
-             VarHandleChars.FieldStaticReadOnly,
              VarHandleDoubles.Array,
              VarHandleDoubles.FieldInstanceReadOnly,
-             VarHandleDoubles.FieldStaticReadOnly,
              VarHandleFloats.Array,
              VarHandleFloats.FieldInstanceReadOnly,
-             VarHandleFloats.FieldStaticReadOnly,
              VarHandleInts.Array,
              VarHandleInts.FieldInstanceReadOnly,
-             VarHandleInts.FieldStaticReadOnly,
              VarHandleLongs.Array,
              VarHandleLongs.FieldInstanceReadOnly,
-             VarHandleLongs.FieldStaticReadOnly,
              VarHandleReferences.FieldInstanceReadOnly,
-             VarHandleReferences.FieldStaticReadOnly,
              VarHandleShorts.Array,
              VarHandleShorts.FieldInstanceReadOnly,
-             VarHandleShorts.FieldStaticReadOnly,
              VarHandleFlatValues.FieldInstanceReadOnly,
              VarHandleNonAtomicReferences.FieldInstanceReadOnly,
-             VarHandleNonAtomicReferences.FieldStaticReadOnly,
              VarHandleNonAtomicFlatValues.FieldInstanceReadOnly {
     final VarForm vform;
     final boolean exact;
@@ -523,17 +513,19 @@ public abstract sealed class VarHandle implements Constable
     }
 
     /**
-     * Returns the target VarHandle.   Subclasses may override this method to implement
-     * additional logic for example lazily initializing the declaring class of a static field var handle.
+     * A barrier for accessing a target var handle used by static var handle
+     * implementation methods.  This allows initialization barriers and strict
+     * field initialization checks.
      */
     @ForceInline
-    VarHandle target() {
-        return asDirect();
+    VarHandle onStaticFieldAccess(boolean read, boolean write) {
+        return this;
     }
 
     /**
-     * Returns the direct target VarHandle.   Indirect VarHandle subclasses should implement
-     * this method.
+     * Returns the direct VarHandle, passed into the method handle that perform
+     * conversions or has the actual implementation when this VarHandle is
+     * indirect.
      *
      * @see #getMethodHandle(int)
      * @see #checkAccessModeThenIsDirect(AccessDescriptor)

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -516,9 +516,11 @@ public abstract sealed class VarHandle implements Constable
      * A barrier for accessing a target var handle used by static var handle
      * implementation methods.  This allows initialization barriers and strict
      * field initialization checks.
+     *
+     * @param reading whether this access performs any read
      */
     @ForceInline
-    VarHandle onStaticFieldAccess(boolean read, boolean write) {
+    VarHandle onStaticFieldAccess(boolean reading) {
         return this;
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -132,12 +132,43 @@ final class VarHandles {
             Class<?> decl = f.getDeclaringClass();
             var vh = makeStaticFieldVarHandle(decl, f, isWriteAllowedOnFinalFields);
             return maybeAdapt((UNSAFE.shouldBeInitialized(decl) || CDS.needsClassInitBarrier(decl))
-                    ? new LazyInitializingVarHandle(vh, decl)
+                    ? new LazyInitializingVarHandle(vh, f.isStrictInit())
                     : vh);
         }
     }
 
-    static VarHandle makeStaticFieldVarHandle(Class<?> decl, MemberName f, boolean isWriteAllowedOnFinalFields) {
+    /// A root class for static field var handles. Allows [LazyInitializingVarHandle]
+    /// to access the declaring class and field offsets.
+    sealed static abstract class StaticFieldVarHandle extends VarHandle permits
+            VarHandleBooleans.FieldStaticReadOnly,
+            VarHandleBytes.FieldStaticReadOnly,
+            VarHandleChars.FieldStaticReadOnly,
+            VarHandleShorts.FieldStaticReadOnly,
+            VarHandleInts.FieldStaticReadOnly,
+            VarHandleLongs.FieldStaticReadOnly,
+            VarHandleFloats.FieldStaticReadOnly,
+            VarHandleDoubles.FieldStaticReadOnly,
+            VarHandleReferences.FieldStaticReadOnly,
+            VarHandleNonAtomicReferences.FieldStaticReadOnly {
+        final Class<?> declaringClass;
+        final Object base;
+        final long fieldOffset;
+
+        StaticFieldVarHandle(VarForm vform, boolean exact, Class<?> declaringClass, Object base, long fieldOffset) {
+            this.declaringClass = declaringClass;
+            this.base = base;
+            this.fieldOffset = fieldOffset;
+            super(vform, exact);
+        }
+
+        @Override
+        public abstract StaticFieldVarHandle withInvokeBehavior();
+
+        @Override
+        public abstract StaticFieldVarHandle withInvokeExactBehavior();
+    }
+
+    static StaticFieldVarHandle makeStaticFieldVarHandle(Class<?> decl, MemberName f, boolean isWriteAllowedOnFinalFields) {
         Object base = MethodHandleNatives.staticFieldBase(f);
         long foffset = MethodHandleNatives.staticFieldOffset(f);
         Class<?> type = f.getFieldType();
@@ -149,9 +180,9 @@ final class VarHandles {
                             ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
                             : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted());
                 } else {
-                    return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                    return f.isFinal() && !isWriteAllowedOnFinalFields
                             ? new VarHandleNonAtomicReferences.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
-                            : new VarHandleNonAtomicReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted()));
+                            : new VarHandleNonAtomicReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted());
                 }
             } else {
                 return f.isFinal() && !isWriteAllowedOnFinalFields
@@ -160,44 +191,44 @@ final class VarHandles {
             }
         }
         else if (type == boolean.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleBooleans.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleBooleans.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleBooleans.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == byte.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleBytes.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleBytes.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleBytes.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == short.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleShorts.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleShorts.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleShorts.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == char.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleChars.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleChars.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleChars.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == int.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleInts.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleInts.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleInts.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == long.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleLongs.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleLongs.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleLongs.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == float.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleFloats.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleFloats.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleFloats.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == double.class) {
-            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+            return f.isFinal() && !isWriteAllowedOnFinalFields
                     ? new VarHandleDoubles.FieldStaticReadOnly(decl, base, foffset)
-                    : new VarHandleDoubles.FieldStaticReadWrite(decl, base, foffset));
+                    : new VarHandleDoubles.FieldStaticReadWrite(decl, base, foffset);
         }
         else {
             throw new UnsupportedOperationException();

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -48,7 +48,8 @@ import static java.lang.invoke.MethodHandleStatics.newIllegalArgumentException;
 
 final class VarHandles {
 
-    static VarHandle makeFieldHandle(MemberName f, Class<?> refc, boolean isWriteAllowedOnFinalFields) {
+    static VarHandle makeFieldHandle(MemberName f, Class<?> refc, boolean trusted) {
+        boolean noWriting = f.isFinal() && (!trusted || f.isStrictInit());
         if (!f.isStatic()) {
             long foffset = MethodHandleNatives.objectFieldOffset(f);
             Class<?> type = f.getFieldType();
@@ -59,68 +60,68 @@ final class VarHandles {
                     boolean isFlat = f.isFlat();
                     if (isFlat) {
                         if (isAtomic) {
-                            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                            return maybeAdapt(noWriting
                                     ? new VarHandleFlatValues.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted(), layout)
                                     : new VarHandleFlatValues.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted(), layout));
                         } else {
-                            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                            return maybeAdapt(noWriting
                                     ? new VarHandleNonAtomicFlatValues.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted(), layout)
                                     : new VarHandleNonAtomicFlatValues.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted(), layout));
                         }
                     } else {
                         if (isAtomic) {
-                            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                            return maybeAdapt(noWriting
                                     ? new VarHandleReferences.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted())
                                     : new VarHandleReferences.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted()));
                         } else {
-                            return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                            return maybeAdapt(noWriting
                                     ? new VarHandleNonAtomicReferences.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted())
                                     : new VarHandleNonAtomicReferences.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted()));
                         }
                     }
                 } else {
-                    return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                    return maybeAdapt(noWriting
                        ? new VarHandleReferences.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted())
                        : new VarHandleReferences.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted()));
                 }
             }
             else if (type == boolean.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleBooleans.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleBooleans.FieldInstanceReadWrite(refc, foffset));
             }
             else if (type == byte.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleBytes.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleBytes.FieldInstanceReadWrite(refc, foffset));
             }
             else if (type == short.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleShorts.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleShorts.FieldInstanceReadWrite(refc, foffset));
             }
             else if (type == char.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleChars.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleChars.FieldInstanceReadWrite(refc, foffset));
             }
             else if (type == int.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleInts.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleInts.FieldInstanceReadWrite(refc, foffset));
             }
             else if (type == long.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleLongs.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleLongs.FieldInstanceReadWrite(refc, foffset));
             }
             else if (type == float.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleFloats.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleFloats.FieldInstanceReadWrite(refc, foffset));
             }
             else if (type == double.class) {
-                return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
+                return maybeAdapt(noWriting
                        ? new VarHandleDoubles.FieldInstanceReadOnly(refc, foffset)
                        : new VarHandleDoubles.FieldInstanceReadWrite(refc, foffset));
             }
@@ -130,7 +131,7 @@ final class VarHandles {
         }
         else {
             Class<?> decl = f.getDeclaringClass();
-            var vh = makeStaticFieldVarHandle(decl, f, isWriteAllowedOnFinalFields);
+            var vh = makeStaticFieldVarHandle(decl, f, noWriting);
             return maybeAdapt((UNSAFE.shouldBeInitialized(decl) || CDS.needsClassInitBarrier(decl))
                     ? new LazyInitializingVarHandle(vh, f.isStrictInit())
                     : vh);
@@ -168,7 +169,7 @@ final class VarHandles {
         public abstract StaticFieldVarHandle withInvokeExactBehavior();
     }
 
-    static StaticFieldVarHandle makeStaticFieldVarHandle(Class<?> decl, MemberName f, boolean isWriteAllowedOnFinalFields) {
+    static StaticFieldVarHandle makeStaticFieldVarHandle(Class<?> decl, MemberName f, boolean noWriting) {
         Object base = MethodHandleNatives.staticFieldBase(f);
         long foffset = MethodHandleNatives.staticFieldOffset(f);
         Class<?> type = f.getFieldType();
@@ -176,57 +177,57 @@ final class VarHandles {
             assert !f.isFlat() : ("static field is flat in " + decl + "." + f.getName());
             if (ValueClass.isConcreteValueClass(type)) {
                 if (isAtomicFlat(f)) {
-                    return f.isFinal() && !isWriteAllowedOnFinalFields
+                    return noWriting
                             ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
                             : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted());
                 } else {
-                    return f.isFinal() && !isWriteAllowedOnFinalFields
+                    return noWriting
                             ? new VarHandleNonAtomicReferences.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
                             : new VarHandleNonAtomicReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted());
                 }
             } else {
-                return f.isFinal() && !isWriteAllowedOnFinalFields
+                return noWriting
                         ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
                         : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted());
             }
         }
         else if (type == boolean.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleBooleans.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleBooleans.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == byte.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleBytes.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleBytes.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == short.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleShorts.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleShorts.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == char.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleChars.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleChars.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == int.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleInts.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleInts.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == long.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleLongs.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleLongs.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == float.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleFloats.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleFloats.FieldStaticReadWrite(decl, base, foffset);
         }
         else if (type == double.class) {
-            return f.isFinal() && !isWriteAllowedOnFinalFields
+            return noWriting
                     ? new VarHandleDoubles.FieldStaticReadOnly(decl, base, foffset)
                     : new VarHandleDoubles.FieldStaticReadWrite(decl, base, foffset);
         }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -48,8 +48,9 @@ import static java.lang.invoke.MethodHandleStatics.newIllegalArgumentException;
 
 final class VarHandles {
 
-    static VarHandle makeFieldHandle(MemberName f, Class<?> refc, boolean trusted) {
-        boolean noWriting = f.isFinal() && (!trusted || f.isStrictInit());
+    static VarHandle makeFieldHandle(MemberName f, Class<?> refc, boolean trustedLookup) {
+        // No strict final or trusted final writes: we don't know the lifecycle of such a field.
+        boolean noWriting = f.isFinal() && (!trustedLookup || f.isStrictInit() || f.isTrustedFinalField());
         if (!f.isStatic()) {
             long foffset = MethodHandleNatives.objectFieldOffset(f);
             Class<?> type = f.getFieldType();

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -58,7 +58,6 @@ final class VarHandle$InputType$s {
 
         protected FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}{#if[FlatValue]?, int layout},
                                         VarForm form, boolean exact) {
-            super(form, exact);
             this.fieldOffset = fieldOffset;
             this.receiverType = receiverType;
 #if[Object]
@@ -68,6 +67,7 @@ final class VarHandle$InputType$s {
 #if[FlatValue]
             this.layout = layout;
 #end[FlatValue]
+            super(form, exact);
         }
 
         @Override
@@ -432,10 +432,7 @@ final class VarHandle$InputType$s {
     }
 
 #if[Static]
-    static sealed class FieldStaticReadOnly extends VarHandle {
-        final Class<?> declaringClass;
-        final Object base;
-        final long fieldOffset;
+    static sealed class FieldStaticReadOnly extends VarHandles.StaticFieldVarHandle {
 #if[Object]
         final Class<?> fieldType;
         final boolean nullRestricted;
@@ -450,10 +447,6 @@ final class VarHandle$InputType$s {
 
         protected FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}{#if[FlatValue]?, int layout},
                                       VarForm form, boolean exact) {
-            super(form, exact);
-            this.declaringClass = declaringClass;
-            this.base = base;
-            this.fieldOffset = fieldOffset;
 #if[Object]
             this.fieldType = fieldType;
             this.nullRestricted = nullRestricted;
@@ -461,6 +454,7 @@ final class VarHandle$InputType$s {
 #if[FlatValue]
             this.layout = layout;
 #end[FlatValue]
+            super(form, exact, declaringClass, base, fieldOffset);
         }
 
         @Override
@@ -499,7 +493,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ get(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
             $type$ value = UNSAFE.get$Type$(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -513,7 +507,7 @@ final class VarHandle$InputType$s {
 #if[NonPlainAccess]
         @ForceInline
         static $type$ getVolatile(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
             $type$ value = UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -526,7 +520,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getOpaque(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
             $type$ value = UNSAFE.get$Type$Opaque(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -539,7 +533,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAcquire(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
             $type$ value = UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -588,7 +582,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static void set(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
             UNSAFE.put$Type$(handle.base,
                              handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                              {#if[Object]?checkCast(handle, value):value});
@@ -597,7 +591,7 @@ final class VarHandle$InputType$s {
 #if[NonPlainAccess]
         @ForceInline
         static void setVolatile(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
             UNSAFE.put$Type$Volatile(handle.base,
                                      handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                                      {#if[Object]?checkCast(handle, value):value});
@@ -605,7 +599,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static void setOpaque(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
             UNSAFE.put$Type$Opaque(handle.base,
                                    handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                                    {#if[Object]?checkCast(handle, value):value});
@@ -613,7 +607,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static void setRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
             UNSAFE.put$Type$Release(handle.base,
                                     handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                                     {#if[Object]?checkCast(handle, value):value});
@@ -622,7 +616,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean compareAndSet(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.compareAndSet$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -632,7 +626,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ compareAndExchange(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.compareAndExchange$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -641,7 +635,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ compareAndExchangeAcquire(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.compareAndExchange$Type$Acquire(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -650,7 +644,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ compareAndExchangeRelease(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.compareAndExchange$Type$Release(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -659,7 +653,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSetPlain(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.weakCompareAndSet$Type$Plain(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -668,7 +662,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSet(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.weakCompareAndSet$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -677,7 +671,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSetAcquire(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.weakCompareAndSet$Type$Acquire(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -686,7 +680,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSetRelease(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.weakCompareAndSet$Type$Release(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -695,7 +689,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndSet(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndSet$Type$(handle.base,
                                           handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
@@ -703,7 +697,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndSetAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndSet$Type$Acquire(handle.base,
                                           handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
@@ -711,7 +705,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndSetRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndSet$Type$Release(handle.base,
                                           handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
@@ -721,7 +715,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndAdd(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndAdd$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -729,7 +723,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndAddAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndAdd$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -737,7 +731,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndAddRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndAdd$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -747,7 +741,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseOr(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseOr$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -755,7 +749,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseOrRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseOr$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -763,7 +757,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseOrAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseOr$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -771,7 +765,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseAnd(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseAnd$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -779,7 +773,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseAndRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseAnd$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -787,7 +781,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseAndAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -795,7 +789,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseXor(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseXor$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -803,7 +797,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseXorRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseXor$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -811,7 +805,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseXorAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.target();
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
             return UNSAFE.getAndBitwiseXor$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -493,7 +493,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ get(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true);
             $type$ value = UNSAFE.get$Type$(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -507,7 +507,7 @@ final class VarHandle$InputType$s {
 #if[NonPlainAccess]
         @ForceInline
         static $type$ getVolatile(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true);
             $type$ value = UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -520,7 +520,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getOpaque(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true);
             $type$ value = UNSAFE.get$Type$Opaque(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -533,7 +533,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAcquire(VarHandle ob) {
-            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true, false);
+            FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.onStaticFieldAccess(true);
             $type$ value = UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
 #if[Reference]
@@ -582,7 +582,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static void set(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false);
             UNSAFE.put$Type$(handle.base,
                              handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                              {#if[Object]?checkCast(handle, value):value});
@@ -591,7 +591,7 @@ final class VarHandle$InputType$s {
 #if[NonPlainAccess]
         @ForceInline
         static void setVolatile(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false);
             UNSAFE.put$Type$Volatile(handle.base,
                                      handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                                      {#if[Object]?checkCast(handle, value):value});
@@ -599,7 +599,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static void setOpaque(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false);
             UNSAFE.put$Type$Opaque(handle.base,
                                    handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                                    {#if[Object]?checkCast(handle, value):value});
@@ -607,7 +607,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static void setRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(false);
             UNSAFE.put$Type$Release(handle.base,
                                     handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType},
                                     {#if[Object]?checkCast(handle, value):value});
@@ -616,7 +616,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean compareAndSet(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndSet$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -626,7 +626,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ compareAndExchange(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndExchange$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -635,7 +635,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ compareAndExchangeAcquire(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndExchange$Type$Acquire(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -644,7 +644,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ compareAndExchangeRelease(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndExchange$Type$Release(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -653,7 +653,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSetPlain(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$Plain(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -662,7 +662,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSet(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -671,7 +671,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSetAcquire(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$Acquire(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -680,7 +680,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static boolean weakCompareAndSetRelease(VarHandle ob, $type$ expected, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$Release(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                                {#if[Object]?checkCast(handle, expected):expected},
@@ -689,7 +689,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndSet(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndSet$Type$(handle.base,
                                           handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
@@ -697,7 +697,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndSetAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndSet$Type$Acquire(handle.base,
                                           handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
@@ -705,7 +705,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndSetRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndSet$Type$Release(handle.base,
                                           handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
                                           {#if[Object]?checkCast(handle, value):value});
@@ -715,7 +715,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndAdd(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndAdd$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -723,7 +723,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndAddAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndAdd$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -731,7 +731,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndAddRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndAdd$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -741,7 +741,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseOr(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseOr$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -749,7 +749,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseOrRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseOr$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -757,7 +757,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseOrAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseOr$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -765,7 +765,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseAnd(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseAnd$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -773,7 +773,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseAndRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseAnd$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -781,7 +781,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseAndAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -789,7 +789,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseXor(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseXor$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -797,7 +797,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseXorRelease(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseXor$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -805,7 +805,7 @@ final class VarHandle$InputType$s {
 
         @ForceInline
         static $type$ getAndBitwiseXorAcquire(VarHandle ob, $type$ value) {
-            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true, true);
+            FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.getAndBitwiseXor$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1349,7 +1349,7 @@ public final class Unsafe {
     }
 
     /**
-     * Detects if the given class may need to be initialized. This is often
+     * Detects if the given class is not yet fully initialized. This is often
      * needed in conjunction with obtaining the static field base of a
      * class.
      * @return false only if a call to {@code ensureClassInitialized} would have no effect

--- a/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
+++ b/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
@@ -48,6 +48,8 @@ import java.util.Objects;
 
 import jdk.test.lib.helpers.StrictInit;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -109,11 +111,22 @@ public class StrictInitializingTest {
         assertTrue(executed[0]);
     }
 
+    private static MethodHandles.Lookup[] lookups() {
+        return new MethodHandles.Lookup[] {
+                LookupHelper.IMPL_LOOKUP,
+                LOOKUP,
+        };
+    }
 
-    @Test
-    public void testSetAccessOnStaticStrictFinal() throws Throwable {
-        var vh = LookupHelper.IMPL_LOOKUP.findStaticVarHandle(StrictStaticFinalHolder.class, "f", Object.class);
-        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.SET));
+    @ParameterizedTest
+    @MethodSource("lookups")
+    public void testSetAccessOnStaticFinal(MethodHandles.Lookup lookup) throws Throwable {
+        var strictStaticFinal = lookup.findStaticVarHandle(StrictStaticFinalHolder.class, "strictStaticFinal", Object.class);
+        assertFalse(strictStaticFinal.isAccessModeSupported(VarHandle.AccessMode.SET));
+        var trustedStaticFinal = lookup.findStaticVarHandle(StrictStaticFinalHolder.class, "trustedStaticFinal", Object.class);
+        assertFalse(trustedStaticFinal.isAccessModeSupported(VarHandle.AccessMode.SET));
+        var strictInstanceFinal = lookup.findVarHandle(StrictStaticFinalHolder.class, "strictFinal", Object.class);
+        assertFalse(strictInstanceFinal.isAccessModeSupported(VarHandle.AccessMode.SET));
     }
 
     static LazyInitializingTest.ClassInfo createSampleClass(LazyInitializingTest.SampleData sampleData) {
@@ -163,7 +176,16 @@ class StrictInitializingSample {
     }
 }
 
-class StrictStaticFinalHolder {
+final class StrictStaticFinalHolder {
     @StrictInit
-    static final Object f = 5;
+    static final Object strictStaticFinal = 5;
+    static final Object trustedStaticFinal = new Object();
+
+    @StrictInit
+    final Object strictFinal;
+
+    StrictStaticFinalHolder(Object strictFinal) {
+        this.strictFinal = strictFinal;
+        super();
+    }
 }

--- a/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
+++ b/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8291065
+ * @summary Checks interaction of static field VarHandle with class
+ *          initialization mechanism.
+ * @enablePreview
+ * @library /test/lib
+ * @build LazyInitializingTest ${test.main.class}
+ * @run driver jdk.test.lib.helpers.StrictProcessor StrictInitializingSample
+ * @run junit ${test.main.class}
+ * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true ${test.main.class}
+ * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false ${test.main.class}
+ * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true
+ *                    -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false ${test.main.class}
+ */
+
+import java.io.IOException;
+import java.lang.constant.ConstantDescs;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+
+import jdk.test.lib.helpers.StrictInit;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StrictInitializingTest {
+
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+    @Test
+    public void testOperationsDuringInit() throws Throwable {
+        VarHandle[] handle = new VarHandle[1];
+        boolean[] executed = {false};
+        var ci = createSampleClass(new LazyInitializingTest.SampleData(() -> {
+            assertThrows(IllegalStateException.class, () -> {
+                int _ = (int) handle[0].get();
+            }, "get before write");
+            assertThrows(IllegalStateException.class, () -> {
+                int _ = (int) handle[0].getAndAdd(3);
+            }, "getAndAdd before write");
+            handle[0].set(12);
+            assertEquals(12, (int) handle[0].get());
+            assertEquals(12, (int) handle[0].getAndAddAcquire(3));
+            assertEquals(15, (int) handle[0].getVolatile());
+            executed[0] = true;
+        }, 24));
+        handle[0] = ci.vh();
+
+        ci.definingLookup().ensureInitialized(ci.definingLookup().lookupClass());
+        assertTrue(executed[0]);
+    }
+
+    @Test
+    public void testOperationsOnMethodHandleDuringInit() throws Throwable {
+        MethodHandle[] handle = new MethodHandle[6];
+        boolean[] executed = {false};
+        var ci = createSampleClass(new LazyInitializingTest.SampleData(() -> {
+            assertThrows(IllegalStateException.class, () -> {
+                int _ = (int) handle[0].invoke();
+            }, "get before write");
+            assertThrows(IllegalStateException.class, () -> {
+                int _ = (int) handle[1].invoke(3);
+            }, "getAndAdd before write");
+            assertDoesNotThrow(() -> {
+                handle[2].invokeExact(12);
+                assertEquals(12, (int) handle[3].invokeExact());
+                assertEquals(12, (int) handle[4].invokeExact((int) 3));
+                assertEquals(15, (int) handle[5].invokeExact());
+            });
+            executed[0] = true;
+        }, 24));
+        var vh = ci.vh();
+        handle[0] = vh.toMethodHandle(VarHandle.AccessMode.GET);
+        handle[1] = vh.toMethodHandle(VarHandle.AccessMode.GET_AND_ADD);
+        handle[2] = vh.toMethodHandle(VarHandle.AccessMode.SET);
+        handle[3] = vh.toMethodHandle(VarHandle.AccessMode.GET);
+        handle[4] = vh.toMethodHandle(VarHandle.AccessMode.GET_AND_ADD_ACQUIRE);
+        handle[5] = vh.toMethodHandle(VarHandle.AccessMode.GET_VOLATILE);
+
+        ci.definingLookup().ensureInitialized(ci.definingLookup().lookupClass());
+        assertTrue(executed[0]);
+    }
+
+    static LazyInitializingTest.ClassInfo createSampleClass(LazyInitializingTest.SampleData sampleData) {
+        try {
+            var lookup = LOOKUP.defineHiddenClassWithClassData(sampleClassBytes(), sampleData, false);
+            var vh = lookup.findStaticVarHandle(lookup.lookupClass(), "f", int.class);
+            return new LazyInitializingTest.ClassInfo(lookup, vh);
+        } catch (IllegalAccessException | NoSuchFieldException ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    private static byte[] sampleClassBytes;
+
+    private static byte[] sampleClassBytes() {
+        var bytes = sampleClassBytes;
+        if (bytes != null)
+            return bytes;
+
+        try (var in = StrictInitializingTest.class.getResourceAsStream("StrictInitializingSample.class")) {
+            if (in == null)
+                throw new AssertionError("class file not found");
+            return sampleClassBytes = in.readAllBytes();
+        } catch (IOException ex) {
+            throw new AssertionError(ex);
+        }
+    }
+}
+
+// This is used as a template class, whose bytes are used to define
+// hidden classes instead
+class StrictInitializingSample {
+    @StrictInit
+    static int f;
+
+    static {
+        try {
+            var data = MethodHandles.classData(MethodHandles.lookup(), ConstantDescs.DEFAULT_NAME,
+                    LazyInitializingTest.SampleData.class);
+            Objects.requireNonNull(data);
+
+            data.callback().run();
+            f = data.initialValue();
+        } catch (IllegalAccessException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
+++ b/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
@@ -27,9 +27,10 @@
  * @summary Checks interaction of static field VarHandle with class
  *          initialization mechanism.
  * @enablePreview
- * @library /test/lib
- * @build LazyInitializingTest ${test.main.class}
- * @run driver jdk.test.lib.helpers.StrictProcessor StrictInitializingSample
+ * @library java.base /test/lib
+ * @build java.base/java.lang.invoke.*
+ *        LazyInitializingTest ${test.main.class}
+ * @run driver jdk.test.lib.helpers.StrictProcessor StrictInitializingSample StrictStaticFinalHolder
  * @run junit ${test.main.class}
  * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true ${test.main.class}
  * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false ${test.main.class}
@@ -39,6 +40,7 @@
 
 import java.io.IOException;
 import java.lang.constant.ConstantDescs;
+import java.lang.invoke.LookupHelper;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -107,6 +109,13 @@ public class StrictInitializingTest {
         assertTrue(executed[0]);
     }
 
+
+    @Test
+    public void testSetAccessOnStaticStrictFinal() throws Throwable {
+        var vh = LookupHelper.IMPL_LOOKUP.findStaticVarHandle(StrictStaticFinalHolder.class, "f", Object.class);
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.SET));
+    }
+
     static LazyInitializingTest.ClassInfo createSampleClass(LazyInitializingTest.SampleData sampleData) {
         try {
             var lookup = LOOKUP.defineHiddenClassWithClassData(sampleClassBytes(), sampleData, false);
@@ -152,4 +161,9 @@ class StrictInitializingSample {
             throw new ExceptionInInitializerError(e);
         }
     }
+}
+
+class StrictStaticFinalHolder {
+    @StrictInit
+    static final Object f = 5;
 }

--- a/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
+++ b/test/jdk/java/lang/invoke/VarHandles/StrictInitializingTest.java
@@ -66,6 +66,9 @@ public class StrictInitializingTest {
                 int _ = (int) handle[0].get();
             }, "get before write");
             assertThrows(IllegalStateException.class, () -> {
+                boolean _ = (boolean) handle[0].compareAndSet(7, 3);
+            }, "compareAndSet before write");
+            assertThrows(IllegalStateException.class, () -> {
                 int _ = (int) handle[0].getAndAdd(3);
             }, "getAndAdd before write");
             handle[0].set(12);
@@ -82,30 +85,34 @@ public class StrictInitializingTest {
 
     @Test
     public void testOperationsOnMethodHandleDuringInit() throws Throwable {
-        MethodHandle[] handle = new MethodHandle[6];
+        MethodHandle[] handle = new MethodHandle[7];
         boolean[] executed = {false};
         var ci = createSampleClass(new LazyInitializingTest.SampleData(() -> {
             assertThrows(IllegalStateException.class, () -> {
                 int _ = (int) handle[0].invoke();
             }, "get before write");
             assertThrows(IllegalStateException.class, () -> {
-                int _ = (int) handle[1].invoke(3);
+                boolean _ = (boolean) handle[1].invoke(7, 3);
+            }, "compareAndSet before write");
+            assertThrows(IllegalStateException.class, () -> {
+                int _ = (int) handle[2].invoke(3);
             }, "getAndAdd before write");
             assertDoesNotThrow(() -> {
-                handle[2].invokeExact(12);
-                assertEquals(12, (int) handle[3].invokeExact());
-                assertEquals(12, (int) handle[4].invokeExact((int) 3));
-                assertEquals(15, (int) handle[5].invokeExact());
+                handle[3].invokeExact(12);
+                assertEquals(12, (int) handle[4].invokeExact());
+                assertEquals(12, (int) handle[5].invokeExact((int) 3));
+                assertEquals(15, (int) handle[6].invokeExact());
             });
             executed[0] = true;
         }, 24));
         var vh = ci.vh();
         handle[0] = vh.toMethodHandle(VarHandle.AccessMode.GET);
-        handle[1] = vh.toMethodHandle(VarHandle.AccessMode.GET_AND_ADD);
-        handle[2] = vh.toMethodHandle(VarHandle.AccessMode.SET);
-        handle[3] = vh.toMethodHandle(VarHandle.AccessMode.GET);
-        handle[4] = vh.toMethodHandle(VarHandle.AccessMode.GET_AND_ADD_ACQUIRE);
-        handle[5] = vh.toMethodHandle(VarHandle.AccessMode.GET_VOLATILE);
+        handle[1] = vh.toMethodHandle(VarHandle.AccessMode.COMPARE_AND_SET);
+        handle[2] = vh.toMethodHandle(VarHandle.AccessMode.GET_AND_ADD);
+        handle[3] = vh.toMethodHandle(VarHandle.AccessMode.SET);
+        handle[4] = vh.toMethodHandle(VarHandle.AccessMode.GET);
+        handle[5] = vh.toMethodHandle(VarHandle.AccessMode.GET_AND_ADD_ACQUIRE);
+        handle[6] = vh.toMethodHandle(VarHandle.AccessMode.GET_VOLATILE);
 
         ci.definingLookup().ensureInitialized(ci.definingLookup().lookupClass());
         assertTrue(executed[0]);

--- a/test/jdk/java/lang/invoke/VarHandles/java.base/java/lang/invoke/LookupHelper.java
+++ b/test/jdk/java/lang/invoke/VarHandles/java.base/java/lang/invoke/LookupHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang.invoke;
+
+import java.lang.invoke.MethodHandles.Lookup;
+
+public class LookupHelper {
+    public static final Lookup IMPL_LOOKUP = Lookup.IMPL_LOOKUP;
+}


### PR DESCRIPTION
The checks for strict statics for VarHandle was never implemented. Luckily we can reuse LazyInitializingVarHandle so the patch is not too complex.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386677](https://bugs.openjdk.org/browse/JDK-8386677): [lworld] VarHandle does not implement strict static checks (**Bug** - P2)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2550/head:pull/2550` \
`$ git checkout pull/2550`

Update a local copy of the PR: \
`$ git checkout pull/2550` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2550`

View PR using the GUI difftool: \
`$ git pr show -t 2550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2550.diff">https://git.openjdk.org/valhalla/pull/2550.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2550#issuecomment-4710230823)
</details>
