### PR TITLE
8386843: [lworld] cherry-pick JDK-8383879 assert(_cur_stack_depth == num_frames) failed: cur_stack_depth out of sync _cur_stack_depth: 9 num_frames: 10

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2318,6 +2318,7 @@ SetForceEarlyReturn::doit(Thread *target) {
   // Set pending step flag for this early return.
   // It is cleared when next step event is posted.
   _state->set_pending_step_for_earlyret();
+  _state->invalidate_cur_stack_depth();
 }
 
 void

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -409,7 +409,8 @@ int JvmtiThreadState::cur_stack_depth() {
   guarantee(get_thread()->is_handshake_safe_for(current),
             "must be current thread or direct handshake");
 
-  if (!is_interp_only_mode() || _cur_stack_depth == UNKNOWN_STACK_DEPTH) {
+  if (!is_interp_only_mode() || _cur_stack_depth == UNKNOWN_STACK_DEPTH
+      || is_pending_step_for_earlyret() || is_pending_step_for_popframe()) {
     _cur_stack_depth = count_frames();
   } else {
 #ifdef ASSERT
@@ -474,7 +475,7 @@ void JvmtiThreadState::process_pending_step_for_popframe() {
 void JvmtiThreadState::update_for_pop_top_frame() {
   // remove any frame pop notification request for the top frame
   // in any environment
-  int popframe_number = cur_stack_depth();
+  int popframe_number = count_frames();
   {
     JvmtiEnvThreadStateIterator it(this);
     for (JvmtiEnvThreadState* ets = it.first(); ets != nullptr; ets = it.next(ets)) {


### PR DESCRIPTION
In order to reduce noise in the Valhalla CI, I'm cherry-picking the fix for:

[JDK-8383879](https://bugs.openjdk.org/browse/JDK-8383879) assert(_cur_stack_depth == num_frames) failed: cur_stack_depth out of sync _cur_stack_depth: 9 num_frames: 10

from main-line to repo-valhalla.

I have a sanity check Mach5 Tier1 job set running.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386843](https://bugs.openjdk.org/browse/JDK-8386843): [lworld] cherry-pick JDK-8383879 assert(_cur_stack_depth == num_frames) failed: cur_stack_depth out of sync _cur_stack_depth: 9 num_frames: 10 (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2563/head:pull/2563` \
`$ git checkout pull/2563`

Update a local copy of the PR: \
`$ git checkout pull/2563` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2563`

View PR using the GUI difftool: \
`$ git pr show -t 2563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2563.diff">https://git.openjdk.org/valhalla/pull/2563.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2563#issuecomment-4733066505)
</details>
