### PR TITLE
8386889: [lworld] Redundant StoreStore membar after FlatValuePayload::read

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -870,10 +870,6 @@ OopMapSet* Runtime1::generate_code_for(StubId id, StubAssembler* sasm) {
         f.load_argument(0, r1); // r1,: index
         int call_offset = __ call_RT(r0, noreg, CAST_FROM_FN_PTR(address, load_flat_array), r0, r1);
 
-        // Ensure the stores that initialize the buffer are visible
-        // before any subsequent store that publishes this reference.
-        __ membar(Assembler::StoreStore);
-
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers_except_r0(sasm);

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -212,7 +212,6 @@ void InterpreterMacroAssembler::get_method_counters(Register method,
 
 void InterpreterMacroAssembler::read_flat_field(Register entry, Register obj) {
   call_VM(obj, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_flat_field), obj, entry);
-  membar(Assembler::StoreStore);
 }
 
 void InterpreterMacroAssembler::write_flat_field(Register entry, Register field_offset,

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -2432,7 +2432,6 @@ void InterpreterMacroAssembler::notify_method_exit(bool is_native_method, TosSta
 
 void InterpreterMacroAssembler::read_flat_field(Register entry, Register obj) {
   call_VM(obj, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_flat_field), obj, entry);
-  membar(Assembler::StoreStore | Assembler::LoadLoad); // for allocation and volatile load
 }
 
 void InterpreterMacroAssembler::write_flat_field(Register entry, Register tmp1, Register tmp2,

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3417,7 +3417,6 @@ void TemplateTable::fast_accessfield(TosState state) {
       if (support_IRIW_for_not_multiple_copy_atomic_cpu) { __ fence(); }
       __ read_flat_field(Rcache, R17_tos);
       __ verify_oop(R17_tos);
-      // memory barrier in read_flat_field
       break;
     }
     case Bytecodes::_fast_agetfield:

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3417,6 +3417,8 @@ void TemplateTable::fast_accessfield(TosState state) {
       if (support_IRIW_for_not_multiple_copy_atomic_cpu) { __ fence(); }
       __ read_flat_field(Rcache, R17_tos);
       __ verify_oop(R17_tos);
+      __ twi_0(R17_tos);
+      __ isync();
       break;
     }
     case Bytecodes::_fast_agetfield:

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -871,10 +871,6 @@ OopMapSet* Runtime1::generate_code_for(StubId id, StubAssembler* sasm) {
         f.load_argument(0, x11); // x11,: index
         int call_offset = __ call_RT(x10, noreg, CAST_FROM_FN_PTR(address, load_flat_array), x10, x11);
 
-        // Ensure the stores that initialize the buffer are visible
-        // before many subsequent store that publishes this reference.
-        __ membar(MacroAssembler::StoreStore);
-
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers_except_r10(sasm);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -1868,7 +1868,6 @@ void InterpreterMacroAssembler::get_method_counters(Register method,
 
 void InterpreterMacroAssembler::read_flat_field(Register entry, Register obj) {
   call_VM(obj, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_flat_field), obj, entry);
-  membar(MacroAssembler::StoreStore);
 }
 
 void InterpreterMacroAssembler::write_flat_field(Register entry, Register field_offset,


### PR DESCRIPTION
Hello,

This is (yet another) cleanup to remove redundant memory barriers after the new ValuePayload abstraction API in the runtime. The ValuePayload API's (including FlatValuePayload::read) does the necessary calls to order stores of the copy before the oop is published (OrderAccess::storestore), making the platform-specific memory barriers redundant.

I don't have hardware access to RISCV or PPC, but looking at the runtime implementations of OrderAccess::storestore, they achieve the same thing as the platform-specific memory barriers that I suggest we remove in this PR. ~~GHA will show that this compiles at least.~~ Edit: looks like linux-cross-compile is not enabled for the lworld branch yet.

`membar(Assembler::StoreStore | Assembler::LoadLoad);` and `OrderAccess::storestore()` both boil down to `lwsync` on PPC.

The C1 call to `load_flat_array` already omits the memory barrier, so we don't need to remove it here.

Testing:
* Oracle's tier1-3 linux-aarch64
* GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386889](https://bugs.openjdk.org/browse/JDK-8386889): [lworld] Redundant StoreStore membar after FlatValuePayload::read (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - no project role)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2581/head:pull/2581` \
`$ git checkout pull/2581`

Update a local copy of the PR: \
`$ git checkout pull/2581` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2581`

View PR using the GUI difftool: \
`$ git pr show -t 2581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2581.diff">https://git.openjdk.org/valhalla/pull/2581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2581#issuecomment-4797948398)
</details>
