### PR TITLE
8386719: [lworld] Remaining ValueClass argument verification issues 

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -434,8 +434,8 @@ JVM_ENTRY(jarray, JVM_CopyOfSpecialArray(JNIEnv *env, jarray orig, jint from, ji
   arrayOop org = (arrayOop)o;
   arrayHandle oh(THREAD, org);
   ObjArrayKlass* ak = ObjArrayKlass::cast(org->klass());
-  InlineKlass* vk = InlineKlass::cast(ak->element_klass());
   int len = to - from;  // length of the new array
+  assert(len >= 0, "Java caller checks that from <= to");
   int orig_length = org->length();
   if (ak->is_null_free_array_klass()) {
     if ((len != 0) && (from >= orig_length || to > orig_length)) {
@@ -448,22 +448,25 @@ JVM_ENTRY(jarray, JVM_CopyOfSpecialArray(JNIEnv *env, jarray orig, jint from, ji
     dest = fak->allocate_instance(len, CHECK_NULL);
   } else {
     const ArrayProperties props = ArrayProperties::Default().with_null_restricted(ak->is_null_free_array_klass());
+    InlineKlass* vk = InlineKlass::cast(ak->element_klass());
     dest = oopFactory::new_objArray(vk, len, props,  CHECK_NULL);
   }
 
-  arrayHandle dh(THREAD, dest);
+  objArrayHandle dh(THREAD, dest);
 
   int copy_len = MIN2(to, orig_length) - MIN2(from, orig_length);
   if (copy_len != 0) {
     assert(!ak->is_null_free_array_klass() || copy_len == len,
            "Failed to throw the IllegalArgumentException");
     ak->copy_array(oh(), from, dh(), 0, copy_len, CHECK_NULL);
+    // Null out values past the length of the copy
     for (int i = copy_len; i < len; i++) {
-      ((objArrayOop)dh())->obj_at_put(i, nullptr);
+      dh()->obj_at_put(i, nullptr);
     }
   } else {
     for (int i = 0; i < len; i++) {
-      ((objArrayOop)dh())->obj_at_put(i, nullptr);
+      assert(!dh()->is_null_free_array(), "Should have thrown an IAE above");
+      dh()->obj_at_put(i, nullptr);
     }
   }
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -430,56 +430,45 @@ JVM_END
 JVM_ENTRY(jarray, JVM_CopyOfSpecialArray(JNIEnv *env, jarray orig, jint from, jint to))
   oop o = JNIHandles::resolve_non_null(orig);
   assert(o->is_array(), "Must be");
-  oop array = nullptr;
+  objArrayOop dest = nullptr;
   arrayOop org = (arrayOop)o;
   arrayHandle oh(THREAD, org);
   ObjArrayKlass* ak = ObjArrayKlass::cast(org->klass());
   InlineKlass* vk = InlineKlass::cast(ak->element_klass());
   int len = to - from;  // length of the new array
+  int orig_length = org->length();
   if (ak->is_null_free_array_klass()) {
-    if ((len != 0) && (from >= org->length() || to > org->length())) {
+    if ((len != 0) && (from >= orig_length || to > orig_length)) {
       THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Copying of null-free array with uninitialized elements");
     }
   }
-  if (ak->is_flatArray_klass()) {
-    // The whole JVM_CopyOfSpecialArray is currently broken. Fix this in a separate bugfix.
-    int org_length = org->length();
-    int copy_len = MIN2(to, org_length) - MIN2(from, org_length);
-    FlatArrayKlass* const fak = FlatArrayKlass::cast(org->klass());
-    flatArrayOop dst = fak->allocate_instance(len, CHECK_NULL);
-    assert(!ak->is_null_free_array_klass() || copy_len == len,
-           "Failed to throw the IllegalArgumentException");
-    if (copy_len != 0) {
-      int start = MIN2(from, org_length - 1);
-      FlatArrayPayload src_payload(flatArrayOop(oh()), start, fak);
-      FlatArrayPayload dst_payload(dst, 0, fak);
-      int end = to < oh()->length() ? to : oh()->length();
-      for (int i = from; i < end; i++) {
-        // Copy a value
-        src_payload.copy_to(dst_payload);
 
-        // Advance to the next element
-        src_payload.next_element();
-        dst_payload.next_element();
-      }
-    }
-    array = dst;
+  if (ak->is_flatArray_klass()) {
+    FlatArrayKlass* const fak = FlatArrayKlass::cast(org->klass());
+    dest = fak->allocate_instance(len, CHECK_NULL);
   } else {
     const ArrayProperties props = ArrayProperties::Default().with_null_restricted(ak->is_null_free_array_klass());
+    dest = oopFactory::new_objArray(vk, len, props,  CHECK_NULL);
+  }
 
-    array = oopFactory::new_objArray(vk, len, props,  CHECK_NULL);
-    int end = to < oh()->length() ? to : oh()->length();
-    for (int i = from; i < end; i++) {
-      if (i < ((objArrayOop)oh())->length()) {
-        oop val = ((objArrayOop)oh())->obj_at(i, CHECK_NULL);
-        ((objArrayOop)array)->obj_at_put(i - from, val);
-      } else {
-        assert(!ak->is_null_free_array_klass(), "Must be a nullable array");
-        ((objArrayOop)array)->obj_at_put(i - from, nullptr);
-      }
+  arrayHandle dh(THREAD, dest);
+
+  int copy_len = MIN2(to, orig_length) - MIN2(from, orig_length);
+  if (copy_len != 0) {
+    assert(!ak->is_null_free_array_klass() || copy_len == len,
+           "Failed to throw the IllegalArgumentException");
+    ak->copy_array(oh(), from, dh(), 0, copy_len, CHECK_NULL);
+    for (int i = copy_len; i < len; i++) {
+      ((objArrayOop)dh())->obj_at_put(i, nullptr);
+    }
+  } else {
+    for (int i = 0; i < len; i++) {
+      ((objArrayOop)dh())->obj_at_put(i, nullptr);
     }
   }
-  return (jarray) JNIHandles::make_local(THREAD, array);
+
+  return (jarray) JNIHandles::make_local(THREAD, dh());
+
 JVM_END
 
 #ifdef ASSERT

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -172,7 +172,16 @@ public final class ValueClass {
     @IntrinsicCandidate
     private static native boolean isFlatArray0(Object[] array);
 
+    @ForceInline
+    private static void validateSpecialArray(Object[] array) {
+        Objects.requireNonNull(array);
+        if (!isConcreteValueClass(array.getClass().getComponentType())) {
+          throw new IllegalArgumentException("Element class is not a concrete value class");
+        }
+    }
+
     public static Object[] copyOfSpecialArray(Object[] array, int newLength) {
+        validateSpecialArray(array);
         if (newLength < 0) {
             throw new NegativeArraySizeException("" + newLength);
         }
@@ -180,6 +189,7 @@ public final class ValueClass {
     }
 
     public static Object[] copyOfRangeSpecialArray(Object[] array, int from, int to) {
+        validateSpecialArray(array);
         int length = array.length;
         if (from < 0 || from > length) {
             throw new ArrayIndexOutOfBoundsException("source index " + from + " out of bounds for object array[" + length + "]");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -636,7 +636,7 @@ public class InlineTypeArray {
         expected3b[2] = null;
         checkArrayElementsEqual(exceedingRangeCopy, expected3b);
 
-        // Range starting after the end of the original array, must suceed for nullable arrays
+        // Range starting after the end of the original array, must succeed for nullable arrays
         MyInt[] farRangeCopy = (MyInt[]) Arrays.copyOfRange(myInts, myInts.length, myInts.length + 1);
         MyInt[] expected3c = (MyInt[])ValueClass.newNullableAtomicArray(MyInt.class, 1);
         expected3c[0] = null;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestArrayFactories.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestArrayFactories.java
@@ -294,6 +294,123 @@ public class TestArrayFactories {
         } catch (NullPointerException e) { }
     }
 
+    // Test arguments validation in copyOfSpecialArray()
+
+    static void test_26() {
+        try {
+            var a = ValueClass.copyOfSpecialArray(null, 0);
+            throw new RuntimeException("Missing NullPointerException");
+        } catch (NullPointerException e) {}
+    }
+
+    static void test_27() {
+        var array = ValueClass.newNullRestrictedNonAtomicArray(MyVal.class, 1, new MyVal());
+        try {
+            var a = ValueClass.copyOfSpecialArray(array, -1);
+            throw new RuntimeException("Missing NegativeArraySizeException");
+        } catch (NegativeArraySizeException e) {}
+    }
+
+    static void test_28() {
+        var array = new Object[1];
+        try {
+            var a = ValueClass.copyOfSpecialArray(array, 0);
+            throw new RuntimeException("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {}
+    }
+
+    static void test_29() {
+        var array = ValueClass.newNullRestrictedNonAtomicArray(MyVal.class, 2, new MyVal());
+        try {
+            var a = ValueClass.copyOfSpecialArray(array, 4);
+            throw new RuntimeException("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {}
+    }
+
+    static void test_30() {
+        var array = ValueClass.newNullRestrictedAtomicArray(MyVal.class, 2, new MyVal());
+        try {
+            var a = ValueClass.copyOfSpecialArray(array, 4);
+            throw new RuntimeException("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {}
+    }
+
+    static void test_31() {
+        var array = ValueClass.newNullableAtomicArray(MyVal.class, 2);
+        try {
+            var a = ValueClass.copyOfSpecialArray(array, 4);
+            Asserts.assertEquals(a.length, 4);
+        } catch (Throwable e) {
+            throw new RuntimeException("Unexpected exception " + e);
+        }
+    }
+
+    // Test arguments validation in copyOfRangeSpecialArray()
+
+    static void test_32() {
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(null, 0, 1);
+            throw new RuntimeException("Missing NullPointerException");
+        } catch (NullPointerException e) {}
+    }
+
+    static void test_33() {
+        var array = ValueClass.newNullRestrictedNonAtomicArray(MyVal.class, 2, new MyVal());
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(array, -1, 1);
+            throw new RuntimeException("Missing ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException e) {}
+    }
+
+    static void test_34() {
+        var array = ValueClass.newNullRestrictedNonAtomicArray(MyVal.class, 2, new MyVal());
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(array, 3, 4);
+            throw new RuntimeException("Missing ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException e) {}
+    }
+
+    static void test_35() {
+        var array = ValueClass.newNullRestrictedNonAtomicArray(MyVal.class, 2, new MyVal());
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(array, 1, 0);
+            throw new RuntimeException("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {}
+    }
+
+    static void test_36() {
+        var array = ValueClass.newNullRestrictedNonAtomicArray(MyVal.class, 2, new MyVal());
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(array, 2, 4);
+            throw new RuntimeException("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {}
+    }
+
+    static void test_37() {
+        var array = ValueClass.newNullRestrictedAtomicArray(MyVal.class, 2, new MyVal());
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(array, 2, 4);
+            throw new RuntimeException("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {}
+    }
+
+    static void test_38() {
+        var array = ValueClass.newNullableAtomicArray(MyVal.class, 2);
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(array, 2, 4);
+        } catch (Throwable e) {
+            throw new RuntimeException("Unexpected exception " + e);
+        }
+    }
+
+    static void test_39() {
+      var array = new Object[1];
+        try {
+            var a = ValueClass.copyOfRangeSpecialArray(array, 0, 0);
+            throw new RuntimeException("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {}
+    }
+
     public static void main(String[] args) {
         var test = new TestArrayFactories();
         Class c = test.getClass();


### PR DESCRIPTION
This patch adds missing argument validation to  copyOfSpecialArray() and copyOfRangeSpecialArray().
The implementation in JVM_CopyOfSpecialArray is also updated to address a number of issues (inconsistencies, code duplication, buggy index computation). Those changes should solve JDK-8387251.

Tested with Mach5, tier1-4.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386719](https://bugs.openjdk.org/browse/JDK-8386719): [lworld] Remaining ValueClass argument verification issues (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2586/head:pull/2586` \
`$ git checkout pull/2586`

Update a local copy of the PR: \
`$ git checkout pull/2586` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2586`

View PR using the GUI difftool: \
`$ git pr show -t 2586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2586.diff">https://git.openjdk.org/valhalla/pull/2586.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2586#issuecomment-4810112563)
</details>
