### PR TITLE
8386904: [lworld] ProblemList tests that fail due to JDK-8375645 on all platforms

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -62,5 +62,7 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 #############################################################################
 
 # Valhalla failures start here:
+compiler/valhalla/inlinetypes/TestValueClasses.java#id0 8387030 generic-all
+compiler/valhalla/inlinetypes/TestValueClasses.java#id6 8387030 generic-all
 
 runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8378071 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -194,6 +194,8 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 #############################################################################
 
 # Valhalla failures start here:
+applications/ctw/modules/java_base_2.java 8375645 generic-all
+
 compiler/codegen/TestRedundantLea.java#Spill                            8361089 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id4                   8386160 generic-all
 compiler/valhalla/inlinetypes/TestSafepointScalarizationNodeGrowth.java 8386999 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -194,6 +194,7 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 #############################################################################
 
 # Valhalla failures start here:
+applications/ctw/modules/java_base.java 8375645 generic-all
 applications/ctw/modules/java_base_2.java 8375645 generic-all
 
 compiler/codegen/TestRedundantLea.java#Spill                            8361089 generic-all


### PR DESCRIPTION
Trivial fixes to ProblemList tests in repo-valhalla:
- [JDK-8386904](https://bugs.openjdk.org/browse/JDK-8386904) [lworld] ProblemList tests that fail due to JDK-8375645 on all platforms
- [JDK-8387050](https://bugs.openjdk.org/browse/JDK-8387050) [lworld] ProblemList two compiler/valhalla/inlinetypes/TestValueClasses.java sub-tests in Xcomp mode

For JDK-8386904, normally, we do not ProblemList tests in repo-valhalla
when the fix is being chased/developed in main-line. However, in this case,
all of the CI sightings for applications/ctw/modules/java_base_2.java and
applications/ctw/modules/java_base.java are in repo-valhalla.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issues
 * [JDK-8386904](https://bugs.openjdk.org/browse/JDK-8386904): [lworld] ProblemList tests that fail due to JDK-8375645 on all platforms (**Sub-task** - P3)
 * [JDK-8387050](https://bugs.openjdk.org/browse/JDK-8387050): [lworld] ProblemList two compiler/valhalla/inlinetypes/TestValueClasses.java sub-tests in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2567/head:pull/2567` \
`$ git checkout pull/2567`

Update a local copy of the PR: \
`$ git checkout pull/2567` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2567`

View PR using the GUI difftool: \
`$ git pr show -t 2567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2567.diff">https://git.openjdk.org/valhalla/pull/2567.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2567#issuecomment-4773645203)
</details>
