### PR TITLE
8387300: [lworld] Minor review comments in javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -267,11 +267,6 @@ public class Lint {
         MODULE("module", Property.ENABLED_BY_DEFAULT),
 
         /**
-         * Warn about issues related to migration of JDK classes.
-         */
-        MIGRATION("migration"),
-
-        /**
          * Warn about issues regarding module opens.
          */
         OPENS("opens", Property.ENABLED_BY_DEFAULT),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -298,13 +298,13 @@ public enum Source {
         WARN_ON_ILLEGAL_UTF8(MIN, JDK21),
         UNNAMED_VARIABLES(JDK22, Fragments.FeatureUnnamedVariables, DiagKind.PLURAL),
         PRIMITIVE_PATTERNS(JDK23, Fragments.FeaturePrimitivePatterns, DiagKind.PLURAL),
-        VALUE_CLASSES(JDK22, Fragments.FeatureValueClasses, DiagKind.PLURAL),
         FLEXIBLE_CONSTRUCTORS(JDK25, Fragments.FeatureFlexibleConstructors, DiagKind.NORMAL),
         MODULE_IMPORTS(JDK25, Fragments.FeatureModuleImports, DiagKind.PLURAL),
         JAVA_BASE_TRANSITIVE(JDK25, Fragments.FeatureJavaBaseTransitive, DiagKind.PLURAL),
         PRIVATE_MEMBERS_IN_PERMITS_CLAUSE(JDK19),
         ERASE_POLY_SIG_RETURN_TYPE(JDK24),
         CAPTURE_MREF_RETURN_TYPE(JDK26),
+        VALUE_CLASSES(DEFAULT, Fragments.FeatureValueClasses, DiagKind.PLURAL),
         ;
 
         enum DiagKind {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3905,9 +3905,9 @@ public class JavacParser implements Parser {
         }
         if (name == names.value) {
             if (allowValueClasses) {
-                return Source.JDK23;
+                return Source.DEFAULT;
             } else if (shouldWarn) {
-                log.warning(pos, Warnings.RestrictedTypeNotAllowedPreview(name, Source.JDK23));
+                log.warning(pos, Warnings.RestrictedTypeNotAllowedPreview(name, Source.DEFAULT));
             }
         }
         if (name == names.sealed) {
@@ -5042,7 +5042,7 @@ public class JavacParser implements Parser {
                 case CLASS: case INTERFACE: case ENUM:
                     isValueModifier = true;
                     break;
-                case IDENTIFIER: // value record R || value value || new value Comparable() {} ??
+                case IDENTIFIER: // value record R || value value
                     if (next.name() == names.record || next.name() == names.value
                             || (mode & EXPR) != 0)
                         isValueModifier = true;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -237,9 +237,6 @@ javac.opt.Xlint.desc.lossy-conversions=\
 
 javac.opt.Xlint.desc.module=\
     Warn about module system related issues.
-
-javac.opt.Xlint.desc.migration=\
-    Warn about issues related to migration of JDK classes.
 
 javac.opt.Xlint.desc.opens=\
     Warn about issues regarding module opens.


### PR DESCRIPTION
Some comments on the javac review thread:

1. Versions for value class feature
2. Redundant migration category

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387300](https://bugs.openjdk.org/browse/JDK-8387300): [lworld] Minor review comments in javac (**Enhancement** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2582/head:pull/2582` \
`$ git checkout pull/2582`

Update a local copy of the PR: \
`$ git checkout pull/2582` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2582`

View PR using the GUI difftool: \
`$ git pr show -t 2582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2582.diff">https://git.openjdk.org/valhalla/pull/2582.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2582#issuecomment-4800824616)
</details>
