### PR TITLE
8387001: [lworld] compiler/eliminateAutobox/TestSafepointDebugInfo.java asserts with preview since merge jdk-28+3

### DIFF
--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -36,7 +36,6 @@
 # Valhalla failures start here:
 
 # Compiler:
-compiler/eliminateAutobox/TestSafepointDebugInfo.java   8387001 generic-all
 
 # Runtime:
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#default_gc 8382398 generic-all


### PR DESCRIPTION
The issue does not reproduce anymore after the backout done by [JDK-8387054](https://bugs.openjdk.org/browse/JDK-8387054). The REDO by [JDK-8386999](https://bugs.openjdk.org/browse/JDK-8386999) fixed the issue. I did not investigate deeper but verified by running extensive testing. Let's un-problem-list.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387001](https://bugs.openjdk.org/browse/JDK-8387001): [lworld] compiler/eliminateAutobox/TestSafepointDebugInfo.java asserts with preview since merge jdk-28+3 (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2587/head:pull/2587` \
`$ git checkout pull/2587`

Update a local copy of the PR: \
`$ git checkout pull/2587` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2587`

View PR using the GUI difftool: \
`$ git pr show -t 2587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2587.diff">https://git.openjdk.org/valhalla/pull/2587.diff</a>

</details>
