### PR TITLE
8387454: [lworld] Update Strict fields JEP number

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -69,7 +69,7 @@ public @interface PreviewFeature {
      * Values should be annotated with the feature's {@code JEP}.
      */
     public enum Feature {
-        @JEP(number = 8350458, title = "Strict Field Initialization in the JVM", status = "Preview")
+        @JEP(number = 539, title = "Strict Field Initialization in the JVM", status = "Preview")
         STRICT_FIELDS,
         @JEP(number=401, title="Value Classes and Objects", status = "Preview")
         VALUE_OBJECTS,


### PR DESCRIPTION
Strict fields JEP is now assigned number [539](https://openjdk.org/jeps/539). Update the references in the documentations.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387454](https://bugs.openjdk.org/browse/JDK-8387454): [lworld] Update Strict fields JEP number (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2596/head:pull/2596` \
`$ git checkout pull/2596`

Update a local copy of the PR: \
`$ git checkout pull/2596` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2596`

View PR using the GUI difftool: \
`$ git pr show -t 2596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2596.diff">https://git.openjdk.org/valhalla/pull/2596.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2596#issuecomment-4837563088)
</details>
