### PR TITLE
8386803: [lworld] remove HEADERS parameter from SetupJavaCompilation call for MODULE-PREVIEW_CLASSES_LABEL

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -156,7 +156,6 @@ ifneq ($(MODULE_PREVIEW_SRC_DIRS),)
       INCLUDES := $(JDK_USER_DEFINED_FILTER), \
       FAIL_NO_SRC := $(FAIL_NO_SRC), \
       BIN := $(PREVIEW_OUTPUTDIR)/, \
-      HEADERS := $(SUPPORT_OUTPUTDIR)/headers, \
       DISABLED_WARNINGS := $(DISABLED_WARNINGS_java) preview, \
       EXCLUDES := $(EXCLUDES), \
       EXCLUDE_FILES := $(EXCLUDE_FILES), \


### PR DESCRIPTION
A trivial fix to remove HEADERS parameter from SetupJavaCompilation call for MODULE-PREVIEW_CLASSES_LABEL.

I tested this fix with a local macosx-aarch64 build of three configs: release, fastdebug, slowdebug.
I'm also testing it with a Mach5 Tier1 job set.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386803](https://bugs.openjdk.org/browse/JDK-8386803): [lworld] remove HEADERS parameter from SetupJavaCompilation call for MODULE-PREVIEW_CLASSES_LABEL (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2560/head:pull/2560` \
`$ git checkout pull/2560`

Update a local copy of the PR: \
`$ git checkout pull/2560` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2560`

View PR using the GUI difftool: \
`$ git pr show -t 2560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2560.diff">https://git.openjdk.org/valhalla/pull/2560.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2560#issuecomment-4724554825)
</details>
