### PR TITLE
8386237: [lworld] compiler/valhalla/inlinetypes/TestIntrinsics.java sub-tests fail with merge_jdk-28+1

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -3201,7 +3201,7 @@ void TypeNode::create_halt_path(PhaseIterGVN* igvn, Node* c, PhaseIdealLoop* loo
   }
 
   stringStream ss;
-  ss.print("dead path discovered by TypeNode during %s: this:%d; c:%d  method:%s", phase_str, this->_idx, c->_idx, igvn->C->method()->name()->as_quoted_ascii());
+  ss.print("dead path discovered by TypeNode during %s", phase_str);
 
   Node* halt = new HaltNode(c, frame, ss.as_string(igvn->C->comp_arena()));
   if (loop == nullptr) {

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -3201,7 +3201,7 @@ void TypeNode::create_halt_path(PhaseIterGVN* igvn, Node* c, PhaseIdealLoop* loo
   }
 
   stringStream ss;
-  ss.print("dead path discovered by TypeNode during %s", phase_str);
+  ss.print("dead path discovered by TypeNode during %s: this:%d; c:%d  method:%s", phase_str, this->_idx, c->_idx, igvn->C->method()->name()->as_quoted_ascii());
 
   Node* halt = new HaltNode(c, frame, ss.as_string(igvn->C->comp_arena()));
   if (loop == nullptr) {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6989,7 +6989,10 @@ const TypeOopPtr* TypeAryKlassPtr::as_instance_type(bool klass_change) const {
     // Unrefined types aren't trustworthy! Let's not mistake their ignorance for information.
     flat = false;
     // There are asserts that expect us to not be entirely naive about flatness.
-    bool must_be_ref_or_prim_array = !elem()->isa_ptr() || (elem()->is_ptr()->flat_in_array() == TypePtr::NotFlat);
+    bool must_be_ref_or_prim_array =
+        !elem()->isa_ptr() ||
+        (elem()->is_ptr()->flat_in_array() == TypePtr::NotFlat) ||
+        !(elem()->is_inlinetypeptr() && elem()->inline_klass()->maybe_flat_in_array());
     not_flat = must_be_ref_or_prim_array;
     not_null_free = must_be_ref_or_prim_array;
     atomic = must_be_ref_or_prim_array;

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3209,7 +3209,7 @@ bool TypePtr::would_improve_ptr(ProfilePtrKind ptr_kind) const {
 }
 
 TypePtr::FlatInArray TypePtr::compute_flat_in_array(ciInstanceKlass* instance_klass, bool is_exact) {
-  if (!instance_klass->can_be_inline_klass(is_exact)) {
+  if (!instance_klass->can_be_inline_klass(is_exact) || !UseArrayFlattening) {
     // Definitely not a value class and thus never flat in an array.
     return NotFlat;
   }
@@ -5632,7 +5632,6 @@ template<class T> TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*
         // Even though MyValue is final, [LMyValue is only exact if the array
         // is (not) null-free due to null-free [LMyValue <: null-able [LMyValue.
         if (res_xk && !res_null_free && !res_not_null_free) {
-          ptr = NotNull;
           res_xk = false;
         }
       }
@@ -6970,11 +6969,32 @@ const TypeOopPtr* TypeAryKlassPtr::as_instance_type(bool klass_change) const {
   } else {
     el = elem();
   }
-  bool null_free = _null_free;
-  if (null_free && el->isa_ptr()) {
+  if (!UseNewCode) {
+    bool null_free = _null_free;
+    if (null_free && el->isa_ptr()) {
+      el = el->is_ptr()->join_speculative(TypePtr::NOTNULL);
+    }
+    return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS, false, is_flat(), is_not_flat(), is_not_null_free(), is_atomic()), k, xk, Offset(0));
+  }
+  if (_refined_type && _null_free && el->isa_ptr()) {
     el = el->is_ptr()->join_speculative(TypePtr::NOTNULL);
   }
-  return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS, false, is_flat(), is_not_flat(), is_not_null_free(), is_atomic()), k, xk, Offset(0));
+  bool flat, not_flat, not_null_free, atomic;
+  if (_refined_type) {
+    flat = is_flat();
+    not_flat = is_not_flat();
+    not_null_free = is_not_null_free();
+    atomic = is_atomic();
+  } else {
+    // Unrefined types aren't trustworthy! Let's not mistake their ignorance for information.
+    flat = false;
+    // There are asserts that expect us to not be entirely naive about flatness.
+    bool must_be_ref_or_prim_array = !elem()->isa_ptr() || (elem()->is_ptr()->flat_in_array() == TypePtr::NotFlat);
+    not_flat = must_be_ref_or_prim_array;
+    not_null_free = must_be_ref_or_prim_array;
+    atomic = must_be_ref_or_prim_array;
+  }
+  return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS, false, flat, not_flat, not_null_free, atomic), k, xk, Offset(0));
 }
 
 

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3210,13 +3210,19 @@ bool TypePtr::would_improve_ptr(ProfilePtrKind ptr_kind) const {
 
 TypePtr::FlatInArray TypePtr::compute_flat_in_array(ciInstanceKlass* instance_klass, bool is_exact) {
   if (!instance_klass->can_be_inline_klass(is_exact) || !UseArrayFlattening) {
-    // Definitely not a value class and thus never flat in an array.
+    // Definitely not a value class, or flattening is not even enabled, and thus never flat in an array.
     return NotFlat;
   }
-  if (instance_klass->is_inlinetype() && instance_klass->as_inline_klass()->is_always_flat_in_array()) {
-    return Flat;
+  if (instance_klass->is_inlinetype()) {
+    if (instance_klass->as_inline_klass()->is_always_flat_in_array()) {
+      return Flat;
+    }
+    if (instance_klass->as_inline_klass()->maybe_flat_in_array()) {
+      return MaybeFlat;
+    }
+    return NotFlat;
   }
-  // We don't know.
+  // It's not an inline class, but can still be, so we don't know.
   return MaybeFlat;
 }
 
@@ -6992,14 +6998,13 @@ const TypeOopPtr* TypeAryKlassPtr::as_instance_type(bool klass_change) const {
     // Only arrays of value classes can be null free. Otherwise, not_null_free == true. That is if the element type
     // is not an instance class, or this instance class cannot be an inline type, it's surely not null-restricted.
     not_null_free = !elem()->isa_instklassptr() || !elem()->is_instklassptr()->can_be_inline_type();
-    bool array_can_be_flat =
-        UseArrayFlattening &&  // Obviously
-        elem()->isa_instklassptr() &&  // Arrays of arrays or primitives are not flat
-        elem()->is_instklassptr()->can_be_inline_type() &&  // The element type is a value class or can be derived into one (like Object[] or AbstractValue[])
-        (
-          !elem()->is_instklassptr()->klass()->is_inlinetype() ||  // The element type is not a value class itself, maybe a child class is flattenable. Who knows?
-          elem()->is_instklassptr()->klass()->maybe_flat_in_array()  // The element type is an value class, let's ask whether it can be flat.
-        );
+    bool array_can_be_flat;
+    if (elem()->isa_instklassptr()) {
+      FlatInArray elem_flat_in_array = elem()->is_instklassptr()->flat_in_array();
+      array_can_be_flat = elem_flat_in_array == MaybeFlat || elem_flat_in_array == Flat;
+    } else {
+      array_can_be_flat = false;
+    }
     not_flat = !array_can_be_flat;
     atomic = !array_can_be_flat;
   }

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6989,13 +6989,14 @@ const TypeOopPtr* TypeAryKlassPtr::as_instance_type(bool klass_change) const {
     // Unrefined types aren't trustworthy! Let's not mistake their ignorance for information.
     flat = false;
     // There are asserts that expect us to not be entirely naive about flatness.
-    bool must_be_ref_or_prim_array =
-        !elem()->isa_ptr() ||
-        (elem()->is_ptr()->flat_in_array() == TypePtr::NotFlat) ||
-        !(elem()->is_inlinetypeptr() && elem()->inline_klass()->maybe_flat_in_array());
-    not_flat = must_be_ref_or_prim_array;
-    not_null_free = must_be_ref_or_prim_array;
-    atomic = must_be_ref_or_prim_array;
+    bool array_can_be_flat =
+        UseArrayFlattening &&
+        elem()->isa_instklassptr() &&
+        elem()->is_instklassptr()->can_be_inline_type() &&
+        (!elem()->is_instklassptr()->klass()->is_inlinetype() || elem()->is_instklassptr()->klass()->maybe_flat_in_array());
+    not_flat = !array_can_be_flat;
+    not_null_free = !array_can_be_flat;
+    atomic = !array_can_be_flat;
   }
   return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS, false, flat, not_flat, not_null_free, atomic), k, xk, Offset(0));
 }

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6976,26 +6976,31 @@ const TypeOopPtr* TypeAryKlassPtr::as_instance_type(bool klass_change) const {
     }
     return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS, false, is_flat(), is_not_flat(), is_not_null_free(), is_atomic()), k, xk, Offset(0));
   }
-  if (_refined_type && _null_free && el->isa_ptr()) {
-    el = el->is_ptr()->join_speculative(TypePtr::NOTNULL);
-  }
   bool flat, not_flat, not_null_free, atomic;
   if (_refined_type) {
+    if (_null_free && el->isa_ptr()) {
+      el = el->is_ptr()->join_speculative(TypePtr::NOTNULL);
+    }
     flat = is_flat();
     not_flat = is_not_flat();
     not_null_free = is_not_null_free();
     atomic = is_atomic();
-  } else {
-    // Unrefined types aren't trustworthy! Let's not mistake their ignorance for information.
+  } else {  // Unrefined types aren't trustworthy! Let's not mistake their ignorance for information.
+    // We can always have arrays of references. Flatness is not guaranteed.
     flat = false;
-    // There are asserts that expect us to not be entirely naive about flatness.
+    // There are asserts that expect us to not be entirely naive about properties.
+    // Only arrays of value classes can be null free. Otherwise, not_null_free == true. That is if the element type
+    // is not an instance class, or this instance class cannot be an inline type, it's surely not null-restricted.
+    not_null_free = !elem()->isa_instklassptr() || !elem()->is_instklassptr()->can_be_inline_type();
     bool array_can_be_flat =
-        UseArrayFlattening &&
-        elem()->isa_instklassptr() &&
-        elem()->is_instklassptr()->can_be_inline_type() &&
-        (!elem()->is_instklassptr()->klass()->is_inlinetype() || elem()->is_instklassptr()->klass()->maybe_flat_in_array());
+        UseArrayFlattening &&  // Obviously
+        elem()->isa_instklassptr() &&  // Arrays of arrays or primitives are not flat
+        elem()->is_instklassptr()->can_be_inline_type() &&  // The element type is a value class or can be derived into one (like Object[] or AbstractValue[])
+        (
+          !elem()->is_instklassptr()->klass()->is_inlinetype() ||  // The element type is not a value class itself, maybe a child class is flattenable. Who knows?
+          elem()->is_instklassptr()->klass()->maybe_flat_in_array()  // The element type is an value class, let's ask whether it can be flat.
+        );
     not_flat = !array_can_be_flat;
-    not_null_free = !array_can_be_flat;
     atomic = !array_can_be_flat;
   }
   return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS, false, flat, not_flat, not_null_free, atomic), k, xk, Offset(0));

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6975,13 +6975,6 @@ const TypeOopPtr* TypeAryKlassPtr::as_instance_type(bool klass_change) const {
   } else {
     el = elem();
   }
-  if (!UseNewCode) {
-    bool null_free = _null_free;
-    if (null_free && el->isa_ptr()) {
-      el = el->is_ptr()->join_speculative(TypePtr::NOTNULL);
-    }
-    return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS, false, is_flat(), is_not_flat(), is_not_null_free(), is_atomic()), k, xk, Offset(0));
-  }
   bool flat, not_flat, not_null_free, atomic;
   if (_refined_type) {
     if (_null_free && el->isa_ptr()) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -199,10 +199,6 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 # Valhalla failures start here:
 compiler/codegen/TestRedundantLea.java#Spill              8361089 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id4 8386160 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id0 8386237 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id1 8386237 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id5 8386237 generic-all
-compiler/valhalla/inlinetypes/TestIntrinsics.java#id6 8386237 generic-all
 
 vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all
 


### PR DESCRIPTION
When https://github.com/openjdk/jdk/pull/31162 landed in Valhalla, it added this bit of code in `GrraphKit::gen_checkcast`:

https://github.com/openjdk/valhalla/blob/a339024e1f415bfd7c6875538f2adff77bf087f0/src/hotspot/share/opto/graphKit.cpp#L3914-L3916

While it manifests as a memory problem (and indeed, the memory graph is all fucked up), the causes lies in the type system, and more precisely, in `as_instance_type` invoked from `gen_checkcast` as well:

https://github.com/openjdk/valhalla/blob/a339024e1f415bfd7c6875538f2adff77bf087f0/src/hotspot/share/opto/graphKit.cpp#L3692

The problem is that `TypeAryKlassPtr::as_instance_type` will trust all the `is_flat()`, `is_not_flat()`, `is_not_null_free()`, `is_atomic()`, `null_free()` from an unrefined type:
https://github.com/openjdk/valhalla/blob/a339024e1f415bfd7c6875538f2adff77bf087f0/src/hotspot/share/opto/type.cpp#L6975-L6990

But unrefined types represent Java types: they don't express notions such as flatness, atomicity... These flags are arbitrary in unrefined types.

We should not! Before https://github.com/openjdk/jdk/pull/31162, this was unoticed because when parsing some array load or store, we were not reusing the casted value from `gen_checkcast`: it was indeed found to be stupidly small (like null or empty), because it was the intersection of some actual type, and the type wrongly created by `TypeAryKlassPtr::as_instance_type`, but it had no impact that we were not replacing anything in the map, this code in `Parse::array_store`
https://github.com/openjdk/valhalla/blob/a339024e1f415bfd7c6875538f2adff77bf087f0/src/hotspot/share/opto/parse2.cpp#L212-L214
would get the uncasted (more correct) version, freshly from the map.

So, we need to fix `TypeAryKlassPtr::as_instance_type`. While putting everything to "unknown" is sound, it is not a solution here: a lot of asserts expect us to be way more specific. I've managed to reuse `TypeInstKlassPtr::flat_in_array()`, but I had to make it more precise not to hit asserts such as
https://github.com/openjdk/valhalla/blob/a339024e1f415bfd7c6875538f2adff77bf087f0/src/hotspot/share/opto/parse2.cpp#L91-L92

I think we should consider changing the default values for unrefined types to some clearly incorrect combinations, such as `_flat == _not_flat == true`, so that if we use unrefined types as refined accidentally, it would probably be a train wreck immediately, and not accidentally correct, or plausible.

I also had to fix `TypePtr::meet_aryptr`: in the case `BotPTR`, we used to set `ptr` to `NotNull` in the case the result is not exact. This was breaking the verification of meet properties. Once again, because of damn dual!!! But clearly, we had a `TopPTR` in the non-dual, and I don't see a reason why `meet_aryptr` between bottom and anything should be less than bottom. Bottom is the universe! We shouldn't get less by adding something in it. And tests seem ok with it...

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386237](https://bugs.openjdk.org/browse/JDK-8386237): [lworld] compiler/valhalla/inlinetypes/TestIntrinsics.java sub-tests fail with merge_jdk-28+1 (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2554/head:pull/2554` \
`$ git checkout pull/2554`

Update a local copy of the PR: \
`$ git checkout pull/2554` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2554`

View PR using the GUI difftool: \
`$ git pr show -t 2554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2554.diff">https://git.openjdk.org/valhalla/pull/2554.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2554#issuecomment-4727347829)
</details>
