### PR TITLE
8386999: [lworld] C2: assert(is_dead_loop_safe()) failed: shouldn't be cleared yet

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -184,7 +184,7 @@ JVMState* DirectCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
-  if (is_late_inline() && !call->is_boxing_method() && ret->is_Proj()) {
+  if (is_late_inline() && !call->is_boxing_method() && ret->is_Proj() && ret->in(0) == call) {
     // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
     ret->mark_not_dead_loop_safe();
   }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -285,7 +285,7 @@ JVMState* VirtualCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false /*must_throw*/, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
-  if (is_late_inline() && ret->is_Proj()) {
+  if (is_late_inline() && ret->is_Proj() && ret->in(0) == call) {
     // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
     ret->mark_not_dead_loop_safe();
   }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -184,6 +184,10 @@ JVMState* DirectCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
+  if (is_late_inline() && !call->is_boxing_method() && ret->is_Proj()) {
+    // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
+    ret->mark_not_dead_loop_safe();
+  }
   kit.push_node(method()->return_type()->basic_type(), ret);
   return kit.transfer_exceptions_into_jvms();
 }
@@ -281,6 +285,10 @@ JVMState* VirtualCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false /*must_throw*/, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
+  if (is_late_inline() && ret->is_Proj()) {
+    // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
+    ret->mark_not_dead_loop_safe();
+  }
   kit.push_node(method()->return_type()->basic_type(), ret);
 
   // Represent the effect of an implicit receiver null_check

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1080,6 +1080,11 @@ public:
   // The data node which is safe to leave in dead loop during IGVN optimization.
   bool is_dead_loop_safe() const;
 
+  void mark_not_dead_loop_safe() {
+    assert(is_dead_loop_safe(), "shouldn't be cleared yet");
+    remove_flag(Node::Flag_is_dead_loop_safe);
+  }
+
   // is_Copy() returns copied edge index (0 or 1)
   uint is_Copy() const { return (_flags & Flag_is_Copy); }
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -199,7 +199,6 @@ applications/ctw/modules/java_base_2.java 8375645 generic-all
 
 compiler/codegen/TestRedundantLea.java#Spill                            8361089 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id4                   8386160 generic-all
-compiler/valhalla/inlinetypes/TestSafepointScalarizationNodeGrowth.java 8386999 generic-all
 
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8386674 linux-aarch64
 

--- a/test/hotspot/jtreg/compiler/c2/TestDeadLoopLateInlining.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadLoopLateInlining.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8375694
+ * @summary C2: Dead loop constructed with CastPP in late inlining
+ * @run main ${test.main.class}
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
+ *                   -XX:CompileOnly=${test.main.class}::test* -Xcomp ${test.main.class}
+ */
+
+package compiler.c2;
+
+public class TestDeadLoopLateInlining {
+    private static Object fieldObject;
+    private static int field;
+    private static A fieldA = new A();
+    private static B fieldB = new B();
+
+    public static void main(String[] args) {
+        test1(0, true);
+        test2(0, 0, true);
+    }
+
+    private static Object test1(int j, boolean flag) {
+        if (j < 42) {
+            if (flag) {
+                field = 42;
+            }
+            Object o = fieldObject;
+            if (j >= 42) {
+                for (int i = 1; i < 10; ) {
+                    boolean boolRes = lateInlined2();
+                    if (boolRes) {
+                        i *= 2;
+                        o = lateInlined1(o);
+                        if (o == null) {
+                            throw new RuntimeException();
+                        }
+                    } else {
+                        i++;
+                    }
+                }
+            }
+            return o;
+        }
+        return null;
+    }
+
+    private static Object test2(int j, int k, boolean flag) {
+        A a;
+        if (k < 42) {
+            if (flag) {
+                field = 42;
+            }
+            if (k >= 42) {
+                a = fieldA;
+            } else {
+                a = fieldB;
+            }
+            if (a == null) {
+                throw new RuntimeException("never taken");
+            }
+            if (j < 42) {
+                if (flag) {
+                    field = 42;
+                }
+                Object o = fieldObject;
+                if (j >= 42) {
+                    for (int i = 1; i < 10; ) {
+                        boolean boolRes = lateInlined2();
+                        if (boolRes) {
+                            i *= 2;
+                            o = a.lateInlined(o);
+                            if (o == null) {
+                                throw new RuntimeException();
+                            }
+                        } else {
+                            i++;
+                        }
+                    }
+                }
+                return o;
+            }
+        }
+        return null;
+    }
+
+    private static boolean lateInlined2() {
+        return true;
+    }
+
+    private static Object lateInlined1(Object o) {
+        return o;
+    }
+
+
+    static class A {
+        Object lateInlined(Object o) {
+            return o;
+        }
+    }
+
+    static class B extends A {
+        Object lateInlined(Object o) {
+            return o;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallProjSubsumed.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallProjSubsumed.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8386999
+ * @summary [lworld] C2: assert(is_dead_loop_safe()) failed: shouldn't be cleared yet
+ * @enablePreview
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-TieredCompilation
+ *                   -XX:-UseOnStackReplacement -XX:+AlwaysIncrementalInline ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestCallProjSubsumed {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1();
+        }
+    }
+
+    static int test1() {
+        Integer ib = lateInlined1();
+        return ib.intValue();
+    }
+
+    static int lateInlined1() {
+        return 42;
+    }
+}


### PR DESCRIPTION
The problem, here, is that, when a `Proj` is created for a late
inlining call and transformed, it is replaced by a `Proj` for a
dominating call. As a consequence, the code tries to clear an already
cleared flag.

Beyond the fix for the crash here, 8375694 (that added that code)
expects a single return projection but there can be several with the
scalarized calling convention. I filed 8387131 to investigate if the
change from 8375694 needs to be reworked.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386999](https://bugs.openjdk.org/browse/JDK-8386999): [lworld] C2: assert(is_dead_loop_safe()) failed: shouldn't be cleared yet (**Bug** - P2)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2575/head:pull/2575` \
`$ git checkout pull/2575`

Update a local copy of the PR: \
`$ git checkout pull/2575` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2575`

View PR using the GUI difftool: \
`$ git pr show -t 2575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2575.diff">https://git.openjdk.org/valhalla/pull/2575.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2575#issuecomment-4779881298)
</details>
