### PR TITLE
8386067: [lworld] C2 asserts with "Missed Ideal optimization opportunity in PhaseIterGVN for CmpL"

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -3114,12 +3114,7 @@ private:
       // Replace phi right away to be able to use the inline
       // type node when reaching the phi again through data loops.
       PhaseIterGVN* igvn = _phase->is_IterGVN();
-      for (DUIterator_Fast imax, i = phi->fast_outs(imax); i < imax; i++) {
-        Node* u = phi->fast_out(i);
-        igvn->rehash_node_delayed(u);
-        imax -= u->replace_edge(phi, vt);
-        --i;
-      }
+      igvn->replace_in_uses(phi, vt);
       igvn->rehash_node_delayed(phi);
       assert(phi->outcnt() == 0, "should be dead now");
     }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2486,6 +2486,7 @@ void PhaseIterGVN::subsume_node( Node *old, Node *nn ) {
   temp->destruct(this);     // reuse the _idx of this little guy
 }
 
+// Replaces n with m in all uses, including self-loops.
 void PhaseIterGVN::replace_in_uses(Node* n, Node* m) {
   assert(n != nullptr, "sanity");
   add_users_to_worklist(n);

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2491,11 +2491,9 @@ void PhaseIterGVN::replace_in_uses(Node* n, Node* m) {
   add_users_to_worklist(n);
   for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
     Node* u = n->fast_out(i);
-    if (u != n) {
-      rehash_node_delayed(u);
-      int nb = u->replace_edge(n, m);
-      --i, imax -= nb;
-    }
+    rehash_node_delayed(u);
+    int nb = u->replace_edge(n, m);
+    --i, imax -= nb;
   }
   assert(n->outcnt() == 0, "all uses must be deleted");
 }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2488,6 +2488,7 @@ void PhaseIterGVN::subsume_node( Node *old, Node *nn ) {
 
 void PhaseIterGVN::replace_in_uses(Node* n, Node* m) {
   assert(n != nullptr, "sanity");
+  add_users_to_worklist(n);
   for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
     Node* u = n->fast_out(i);
     if (u != n) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushThroughPhiNotification.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushThroughPhiNotification.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+/*
+ * @test
+ * @summary Test that Phi users are revisited when InlineTypeNode is pushed through.
+ * @bug 8386067
+ * @enablePreview
+ * @run driver ${test.main.class}
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:-TieredCompilation -Xbatch
+ *                   -XX:VerifyIterativeGVN=1110 -XX:+StressIGVN
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+public class TestPushThroughPhiNotification {
+    static Object box(int i) {
+        return i;
+    }
+
+    static boolean test() {
+        Object lhs = null;
+        Object rhs = null;
+        for (int i = 0; i < 10; i++) {
+            if ((i & 1) == 0) {
+                lhs = box(i);
+                rhs = box(i);
+            }
+        }
+        // Phi with (deep) CmpL user from acmp implementation that needs to
+        // be re-visited by IGVN when InlineTypeNode is pushed through.
+        return lhs == rhs;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; i++) {
+            if (!test()) {
+                throw new RuntimeException("Unexpected result");
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushThroughPhiNotification.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushThroughPhiNotification.java
@@ -55,7 +55,7 @@ public class TestPushThroughPhiNotification {
     }
 
     public static void main(String[] args) {
-        for (int i = 0; i < 50_000; i++) {
+        for (int i = 0; i < 5_000; i++) {
             if (!test()) {
                 throw new RuntimeException("Unexpected result");
             }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushThroughPhiNotification.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushThroughPhiNotification.java
@@ -28,7 +28,7 @@ package compiler.valhalla.inlinetypes;
  * @summary Test that Phi users are revisited when InlineTypeNode is pushed through.
  * @bug 8386067
  * @enablePreview
- * @run driver ${test.main.class}
+ * @run main ${test.main.class}
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-TieredCompilation -Xbatch
  *                   -XX:VerifyIterativeGVN=1110 -XX:+StressIGVN


### PR DESCRIPTION
The `PushInlineTypeDown` implementation from [JDK-8302217](https://bugs.openjdk.org/browse/JDK-8302217) rewires `PhiNode` uses to a new `InlineTypeNode` but only adds direct users to the IGVN worklist. Nodes whose transformations depend on deeper input type changes might not be re-enqueued.

In the failing case, the offending shape looks like this:
```CmpL(OrL(CastP2X(phi_or_inline_type), CastP2X(other)), 0L)```

After the Phi input is replaced by a scalarized inline type or a not-null value, [CmpLNode::Ideal](https://github.com/openjdk/valhalla/blob/a0dc49c20ee6d20e925a107b0d3dabc7e0ba8863/src/hotspot/share/opto/subnode.cpp#L899-L922) can fold the corresponding `CastP2X` to the null marker or `1L`. Without notifying users through the normal IGVN replacement path, `VerifyIterativeGVN` will report a missed `CmpL` idealization.

The fix makes `replace_in_uses` notify users before rewiring, and uses it from `PushInlineTypeDown`.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386067](https://bugs.openjdk.org/browse/JDK-8386067): [lworld] C2 asserts with "Missed Ideal optimization opportunity in PhaseIterGVN for CmpL" (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2593/head:pull/2593` \
`$ git checkout pull/2593`

Update a local copy of the PR: \
`$ git checkout pull/2593` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2593`

View PR using the GUI difftool: \
`$ git pr show -t 2593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2593.diff">https://git.openjdk.org/valhalla/pull/2593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2593#issuecomment-4833716416)
</details>
