### PR TITLE
8386796: [lworld] Problemlist serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp on linux-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -205,6 +205,7 @@ compiler/valhalla/inlinetypes/TestIntrinsics.java#id1 8386237 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id5 8386237 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id6 8386237 generic-all
 
+serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp 8386674 linux-aarch64
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8386674 linux-aarch64
 
 vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all


### PR DESCRIPTION
The test failed a couple times immediately after jdk28 merge.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386796](https://bugs.openjdk.org/browse/JDK-8386796): [lworld] Problemlist serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp on linux-aarch64 (**Sub-task** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2559/head:pull/2559` \
`$ git checkout pull/2559`

Update a local copy of the PR: \
`$ git checkout pull/2559` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2559`

View PR using the GUI difftool: \
`$ git pr show -t 2559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2559.diff">https://git.openjdk.org/valhalla/pull/2559.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2559#issuecomment-4722844551)
</details>
