### PR TITLE
8386791: [lworld] ClassFile API review changes

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LoadableDescriptorsAttribute.java
@@ -30,6 +30,7 @@ import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassElement;
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.constant.ClassDesc;
+import java.util.Arrays;
 import java.util.List;
 
 import jdk.internal.classfile.impl.BoundAttribute;
@@ -74,6 +75,8 @@ public sealed interface LoadableDescriptorsAttribute
     /**
      * {@return a {@code LoadableDescriptors} attribute}
      * @param loadableDescriptors the loadable descriptors
+     * @throws IllegalArgumentException if the number of loadable descriptors
+     *         exceeds the limit of {@link java.lang.classfile##u2 u2}
      */
     static LoadableDescriptorsAttribute of(List<Utf8Entry> loadableDescriptors) {
         return new UnboundAttribute.UnboundLoadableDescriptorsAttribute(loadableDescriptors);
@@ -82,8 +85,30 @@ public sealed interface LoadableDescriptorsAttribute
     /**
      * {@return a {@code LoadableDescriptors} attribute}
      * @param loadableDescriptors the loadable descriptors
+     * @throws IllegalArgumentException if the number of loadable descriptors
+     *         exceeds the limit of {@link java.lang.classfile##u2 u2}
      */
     static LoadableDescriptorsAttribute of(Utf8Entry... loadableDescriptors) {
         return of(List.of(loadableDescriptors));
+    }
+
+    /**
+     * {@return a {@code LoadableDescriptors} attribute}
+     * @param loadableDescriptors the loadable descriptors
+     * @throws IllegalArgumentException if the number of loadable descriptors
+     *         exceeds the limit of {@link java.lang.classfile##u2 u2}
+     */
+    static LoadableDescriptorsAttribute ofSymbols(List<ClassDesc> loadableDescriptors) {
+        return of(Util.fieldDescriptorList(loadableDescriptors));
+    }
+
+    /**
+     * {@return a {@code LoadableDescriptors} attribute}
+     * @param loadableDescriptors the loadable descriptors
+     * @throws IllegalArgumentException if the number of loadable descriptors
+     *         exceeds the limit of {@link java.lang.classfile##u2 u2}
+     */
+    static LoadableDescriptorsAttribute ofSymbols(ClassDesc... loadableDescriptors) {
+        return ofSymbols(Arrays.asList(loadableDescriptors));
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AccessFlagsImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AccessFlagsImpl.java
@@ -56,8 +56,8 @@ public final class AccessFlagsImpl extends AbstractElement
         int major = version & 0xFFFF;
         int minor = version >>> Character.SIZE;
 
-        ClassFileFormatVersion cffv = minor == ClassFile.PREVIEW_MINOR_VERSION
-                ? null // Try to guess for older preview features
+        ClassFileFormatVersion cffv = major == ClassFile.latestMajorVersion() && minor == ClassFile.PREVIEW_MINOR_VERSION
+                ? null // Current preview features
                 : VM.isSupportedClassFileVersion(major, minor) ? ClassFileFormatVersion.fromMajor(major)
                                                                : ClassFileFormatVersion.latest(); // Fallback
         this(location, mask, cffv);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassRemapperImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassRemapperImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,9 @@ public record ClassRemapperImpl(Function<ClassDesc, ClassDesc> mapFunction) impl
                         psa.permittedSubclasses().stream().map(ps ->
                                 map(ps.asSymbol())).toList()));
             case LoadableDescriptorsAttribute pa ->
-                clb.with(LoadableDescriptorsAttribute.of(pa.loadableDescriptors()));
+                clb.with(LoadableDescriptorsAttribute.ofSymbols(
+                        pa.loadableDescriptorSymbols().stream()
+                                .map(this::map).toList()));
             case RuntimeVisibleAnnotationsAttribute aa ->
                 clb.with(RuntimeVisibleAnnotationsAttribute.of(
                         mapAnnotations(aa.annotations())));

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,6 +197,14 @@ public final class Util {
         var result = new Object[list.size()]; // null check
         for (int i = 0; i < result.length; i++) {
             result[i] = TemporaryConstantPool.INSTANCE.classEntry(list.get(i));
+        }
+        return SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArray(result);
+    }
+
+    public static List<Utf8Entry> fieldDescriptorList(List<? extends ClassDesc> list) {
+        var result = new Object[list.size()]; // null check
+        for (int i = 0; i < result.length; i++) {
+            result[i] = TemporaryConstantPool.INSTANCE.utf8Entry(list.get(i));
         }
         return SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArray(result);
     }

--- a/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
+++ b/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ class RebuildingTransformation {
                             ici.outerClass().map(ClassEntry::asSymbol),
                             ici.innerName().map(Utf8Entry::stringValue),
                             ici.flagsMask())).toArray(InnerClassInfo[]::new)));
-                    case LoadableDescriptorsAttribute a -> clb.with(LoadableDescriptorsAttribute.of(a.loadableDescriptors()));
+                    case LoadableDescriptorsAttribute a -> clb.with(LoadableDescriptorsAttribute.ofSymbols(a.loadableDescriptorSymbols()));
                     case ModuleAttribute a -> clb.with(ModuleAttribute.of(a.moduleName().asSymbol(), mob -> {
                         mob.moduleFlags(a.moduleFlagsMask());
                         a.moduleVersion().ifPresent(v -> mob.moduleVersion(v.stringValue()));


### PR DESCRIPTION
Address some ClassFile API problems:

1. Missing symbolic representation of LoadableDescriptors, throws spec fixes
2. Fallback to regular parsing for older preview for AccessFlagsImpl
3. ClassRemapperImpl and RebuildingTransformation

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386791](https://bugs.openjdk.org/browse/JDK-8386791): [lworld] ClassFile API review changes (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - no project role)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2557/head:pull/2557` \
`$ git checkout pull/2557`

Update a local copy of the PR: \
`$ git checkout pull/2557` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2557`

View PR using the GUI difftool: \
`$ git pr show -t 2557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2557.diff">https://git.openjdk.org/valhalla/pull/2557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2557#issuecomment-4721754945)
</details>
