### PR TITLE
8387131: [lworld] C2: revisit 8375694 for scalarized return values

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -184,9 +184,31 @@ JVMState* DirectCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
-  if (is_late_inline() && !call->is_boxing_method() && ret->is_Proj() && ret->in(0) == call) {
+  if (is_late_inline() && !call->is_boxing_method()) {
     // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
-    ret->mark_not_dead_loop_safe();
+    if (ret->is_Proj() && ret->in(0) == call) {
+      ret->mark_not_dead_loop_safe();
+    } else if (ret->isa_InlineType()) {
+      InlineTypeNode* vt = ret->as_InlineType();
+      Node* oop = vt->get_oop();
+      if (oop->is_Proj()) {
+        assert(oop->in(0) == call, "");
+        oop->mark_not_dead_loop_safe();
+      }
+      Node* null_marker = vt->get_null_marker();
+      if (null_marker->is_Proj()) {
+        assert(null_marker->in(0) == call, "");
+        null_marker->mark_not_dead_loop_safe();
+      }
+
+      for (uint i = 0; i < vt->field_count(); i++) {
+        Node* field = vt->field_value(i);
+        if (field->is_Proj()) {
+          assert(field->in(0) == call, "");
+          field->mark_not_dead_loop_safe();
+        }
+      }
+    }
   }
   kit.push_node(method()->return_type()->basic_type(), ret);
   return kit.transfer_exceptions_into_jvms();
@@ -285,9 +307,31 @@ JVMState* VirtualCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false /*must_throw*/, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
-  if (is_late_inline() && ret->is_Proj() && ret->in(0) == call) {
+  if (is_late_inline()) {
     // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
-    ret->mark_not_dead_loop_safe();
+    if (ret->is_Proj() && ret->in(0) == call) {
+      ret->mark_not_dead_loop_safe();
+    } else if (ret->isa_InlineType()) {
+      InlineTypeNode* vt = ret->as_InlineType();
+      Node* oop = vt->get_oop();
+      if (oop->is_Proj()) {
+        assert(oop->in(0) == call, "");
+        oop->mark_not_dead_loop_safe();
+      }
+      Node* null_marker = vt->get_null_marker();
+      if (null_marker->is_Proj()) {
+        assert(null_marker->in(0) == call, "");
+        null_marker->mark_not_dead_loop_safe();
+      }
+
+      for (uint i = 0; i < vt->field_count(); i++) {
+        Node* field = vt->field_value(i);
+        if (field->is_Proj()) {
+          assert(field->in(0) == call, "");
+          field->mark_not_dead_loop_safe();
+        }
+      }
+    }
   }
   kit.push_node(method()->return_type()->basic_type(), ret);
 

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -73,20 +73,17 @@ void CallGenerator::mark_projs_not_dead_loop_safe(Node* ret) const {
   } else if (ret->isa_InlineType()) {
     InlineTypeNode* vt = ret->as_InlineType();
     Node* oop = vt->get_oop();
-    if (oop->is_Proj()) {
-      assert(oop->in(0) == call, "projection was replaced by dominating one");
+    if (oop->is_Proj() && oop->in(0) == call) {
       oop->mark_not_dead_loop_safe();
     }
     Node* null_marker = vt->get_null_marker();
-    if (null_marker->is_Proj()) {
-      assert(null_marker->in(0) == call, "projection was replaced by dominating one");
+    if (null_marker->is_Proj() && null_marker->in(0) == call) {
       null_marker->mark_not_dead_loop_safe();
     }
 
     for (uint i = 0; i < vt->field_count(); i++) {
       Node* field = vt->field_value(i);
-      if (field->is_Proj()) {
-        assert(field->in(0) == call, "projection was replaced by dominating one");
+      if (field->is_Proj() && field->in(0) == call) {
         field->mark_not_dead_loop_safe();
       }
     }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -62,6 +62,37 @@ bool CallGenerator::is_inlined_method_handle_intrinsic(ciMethod* symbolic_info, 
   return symbolic_info->is_method_handle_intrinsic() && !m->is_method_handle_intrinsic();
 }
 
+// If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
+void CallGenerator::mark_projs_not_dead_loop_safe(Node* ret) const {
+  if (!is_late_inline()) {
+    return;
+  }
+  CallNode* call = call_node();
+  if (ret->is_Proj() && ret->in(0) == call) {
+    ret->mark_not_dead_loop_safe();
+  } else if (ret->isa_InlineType()) {
+    InlineTypeNode* vt = ret->as_InlineType();
+    Node* oop = vt->get_oop();
+    if (oop->is_Proj()) {
+      assert(oop->in(0) == call, "projection was replaced by dominating one");
+      oop->mark_not_dead_loop_safe();
+    }
+    Node* null_marker = vt->get_null_marker();
+    if (null_marker->is_Proj()) {
+      assert(null_marker->in(0) == call, "projection was replaced by dominating one");
+      null_marker->mark_not_dead_loop_safe();
+    }
+
+    for (uint i = 0; i < vt->field_count(); i++) {
+      Node* field = vt->field_value(i);
+      if (field->is_Proj()) {
+        assert(field->in(0) == call, "projection was replaced by dominating one");
+        field->mark_not_dead_loop_safe();
+      }
+    }
+  }
+}
+
 //-----------------------------ParseGenerator---------------------------------
 // Internal class which handles all direct bytecode traversal.
 class ParseGenerator : public InlineCallGenerator {
@@ -184,31 +215,8 @@ JVMState* DirectCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
-  if (is_late_inline() && !call->is_boxing_method()) {
-    // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
-    if (ret->is_Proj() && ret->in(0) == call) {
-      ret->mark_not_dead_loop_safe();
-    } else if (ret->isa_InlineType()) {
-      InlineTypeNode* vt = ret->as_InlineType();
-      Node* oop = vt->get_oop();
-      if (oop->is_Proj()) {
-        assert(oop->in(0) == call, "");
-        oop->mark_not_dead_loop_safe();
-      }
-      Node* null_marker = vt->get_null_marker();
-      if (null_marker->is_Proj()) {
-        assert(null_marker->in(0) == call, "");
-        null_marker->mark_not_dead_loop_safe();
-      }
-
-      for (uint i = 0; i < vt->field_count(); i++) {
-        Node* field = vt->field_value(i);
-        if (field->is_Proj()) {
-          assert(field->in(0) == call, "");
-          field->mark_not_dead_loop_safe();
-        }
-      }
-    }
+  if (!call->is_boxing_method()) {
+    mark_projs_not_dead_loop_safe(ret);
   }
   kit.push_node(method()->return_type()->basic_type(), ret);
   return kit.transfer_exceptions_into_jvms();
@@ -307,32 +315,7 @@ JVMState* VirtualCallGenerator::generate(JVMState* jvms) {
   kit.set_arguments_for_java_call(call);
   kit.set_edges_for_java_call(call, false /*must_throw*/, _separate_io_proj);
   Node* ret = kit.set_results_for_java_call(call, _separate_io_proj);
-  if (is_late_inline()) {
-    // If late inlining for this call happens in a dead part of the graph it can leave a dead loop behind
-    if (ret->is_Proj() && ret->in(0) == call) {
-      ret->mark_not_dead_loop_safe();
-    } else if (ret->isa_InlineType()) {
-      InlineTypeNode* vt = ret->as_InlineType();
-      Node* oop = vt->get_oop();
-      if (oop->is_Proj()) {
-        assert(oop->in(0) == call, "");
-        oop->mark_not_dead_loop_safe();
-      }
-      Node* null_marker = vt->get_null_marker();
-      if (null_marker->is_Proj()) {
-        assert(null_marker->in(0) == call, "");
-        null_marker->mark_not_dead_loop_safe();
-      }
-
-      for (uint i = 0; i < vt->field_count(); i++) {
-        Node* field = vt->field_value(i);
-        if (field->is_Proj()) {
-          assert(field->in(0) == call, "");
-          field->mark_not_dead_loop_safe();
-        }
-      }
-    }
-  }
+  mark_projs_not_dead_loop_safe(ret);
   kit.push_node(method()->return_type()->basic_type(), ret);
 
   // Represent the effect of an implicit receiver null_check

--- a/src/hotspot/share/opto/callGenerator.hpp
+++ b/src/hotspot/share/opto/callGenerator.hpp
@@ -47,6 +47,8 @@ class CallGenerator : public ArenaObj {
   virtual bool           do_late_inline_check(Compile* C, JVMState* jvms) { ShouldNotReachHere(); return false; }
   virtual bool           is_pure_call() const                             { ShouldNotReachHere(); return false; }
 
+  void mark_projs_not_dead_loop_safe(Node* ret) const;
+
  public:
   // Accessors
   ciMethod*          method() const             { return _method; }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadLoopLateInliningWithValues.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadLoopLateInliningWithValues.java
@@ -28,7 +28,9 @@
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
  * @run main ${test.main.class}
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
+ * @run main/othervm -XX:CompileCommand=option,${test.main.class}::lateInlined2,delayinline
+ *                   -XX:CompileCommand=option,${test.main.class}::lateInlined1,delayinline
+ *                   -XX:CompileCommand=option,${test.main.class}$A::lateInlined,delayinline
  *                   -XX:CompileOnly=${test.main.class}::test* -Xcomp ${test.main.class}
  */
 
@@ -50,7 +52,8 @@ public class TestDeadLoopLateInliningWithValues {
     }
 
     public static void main(String[] args) {
-        test1(0, true);
+        MyValue v = new MyValue(null);
+        //test1(0, true);
         test2(0, 0, true);
     }
 
@@ -65,7 +68,8 @@ public class TestDeadLoopLateInliningWithValues {
                     boolean boolRes = lateInlined2();
                     if (boolRes) {
                         i *= 2;
-                        o = lateInlined1(o).o;
+                        MyValue v = new MyValue(o);
+                        o = lateInlined1(v).o;
                         if (o == null) {
                             throw new RuntimeException();
                         }
@@ -78,6 +82,8 @@ public class TestDeadLoopLateInliningWithValues {
         }
         return null;
     }
+
+    static final MyValue[] valueArray = new MyValue[1];
 
     private static Object test2(int j, int k, boolean flag) {
         A a;
@@ -103,7 +109,8 @@ public class TestDeadLoopLateInliningWithValues {
                         boolean boolRes = lateInlined2();
                         if (boolRes) {
                             i *= 2;
-                            o = a.lateInlined(o);
+                            MyValue v = new MyValue(o);
+                            o = a.lateInlined(v).o;
                             if (o == null) {
                                 throw new RuntimeException();
                             }
@@ -122,15 +129,14 @@ public class TestDeadLoopLateInliningWithValues {
         return true;
     }
 
-    @NullRestricted
-    private static MyValue lateInlined1(Object o) {
-        return new MyValue(o);
+    private static MyValue lateInlined1(MyValue o) {
+        return o;
     }
 
 
     static class A {
-        Object lateInlined(Object o) {
-            return o;
+        MyValue lateInlined(MyValue v) {
+            return v;
         }
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadLoopLateInliningWithValues.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadLoopLateInliningWithValues.java
@@ -53,7 +53,7 @@ public class TestDeadLoopLateInliningWithValues {
 
     public static void main(String[] args) {
         MyValue v = new MyValue(null);
-        //test1(0, true);
+        test1(0, true);
         test2(0, 0, true);
     }
 
@@ -141,8 +141,8 @@ public class TestDeadLoopLateInliningWithValues {
     }
 
     static class B extends A {
-        Object lateInlined(Object o) {
-            return o;
+        MyValue lateInlined(MyValue v) {
+            return v;
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadLoopLateInliningWithValues.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadLoopLateInliningWithValues.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8375694
+ * @summary C2: Dead loop constructed with CastPP in late inlining
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class}
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
+ *                   -XX:CompileOnly=${test.main.class}::test* -Xcomp ${test.main.class}
+ */
+
+package compiler.c2;
+import jdk.internal.vm.annotation.NullRestricted;
+
+public class TestDeadLoopLateInliningWithValues {
+    private static Object fieldObject;
+    private static int field;
+    private static A fieldA = new A();
+    private static B fieldB = new B();
+
+    static value class MyValue {
+        Object o;
+
+        MyValue(Object o) {
+            this.o = o;
+        }
+    }
+
+    public static void main(String[] args) {
+        test1(0, true);
+        test2(0, 0, true);
+    }
+
+    private static Object test1(int j, boolean flag) {
+        if (j < 42) {
+            if (flag) {
+                field = 42;
+            }
+            Object o = fieldObject;
+            if (j >= 42) {
+                for (int i = 1; i < 10; ) {
+                    boolean boolRes = lateInlined2();
+                    if (boolRes) {
+                        i *= 2;
+                        o = lateInlined1(o).o;
+                        if (o == null) {
+                            throw new RuntimeException();
+                        }
+                    } else {
+                        i++;
+                    }
+                }
+            }
+            return o;
+        }
+        return null;
+    }
+
+    private static Object test2(int j, int k, boolean flag) {
+        A a;
+        if (k < 42) {
+            if (flag) {
+                field = 42;
+            }
+            if (k >= 42) {
+                a = fieldA;
+            } else {
+                a = fieldB;
+            }
+            if (a == null) {
+                throw new RuntimeException("never taken");
+            }
+            if (j < 42) {
+                if (flag) {
+                    field = 42;
+                }
+                Object o = fieldObject;
+                if (j >= 42) {
+                    for (int i = 1; i < 10; ) {
+                        boolean boolRes = lateInlined2();
+                        if (boolRes) {
+                            i *= 2;
+                            o = a.lateInlined(o);
+                            if (o == null) {
+                                throw new RuntimeException();
+                            }
+                        } else {
+                            i++;
+                        }
+                    }
+                }
+                return o;
+            }
+        }
+        return null;
+    }
+
+    private static boolean lateInlined2() {
+        return true;
+    }
+
+    @NullRestricted
+    private static MyValue lateInlined1(Object o) {
+        return new MyValue(o);
+    }
+
+
+    static class A {
+        Object lateInlined(Object o) {
+            return o;
+        }
+    }
+
+    static class B extends A {
+        Object lateInlined(Object o) {
+            return o;
+        }
+    }
+}


### PR DESCRIPTION
In mainline, a single value can be returned from a call. With
valhalla, multiple values can be returned so the fix for 8375694 needs
to be adjusted.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387131](https://bugs.openjdk.org/browse/JDK-8387131): [lworld] C2: revisit 8375694 for scalarized return values (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2580/head:pull/2580` \
`$ git checkout pull/2580`

Update a local copy of the PR: \
`$ git checkout pull/2580` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2580`

View PR using the GUI difftool: \
`$ git pr show -t 2580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2580.diff">https://git.openjdk.org/valhalla/pull/2580.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2580#issuecomment-4797210150)
</details>
