### PR TITLE
8386720: [lworld] C2: JDK-8385886 counts argument index incorrectly

### DIFF
--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -205,18 +205,24 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
       uint nargs = call->method()->arg_size();
       kit.ensure_stack(kit.sp() + nargs);
       uint in_idx = TypeFunc::Parms;
-      for (uint parm_idx = 0; parm_idx < nargs; parm_idx++) {
-        if (call->method()->is_scalarized_arg(static_cast<int>(parm_idx))) {
-          bool nullable = call->tf()->domain_sig()->field_at(TypeFunc::Parms + parm_idx)->maybe_null();
-          ciInlineKlass* vk = call->tf()->domain_sig()->field_at(TypeFunc::Parms + parm_idx)->inline_klass();
+      int parm_idx = 0;
+      for (uint i = 0; i < nargs; i++) {
+        const Type* arg_type = call->tf()->domain_sig()->field_at(TypeFunc::Parms + i);
+        if (arg_type->is_inlinetypeptr() && !call->method()->mismatch() && call->method()->is_scalarized_arg(parm_idx)) {
+          bool nullable = arg_type->maybe_null();
+          ciInlineKlass* vk = arg_type->inline_klass();
           InlineTypeNode* it = InlineTypeNode::make_from_multi(&kit, call, vk, in_idx, true, !nullable);
           kit.push(gvn.transform(it));
         } else {
           kit.push(call->in(in_idx));
           in_idx++;
         }
+        if (arg_type != Type::HALF) {
+          parm_idx++;
+        }
       }
       assert(in_idx == call->tf()->domain_cc()->cnt(), "should have processed exactly as many input as the scalarized calling convention; %d vs %d", in_idx, call->tf()->domain_cc()->cnt());
+      assert(parm_idx == (call->method()->is_static() ? 0 : 1) + call->method()->signature()->count(), "should have processed all the parameters; %d vs %d", parm_idx, (call->method()->is_static() ? 0 : 1) + call->method()->signature()->count());
       jvms = kit.sync_jvms();
 
       Node* new_vbox = nullptr;

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -204,9 +204,9 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
       // Adjust JVMS from post-call to pre-call state: put args on stack
       uint nargs = call->method()->arg_size();
       kit.ensure_stack(kit.sp() + nargs);
-      uint in_idx = TypeFunc::Parms;
-      int parm_idx = 0;
-      for (uint i = 0; i < nargs; i++) {
+      uint in_idx = TypeFunc::Parms;  // The index of the call input, using scalarized calling convention.
+      int parm_idx = 0;  // The index of the Java parameter (no notion of HALF).
+      for (uint i = 0; i < nargs; i++) {  // The index of the argument on the JVM stack (including HALF).
         const Type* arg_type = call->tf()->domain_sig()->field_at(TypeFunc::Parms + i);
         if (arg_type->is_inlinetypeptr() && !call->method()->mismatch() && call->method()->is_scalarized_arg(parm_idx)) {
           bool nullable = arg_type->maybe_null();

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -205,8 +205,8 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
       uint nargs = call->method()->arg_size();
       kit.ensure_stack(kit.sp() + nargs);
       uint in_idx = TypeFunc::Parms;  // The index of the call input, using scalarized calling convention.
-      int parm_idx = 0;  // The index of the Java parameter (no notion of HALF).
-      for (uint i = 0; i < nargs; i++) {  // The index of the argument on the JVM stack (including HALF).
+      int parm_idx = 0;  // The index of the Java parameter: double/long take one slot
+      for (uint i = 0; i < nargs; i++) {  // The index of the argument on the JVM stack: double/long take two slots
         const Type* arg_type = call->tf()->domain_sig()->field_at(TypeFunc::Parms + i);
         if (arg_type->is_inlinetypeptr() && !call->method()->mismatch() && call->method()->is_scalarized_arg(parm_idx)) {
           bool nullable = arg_type->maybe_null();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValuesAndHalf.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValuesAndHalf.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @summary Test that scalarize_vbox_node treats correctly scalarized value class locals
- * @bug 8385886
+ * @bug 8385886 8386720
  * @enablePreview
  * @modules jdk.incubator.vector
  * @run main/othervm -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValuesAndHalf.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizeVboxWithScalarizedValuesAndHalf.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test that scalarize_vbox_node treats correctly scalarized value class locals
+ * @bug 8385886
+ * @enablePreview
+ * @modules jdk.incubator.vector
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+EnableVectorSupport
+ *                   -XX:+EnableVectorReboxing
+ *                   -XX:+EnableVectorAggressiveReboxing
+ *                   -XX:+DeoptimizeALot -XX:DeoptimizeALotInterval=1 -XX:DeoptimizeOnlyAt=61
+ *                   -Xbatch
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::dontcompile
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.incubator.vector.*;
+
+public class TestScalarizeVboxWithScalarizedValuesAndHalf {
+    static final VectorSpecies<Integer> SPECIES = IntVector.SPECIES_128;
+    static final int[] array = new int[64];
+
+    static value class MyValue {
+        int a;
+
+        MyValue(int a) {
+            this.a = a;
+        }
+    }
+
+    static int dontcompile(double d, MyValue myVal, IntVector vector, long l) {
+        return myVal.a;
+    }
+
+    static int test(boolean flag, int v, double d, long l) {
+        MyValue myVal = new MyValue(v);
+
+        IntVector v1 = IntVector.fromArray(SPECIES, array, 0);
+        IntVector v2 = IntVector.fromArray(SPECIES, array, SPECIES.length());
+        IntVector vector = flag ? v1 : v2;
+
+        // bci 61 is the invokestatic
+        // and everything C2 needs to do with it (like allocating arrays for vectors with new_array_blob).
+        // myVal is not null, but after deopt, in dontcompile myVal.a throws a NPE.
+        return dontcompile(d, myVal, vector, l);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 200_000; i++) {
+            test((i & 1) == 0, i, (double)i, (long)(2 * i));
+        }
+    }
+}


### PR DESCRIPTION
We need to take the `HALF` parameters for long/double, in the same way as we do for `CallGenerator::do_late_inline_helper()` or `GraphKit::set_arguments_for_java_call`. Added a targeted assert.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386720](https://bugs.openjdk.org/browse/JDK-8386720): [lworld] C2: JDK-8385886 counts argument index incorrectly (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer) ⚠️ Review applies to [d8b0a248](https://git.openjdk.org/valhalla/pull/2561/files/d8b0a248a85ef1d3ad7961ad8107be286521e25d)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2561/head:pull/2561` \
`$ git checkout pull/2561`

Update a local copy of the PR: \
`$ git checkout pull/2561` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2561`

View PR using the GUI difftool: \
`$ git pr show -t 2561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2561.diff">https://git.openjdk.org/valhalla/pull/2561.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2561#issuecomment-4727624130)
</details>
