### PR TITLE
8386793: [lworld] ProblemList serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation on linux-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -205,6 +205,8 @@ compiler/valhalla/inlinetypes/TestIntrinsics.java#id1 8386237 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id5 8386237 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id6 8386237 generic-all
 
+serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8386674 linux-aarch64
+
 vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all
 
 # The following test failures DID NOT reproduce during Tier[1-8] testing

--- a/test/langtools/ProblemList-enable-preview.txt
+++ b/test/langtools/ProblemList-enable-preview.txt
@@ -34,4 +34,4 @@
 #############################################################################
 
 # Valhalla failures start here:
-tools/javac/platform/CanHandleClassFilesTest.java 8385328 windows-x64
+tools/javac/platform/CanHandleClassFilesTest.java 8385328 generic-all


### PR DESCRIPTION
Trivial fixes to reduce the noise in the Valhalla CI:
- [JDK-8386793](https://bugs.openjdk.org/browse/JDK-8386793) [lworld] ProblemList serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation on linux-aarch64
- [JDK-8386794](https://bugs.openjdk.org/browse/JDK-8386794) [lworld] ProblemList tools/javac/platform/CanHandleClassFilesTest.java on all platforms with enable-preview



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issues
 * [JDK-8386793](https://bugs.openjdk.org/browse/JDK-8386793): [lworld] ProblemList serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation on linux-aarch64 (**Sub-task** - P4)
 * [JDK-8386794](https://bugs.openjdk.org/browse/JDK-8386794): [lworld] ProblemList tools/javac/platform/CanHandleClassFilesTest.java on all platforms with enable-preview (**Sub-task** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2558/head:pull/2558` \
`$ git checkout pull/2558`

Update a local copy of the PR: \
`$ git checkout pull/2558` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2558`

View PR using the GUI difftool: \
`$ git pr show -t 2558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2558.diff">https://git.openjdk.org/valhalla/pull/2558.diff</a>

</details>
