### PR TITLE
8386995: [lworld] Duplicate value classes are a preview feature warning

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -5049,7 +5049,6 @@ public class JavacParser implements Parser {
                     break;
             }
             if (isValueModifier) {
-                checkSourceLevel(Feature.VALUE_CLASSES);
                 return true;
             }
         }

--- a/test/langtools/tools/javac/valhalla/value-objects/DuplicateValueClassWarnings.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/DuplicateValueClassWarnings.java
@@ -1,0 +1,10 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8386995
+ * @summary Value class preview feature warning should be emitted only once
+ * @enablePreview
+ * @compile/ref=DuplicateValueClassWarnings.out -Xlint:preview -XDrawDiagnostics ${test.file}
+ */
+
+public value class DuplicateValueClassWarnings {
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/DuplicateValueClassWarnings.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/DuplicateValueClassWarnings.out
@@ -1,0 +1,2 @@
+DuplicateValueClassWarnings.java:9:8: compiler.warn.preview.feature.use.plural: (compiler.misc.feature.value.classes)
+1 warning


### PR DESCRIPTION
`isValueModifier()` is called twice in `JavacParser`, both calls are immediately followed by a `checkSourceLevel(Feature.VALUE_CLASSES);` when they return true. We can remove this redundant check here, because similar checks for sealed classes, etc. are done outside of modifier detection, too.

Credit to Alan Bateman for discovering this issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386995](https://bugs.openjdk.org/browse/JDK-8386995): [lworld] Duplicate value classes are a preview feature warning (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2570/head:pull/2570` \
`$ git checkout pull/2570`

Update a local copy of the PR: \
`$ git checkout pull/2570` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2570`

View PR using the GUI difftool: \
`$ git pr show -t 2570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2570.diff">https://git.openjdk.org/valhalla/pull/2570.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2570#issuecomment-4763158757)
</details>
