### PR TITLE
8382937: [lworld] System.arraycopy can copy null into a null-restricted array

### DIFF
--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -334,7 +334,7 @@ void FlatArrayKlass::copy_array(arrayOop s, int src_pos,
       flatArrayHandle sh(THREAD, sa);
       for (int i = 0; i < length; i++) {
         oop o = sh->obj_at(src_pos + i, CHECK);
-        dh->obj_at_put(dst_pos + i, o);
+        dh->obj_at_put(dst_pos + i, o, CHECK);
       }
     }
   } else {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+
+/*
+ * @test
+ * @bug 8382937
+ * @summary System.arraycopy must throw NPE when copying null into a null-restricted array.
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.value
+ * @enablePreview
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *                   -XX:+UseArrayFlattening -XX:+UseNullableAtomicValueFlattening
+ *                   -XX:-UseNullFreeAtomicValueFlattening -XX:-UseNullFreeNonAtomicValueFlattening
+ *                   runtime.valhalla.inlinetypes.ArrayCopyStoreNull
+ */
+public class ArrayCopyStoreNull {
+    value record MyRecord(int f) {}
+
+    public static void main(String... args) {
+        MyRecord[] nullableArray =
+                (MyRecord[]) ValueClass.newNullableAtomicArray(MyRecord.class, 2);
+        MyRecord[] nullRestrictedArray =
+                (MyRecord[]) ValueClass.newNullRestrictedAtomicArray(MyRecord.class, 2, new MyRecord(1));
+
+        // Non-null value can be copied into a null-restricted array.
+        nullableArray[0] = new MyRecord(42);
+        System.arraycopy(nullableArray, 0, nullRestrictedArray, 0, 1);
+
+        // Null value cannot be copied into a null-restricted array.
+        nullableArray[1] = null;
+        try {
+            System.arraycopy(nullableArray, 1, nullRestrictedArray, 1, 1);
+        } catch (NullPointerException expected) {
+            return;
+        }
+
+        throw new RuntimeException("System.arraycopy did not throw the required NullPointerException");
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java
@@ -32,8 +32,7 @@ import jdk.internal.value.ValueClass;
  * @requires vm.flagless
  * @modules java.base/jdk.internal.value
  * @enablePreview
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *                   -XX:+UseArrayFlattening -XX:+UseNullableAtomicValueFlattening
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions
  *                   -XX:-UseNullFreeAtomicValueFlattening -XX:-UseNullFreeNonAtomicValueFlattening
  *                   runtime.valhalla.inlinetypes.ArrayCopyStoreNull
  */


### PR DESCRIPTION
Fix null checking when copying from flat arrays to reference arrays.

Previously, `FlatArrayKlass::copy_array` called `obj_at_put` without `CHECK`. 
As aresult, the runtime check for null-restricted arrays was bypassed.

A new test has been added to verify this behaviour.

Thanks.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8382937](https://bugs.openjdk.org/browse/JDK-8382937): [lworld] System.arraycopy can copy null into a null-restricted array (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2577/head:pull/2577` \
`$ git checkout pull/2577`

Update a local copy of the PR: \
`$ git checkout pull/2577` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2577`

View PR using the GUI difftool: \
`$ git pr show -t 2577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2577.diff">https://git.openjdk.org/valhalla/pull/2577.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2577#issuecomment-4790583511)
</details>
