### PR TITLE
8386858: [lworld] omit load_prototype_header when UseObjectMonitorTable is used

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2392,16 +2392,18 @@ void MacroAssembler::test_field_is_flat(Register flags, Register temp_reg, Label
 }
 
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label) {
-  Label test_mark_word;
   // load mark word
   ldr(temp_reg, Address(oop, oopDesc::mark_offset_in_bytes()));
-  // check displaced
-  tst(temp_reg, markWord::unlocked_value);
-  br(Assembler::NE, test_mark_word);
-  // slow path use klass prototype
-  load_prototype_header(temp_reg, oop);
+  if (!UseObjectMonitorTable) {
+    Label test_mark_word;
+    // check displaced
+    tst(temp_reg, markWord::unlocked_value);
+    br(Assembler::NE, test_mark_word);
+    // slow path use klass prototype
+    load_prototype_header(temp_reg, oop);
 
-  bind(test_mark_word);
+    bind(test_mark_word);
+  }
   andr(temp_reg, temp_reg, test_bit);
   if (jmp_set) {
     cbnz(temp_reg, jmp_label);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -3353,16 +3353,18 @@ void MacroAssembler::test_field_is_flat(Register flags, Label& is_flat) {
 
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set,
                                             Label& jmp_label, bool maybe_far) {
-  Label test_mark_word;
   // load mark word
   ld(temp_reg, oopDesc::mark_offset_in_bytes(), oop);
-  // if unlocked bit is set we can directly use the mark word
-  andi_(R0, temp_reg, markWord::unlocked_value);
-  bne(CR0, test_mark_word);
-  // slow path use klass prototype
-  load_prototype_header(temp_reg, oop);
+  if (!UseObjectMonitorTable) {
+    Label test_mark_word;
+    // if unlocked bit is set we can directly use the mark word
+    andi_(R0, temp_reg, markWord::unlocked_value);
+    bne(CR0, test_mark_word);
+    // slow path use klass prototype
+    load_prototype_header(temp_reg, oop);
 
-  bind(test_mark_word);
+    bind(test_mark_word);
+  }
   andi_(R0, temp_reg, test_bit);
   if (maybe_far) {
     bc_far_optimized(jmp_set ? Assembler::bcondCRbiIs0 : Assembler::bcondCRbiIs1,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3763,16 +3763,18 @@ void MacroAssembler::test_oop_is_not_inline_type(Register object, Register tmp, 
 
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t tst_bit, bool jmp_set, Label& jmp_label) {
   assert_different_registers(temp_reg, t0);
-  Label test_mark_word;
   // load mark word
   ld(temp_reg, Address(oop, oopDesc::mark_offset_in_bytes()));
-  // check displaced
-  test_bit(t0, temp_reg, exact_log2(markWord::unlocked_value));
-  bnez(t0, test_mark_word);
-  // slow path use klass prototype
-  load_prototype_header(temp_reg, oop);
+  if (!UseObjectMonitorTable) {
+    Label test_mark_word;
+    // check displaced
+    test_bit(t0, temp_reg, exact_log2(markWord::unlocked_value));
+    bnez(t0, test_mark_word);
+    // slow path use klass prototype
+    load_prototype_header(temp_reg, oop);
 
-  bind(test_mark_word);
+    bind(test_mark_word);
+  }
   andi(temp_reg, temp_reg, tst_bit);
   if (jmp_set) {
     bnez(temp_reg, jmp_label, /* is_far */ true);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2442,18 +2442,20 @@ void MacroAssembler::test_field_is_flat(Register flags, Register temp_reg, Label
 }
 
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label) {
-  Label test_mark_word;
   // load mark word
   movptr(temp_reg, Address(oop, oopDesc::mark_offset_in_bytes()));
-  // check displaced
-  testl(temp_reg, markWord::unlocked_value);
-  jccb(Assembler::notZero, test_mark_word);
-  // slow path use klass prototype
-  push(rscratch1);
-  load_prototype_header(temp_reg, oop, rscratch1);
-  pop(rscratch1);
+  if (!UseObjectMonitorTable) {
+    Label test_mark_word;
+    // check displaced
+    testl(temp_reg, markWord::unlocked_value);
+    jccb(Assembler::notZero, test_mark_word);
+    // slow path use klass prototype
+    push(rscratch1);
+    load_prototype_header(temp_reg, oop, rscratch1);
+    pop(rscratch1);
 
-  bind(test_mark_word);
+    bind(test_mark_word);
+  }
   testl(temp_reg, test_bit);
   jcc((jmp_set) ? Assembler::notZero : Assembler::zero, jmp_label);
 }


### PR DESCRIPTION
Valhalla uses `load_prototype_header()` to read the Valhalla-specific mark word flags from the `klass` when the object appears to be locked.

However, when `UseObjectMonitorTable` is enabled, object monitors are not represented by displaced mark words in the object header.
In that case, the object header still contains the relevant markWord bits, so we can get the loaded header directly.

This patch avoids the locked-object/prototype-header path when `UseObjectMonitorTable` is enabled.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386858](https://bugs.openjdk.org/browse/JDK-8386858): [lworld] omit load_prototype_header when UseObjectMonitorTable is used (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2591/head:pull/2591` \
`$ git checkout pull/2591`

Update a local copy of the PR: \
`$ git checkout pull/2591` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2591`

View PR using the GUI difftool: \
`$ git pr show -t 2591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2591.diff">https://git.openjdk.org/valhalla/pull/2591.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2591#issuecomment-4829341030)
</details>
