### PR TITLE
8387252: [lworld] LoadFlattenedArrayStub may not consider the spill inserted by RA

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2380,6 +2380,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
   } else {
     LIR_Opr result = rlock_result(x, x->elt_type());
     LoadFlattenedArrayStub* slow_path = nullptr;
+    LIR_Opr load_result = result;
 
     if (x->should_profile() && x->array()->maybe_null_free_array()) {
       profile_null_free_array(array, md, data);
@@ -2388,19 +2389,25 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
     if (x->elt_type() == T_OBJECT && x->array()->maybe_flat_array()) {
       assert(x->delayed() == nullptr, "Delayed LoadIndexed only apply to loaded_flat_arrays");
       index.load_item();
-      // if we are loading from a flat array, load it using a runtime call
-      slow_path = new LoadFlattenedArrayStub(array.result(), index.result(), result, state_for(x, x->state_before()));
+      // Use a temporary for the conditional load so that the RA defines
+      // 'result' at the continuation point (after both paths merge).
+      // Otherwise, the RA may insert a spill at the load's def point
+      // (inside the conditional code), and the stub's continuation jump
+      // would skip that spill, leaving the spill slot stale.
+      load_result = new_register(T_OBJECT);
+      slow_path = new LoadFlattenedArrayStub(array.result(), index.result(), load_result, state_for(x, x->state_before()));
       check_flat_array(array.result(), slow_path);
       set_in_conditional_code(true);
     }
 
     DecoratorSet decorators = IN_HEAP | IS_ARRAY;
     access_load_at(decorators, x->elt_type(),
-                   array, index.result(), result,
+                   array, index.result(), load_result,
                    nullptr, null_check_info);
 
     if (slow_path != nullptr) {
       __ branch_destination(slow_path->continuation());
+      __ move(load_result, result);
       set_in_conditional_code(false);
     }
 


### PR DESCRIPTION
Hi, as discussed here, https://github.com/openjdk/jdk/pull/31122#discussion_r3456766597

 I think there's a bug here. Although this issue occurs on RISC-V, we can see that this spill was automatically inserted by RA; we didn't perform any operations manually.
And maybe the reason of a spill move [c_rarg5|L] [stack:10|L] inserted by RA is probably because the registers are under a lot of pressure at this stage.
I created a new issue to track https://bugs.openjdk.org/browse/JDK-8387252, and I'll try to reproduce this bug on other architectures.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387252](https://bugs.openjdk.org/browse/JDK-8387252): [lworld] LoadFlattenedArrayStub may not consider the spill inserted by RA (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2579/head:pull/2579` \
`$ git checkout pull/2579`

Update a local copy of the PR: \
`$ git checkout pull/2579` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2579`

View PR using the GUI difftool: \
`$ git pr show -t 2579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2579.diff">https://git.openjdk.org/valhalla/pull/2579.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2579#issuecomment-4791979777)
</details>
