### PR TITLE
8386815: [lworld] Reduce the number of constructors in IdentityException

### DIFF
--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -48,7 +48,11 @@ public final class IdentityException extends RuntimeException {
     /**
      * Create an {@code IdentityException} with the class name and default message.
      *
-     * @param clazz the class of the object
+     * @apiNote
+     * This constructor does not verify that the given {@code clazz} is a value class.
+     *
+     * @param clazz the class whose name will be included in the exception message
+     * @throws NullPointerException if {@code clazz} is null
      */
     public IdentityException(Class<?> clazz) {
         super(clazz.getName() + " is not an identity class");

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -48,45 +48,11 @@ public final class IdentityException extends RuntimeException {
     }
 
     /**
-     * Create an {@code IdentityException} with the class name and default message.
-     *
-     * @apiNote
-     * This constructor does not verify that the given {@code clazz} is a value class.
-     *
-     * @param clazz the class whose name will be included in the exception message
-     * @throws NullPointerException if {@code clazz} is null
-     */
-    public IdentityException(Class<?> clazz) {
-        super(clazz.getName() + " is not an identity class");
-    }
-
-    /**
      * Create an {@code IdentityException} with a message.
      *
      * @param  message the detail message; can be {@code null}
      */
     public IdentityException(String message) {
         super(message);
-    }
-
-    /**
-     * Create an {@code IdentityException} with a cause.
-     *
-     * @param  cause the cause; {@code null} is permitted, and indicates
-     *               that the cause is nonexistent or unknown.
-     */
-    public IdentityException(Throwable cause) {
-        super(cause);
-    }
-
-    /**
-     * Create an {@code IdentityException} with a message and cause.
-     *
-     * @param  message the detail message; can be {@code null}
-     * @param  cause the cause; {@code null} is permitted, and indicates
-     *               that the cause is nonexistent or unknown.
-     */
-    public IdentityException(String message, Throwable cause) {
-        super(message, cause);
     }
 }

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -228,7 +228,7 @@ public final class Objects {
     public static <T> T requireIdentity(T obj) {
         Objects.requireNonNull(obj);
         if (!hasIdentity(obj))
-            throw new IdentityException(obj.getClass());
+            throw new IdentityException(obj.getClass().getName() + " is not an identity class");
         return obj;
     }
 

--- a/test/jdk/java/lang/IdentityExceptionBasicTest.java
+++ b/test/jdk/java/lang/IdentityExceptionBasicTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @summary Basic tests for java.lang.IdentityException
+ * @enablePreview
+ * @run junit ${test.main.class}
+ */
+class IdentityExceptionBasicTest {
+
+    /*
+     * Verify the constructor which takes the Class parameter
+     */
+    @Test
+    void testClassParam() throws Exception {
+        // verify that the exception message contains the given Class
+        final IdentityException ex = new IdentityException(Integer.class);
+        final String exMsg = ex.getMessage();
+        assertNotNull(exMsg, "exception message missing");
+        assertTrue(exMsg.contains(Integer.class.getName()));
+        assertTrue(exMsg.contains("not an identity class"));
+        assertNull(ex.getCause(), "unexpected cause");
+
+        // verify NullPointerException is thrown for null Class
+        assertThrows(NullPointerException.class, () -> new IdentityException((Class<?>) null));
+    }
+
+    /*
+     * Verify the no-arg constructor
+     */
+    @Test
+    void testNoArg() throws Exception {
+        // verify that there's no exception message and no cause
+        final IdentityException ex = new IdentityException();
+        assertNull(ex.getMessage(), "unexpected exception message");
+        assertNull(ex.getCause(), "unexpected cause");
+    }
+
+    /*
+     * Verify the constructor which takes the String arg
+     */
+    @Test
+    void testStringArg() throws Exception {
+        // verify that null is allowed
+        final IdentityException ex = new IdentityException((String) null);
+        assertNull(ex.getMessage(), "unexpected exception message");
+        assertNull(ex.getCause(), "unexpected cause");
+
+        // verify custom exception message
+        final IdentityException ex2 = new IdentityException("hello world");
+        assertEquals("hello world", ex2.getMessage(), "unexpected exception message");
+        assertNull(ex2.getCause(), "unexpected cause");
+    }
+}

--- a/test/jdk/java/lang/IdentityExceptionBasicTest.java
+++ b/test/jdk/java/lang/IdentityExceptionBasicTest.java
@@ -37,23 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class IdentityExceptionBasicTest {
 
     /*
-     * Verify the constructor which takes the Class parameter
-     */
-    @Test
-    void testClassParam() throws Exception {
-        // verify that the exception message contains the given Class
-        final IdentityException ex = new IdentityException(Integer.class);
-        final String exMsg = ex.getMessage();
-        assertNotNull(exMsg, "exception message missing");
-        assertTrue(exMsg.contains(Integer.class.getName()));
-        assertTrue(exMsg.contains("not an identity class"));
-        assertNull(ex.getCause(), "unexpected cause");
-
-        // verify NullPointerException is thrown for null Class
-        assertThrows(NullPointerException.class, () -> new IdentityException((Class<?>) null));
-    }
-
-    /*
      * Verify the no-arg constructor
      */
     @Test


### PR DESCRIPTION
Can I please get a review of this change which specifies that the `IdentityException` throws a `NullPointerException` if the `Class` passed to its constructor is null?

This change is being proposed as part of the JEP-401 standard library changes that are currently under review at https://github.com/openjdk/jdk/pull/31123.

A new jtreg test has been introduced to verify the basic semantics of this exception class.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386815](https://bugs.openjdk.org/browse/JDK-8386815): [lworld] Reduce the number of constructors in IdentityException (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2562/head:pull/2562` \
`$ git checkout pull/2562`

Update a local copy of the PR: \
`$ git checkout pull/2562` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2562`

View PR using the GUI difftool: \
`$ git pr show -t 2562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2562.diff">https://git.openjdk.org/valhalla/pull/2562.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2562#issuecomment-4727751575)
</details>
