### PR TITLE
8386718: [lworld] C2: Integer overflow in arraycopy scaling for flat arrays

### DIFF
--- a/src/hotspot/share/ci/ciFlatArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciFlatArrayKlass.hpp
@@ -51,6 +51,10 @@ protected:
 public:
   LayoutKind layout_kind() const { return get_FlatArrayKlass()->layout_kind(); }
 
+  jint max_elements() const {
+    return get_FlatArrayKlass()->max_elements();
+  }
+
   int log2_element_size() {
     return Klass::layout_helper_log2_element_size(layout_helper());
   }

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1333,6 +1333,9 @@ const TypePtr* PhaseMacroExpand::adjust_for_flat_array(const TypeAryPtr* top_des
       // treat as array of long but scale length, src offset and dest offset
       assert((elem_size % 8) == 0, "not a power of 2?");
       int factor = elem_size / 8;
+      jint max_safe_scaled_index = max_jint / factor;
+      jint max_elements = top_dest->max_flat_elements();
+      guarantee(max_elements <= max_safe_scaled_index, "scaling must never overflow int range");
       length = transform_later(new MulINode(length, intcon(factor)));
       src_offset = transform_later(new MulINode(src_offset, intcon(factor)));
       dest_offset = transform_later(new MulINode(dest_offset, intcon(factor)));

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5246,6 +5246,10 @@ int TypeAryPtr::flat_log_elem_size() const {
   return exact_klass()->as_flat_array_klass()->log2_element_size();
 }
 
+jint TypeAryPtr::max_flat_elements() const {
+  return exact_klass()->as_flat_array_klass()->max_elements();
+}
+
 //------------------------------cast_to_stable---------------------------------
 const TypeAryPtr* TypeAryPtr::cast_to_stable(bool stable, int stable_dimension) const {
   if (stable_dimension <= 0 || (stable_dimension == 1 && stable == this->is_stable()))

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1858,6 +1858,7 @@ public:
   jint flat_layout_helper() const;
   int flat_elem_size() const;
   int flat_log_elem_size() const;
+  jint max_flat_elements() const;
 
   const TypeAryPtr* cast_to_stable(bool stable, int stable_dimension = 1) const;
   int stable_dimension() const;


### PR DESCRIPTION
The scaled index computation for `elem_size > 8` in `adjust_for_flat_array()` could overflow if we used a sufficiently large array. However, we currently cannot create such a huge array because of running out memory first:

With `factor = 2`, we have `elem_size = 16`. To get the `MulI` to overflow, we need an array length larger than `max_jint / 2`. Thus, we require a payload larger than
```
elem_size * length = 16 * (max_jint / 2) = max_jint * 8
```
But the max flat array size is restricted by `FlatArrayKlass::max_elements()` to not exceed `max_jint * 8` bytes. So, we are always getting an OOM before actually observing an overflow.

Nevertheless, I think we should still add a safety check in `adjust_for_flat_array()` if this upper limit ever changes in the future. I suggest to use a `guarantee()` here to also cover product builds. Alternatively, we could also use an `assert` + compilation bailout. But given that we cannot currently observe this failure, I suggest to go with a `guarantee()`.

Since we do not know the exact array length, I propose to calculate the maximum possible array size and compare it to the maximum scaled index. If we ever change `FlatArrayKlass::max_elements()` to allow bigger arrays, we would catch that with the added `guarantee()`.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386718](https://bugs.openjdk.org/browse/JDK-8386718): [lworld] C2: Integer overflow in arraycopy scaling for flat arrays (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2566/head:pull/2566` \
`$ git checkout pull/2566`

Update a local copy of the PR: \
`$ git checkout pull/2566` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2566`

View PR using the GUI difftool: \
`$ git pr show -t 2566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2566.diff">https://git.openjdk.org/valhalla/pull/2566.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2566#issuecomment-4741630492)
</details>
