### PR TITLE
8386709: [lworld] gc/stress/gcbasher/TestGCBasherWithShenandoah.java#aggressive misses @library

### DIFF
--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 /*
  * @test id=aggressive
  * @key stress
+ * @library / /test/lib
  * @requires vm.gc.Shenandoah
  * @requires vm.flavor == "server"
  * @summary Stress the Shenandoah GC by trying to make old objects more likely to be garbage than young objects.


### PR DESCRIPTION
Looks like [JDK-8379695](https://bugs.openjdk.org/browse/JDK-8379695) missed the spot and the test fails.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386709](https://bugs.openjdk.org/browse/JDK-8386709): [lworld] gc/stress/gcbasher/TestGCBasherWithShenandoah.java#aggressive misses @<!---->library (**Bug** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2552/head:pull/2552` \
`$ git checkout pull/2552`

Update a local copy of the PR: \
`$ git checkout pull/2552` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2552`

View PR using the GUI difftool: \
`$ git pr show -t 2552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2552.diff">https://git.openjdk.org/valhalla/pull/2552.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2552#issuecomment-4717310480)
</details>
