### PR TITLE
8386717: [lworld] Test followup after JDK-8386250

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/GetClassModifiers/GetValueClassModifiersTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetClassModifiers/GetValueClassModifiersTest.java
@@ -64,7 +64,7 @@ class GetValueClassModifiersTest {
                 V1.class,
                 V1[].class,
                 V2.class,
-                V2.class,
+                V2[].class,
                 R_V1.class,
                 R_V1[].class,
                 R_V2.class,


### PR DESCRIPTION
Ongoing audit found the small issue introduced in new test for [JDK-8386250](https://bugs.openjdk.org/browse/JDK-8386250). There is a double case for V2.class, the second case should be V2[].class.

Additional testing:
 - [x] Affected test still passes
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386717](https://bugs.openjdk.org/browse/JDK-8386717): [lworld] Test followup after JDK-8386250 (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2553/head:pull/2553` \
`$ git checkout pull/2553`

Update a local copy of the PR: \
`$ git checkout pull/2553` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2553`

View PR using the GUI difftool: \
`$ git pr show -t 2553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2553.diff">https://git.openjdk.org/valhalla/pull/2553.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2553#issuecomment-4718282228)
</details>
