### PR TITLE
8387428: [lworld] ProblemList tests affected by JDK-8349772

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -199,6 +199,9 @@ applications/ctw/modules/java_base_2.java 8375645 generic-all
 
 compiler/codegen/TestRedundantLea.java#Spill                            8361089 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id4                   8386160 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInlining 8349772 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningDontInlineMyAbstractInit 8349772 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningOnStackReplacement 8349772 generic-all
 
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8386674 linux-aarch64
 


### PR DESCRIPTION
A trivial fix to ProblemList tests affected by JDK-8349772.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387428](https://bugs.openjdk.org/browse/JDK-8387428): [lworld] ProblemList tests affected by JDK-8349772 (**Sub-task** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2595/head:pull/2595` \
`$ git checkout pull/2595`

Update a local copy of the PR: \
`$ git checkout pull/2595` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2595`

View PR using the GUI difftool: \
`$ git pr show -t 2595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2595.diff">https://git.openjdk.org/valhalla/pull/2595.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2595#issuecomment-4835155284)
</details>
