### PR TITLE
8387464: [lworld] Increase memlimit and unproblemlist TestValueConstruction.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -199,9 +199,6 @@ applications/ctw/modules/java_base_2.java 8375645 generic-all
 
 compiler/codegen/TestRedundantLea.java#Spill                            8361089 generic-all
 compiler/valhalla/inlinetypes/TestIntrinsics.java#id4                   8386160 generic-all
-compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInlining 8349772 generic-all
-compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningDontInlineMyAbstractInit 8349772 generic-all
-compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningOnStackReplacement 8349772 generic-all
 
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8386674 linux-aarch64
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueConstruction.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueConstruction.java
@@ -143,21 +143,6 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @test id=StressIncrementalInlining
  * @key randomness
  * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
- * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
- * @enablePreview
- * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbatch
- *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
- *                   -XX:CompileCommand=inline,TestValueConstruction::checkDeopt
- *                   compiler.valhalla.inlinetypes.TestValueConstruction
- */
-
-/*
- * @test id=StressIncrementalInliningUnstableIfTraps
- * @key randomness
- * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
- * @requires vm.opt.StressUnstableIfTraps != null & vm.opt.StressUnstableIfTraps
  * @enablePreview
  * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -213,21 +198,6 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @test id=StressIncrementalInliningDontInlineMyAbstractInit
  * @key randomness
  * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
- * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
- * @enablePreview
- * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
- *                   -XX:CompileCommand=inline,TestValueConstruction::checkDeopt
- *                   -XX:CompileCommand=dontinline,*MyAbstract::<init> -Xbatch
- *                   compiler.valhalla.inlinetypes.TestValueConstruction
- */
-/*
- * @test id=StressIncrementalInliningDontInlineMyAbstractInitUnstableIfTraps
- * @key randomness
- * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
- * @requires vm.opt.StressUnstableIfTraps != null & vm.opt.StressUnstableIfTraps
  * @enablePreview
  * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -243,21 +213,6 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @test id=StressIncrementalInliningOnStackReplacement
  * @key randomness
  * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
- * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
- * @enablePreview
- * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
- *                   -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0
- *                   -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 -Xbatch
- *                   compiler.valhalla.inlinetypes.TestValueConstruction
- */
-/*
- * @test id=StressIncrementalInliningOnStackReplacementUnstableIfTraps
- * @key randomness
- * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
- * @requires vm.opt.StressUnstableIfTraps != null & vm.opt.StressUnstableIfTraps
  * @enablePreview
  * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueConstruction.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueConstruction.java
@@ -143,12 +143,28 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @test id=StressIncrementalInlining
  * @key randomness
  * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
+ * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
  * @enablePreview
  * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbatch
  *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
  *                   -XX:CompileCommand=inline,TestValueConstruction::checkDeopt
+ *                   compiler.valhalla.inlinetypes.TestValueConstruction
+ */
+
+/*
+ * @test id=StressIncrementalInliningUnstableIfTraps
+ * @key randomness
+ * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
+ * @requires vm.opt.StressUnstableIfTraps != null & vm.opt.StressUnstableIfTraps
+ * @enablePreview
+ * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbatch
+ *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
+ *                   -XX:CompileCommand=inline,TestValueConstruction::checkDeopt
+ *                   -XX:CompileCommand=MemLimit,*.*,2G~crash
  *                   compiler.valhalla.inlinetypes.TestValueConstruction
  */
 
@@ -197,6 +213,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @test id=StressIncrementalInliningDontInlineMyAbstractInit
  * @key randomness
  * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
+ * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
  * @enablePreview
  * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -206,11 +223,27 @@ import test.java.lang.invoke.lib.InstructionHelper;
  *                   -XX:CompileCommand=dontinline,*MyAbstract::<init> -Xbatch
  *                   compiler.valhalla.inlinetypes.TestValueConstruction
  */
+/*
+ * @test id=StressIncrementalInliningDontInlineMyAbstractInitUnstableIfTraps
+ * @key randomness
+ * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
+ * @requires vm.opt.StressUnstableIfTraps != null & vm.opt.StressUnstableIfTraps
+ * @enablePreview
+ * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
+ *                   -XX:CompileCommand=inline,TestValueConstruction::checkDeopt
+ *                   -XX:CompileCommand=dontinline,*MyAbstract::<init> -Xbatch
+ *                   -XX:CompileCommand=MemLimit,*.*,2G~crash
+ *                   compiler.valhalla.inlinetypes.TestValueConstruction
+ */
 
 /*
  * @test id=StressIncrementalInliningOnStackReplacement
  * @key randomness
  * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
+ * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
  * @enablePreview
  * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -218,6 +251,21 @@ import test.java.lang.invoke.lib.InstructionHelper;
  *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
  *                   -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0
  *                   -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 -Xbatch
+ *                   compiler.valhalla.inlinetypes.TestValueConstruction
+ */
+/*
+ * @test id=StressIncrementalInliningOnStackReplacementUnstableIfTraps
+ * @key randomness
+ * @library /testlibrary /test/lib /compiler/whitebox /test/jdk/java/lang/invoke/common /
+ * @requires vm.opt.StressUnstableIfTraps != null & vm.opt.StressUnstableIfTraps
+ * @enablePreview
+ * @build jdk.test.whitebox.WhiteBox test.java.lang.invoke.lib.InstructionHelper
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-TieredCompilation -XX:+StressIncrementalInlining
+ *                   -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0
+ *                   -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 -Xbatch
+ *                   -XX:CompileCommand=MemLimit,*.*,2G~crash
  *                   compiler.valhalla.inlinetypes.TestValueConstruction
  */
 


### PR DESCRIPTION
After the integration of #2565 three subtests of `compiler/valhalla/inlinetypes/TestValueConstruction.java` started failing, but only when `-XX:+StressUnstableIfTraps` was passed. This PR fixes this by introducing new subtasks with a higher memlimit for the affected subtests.

Alternatively, I could have simply raised the memlimit, but this would diminish the capability of these tests to detect regressions in the scalarization strategy.

Testing:
 - [x] 50 repetitions of `compiler/valhalla/inlinetypes/TestValueConstruction.java`
 - [x] 50 repetitions of `compiler/valhalla/inlinetypes/TestValueConstruction.java` with `-XX:+StressUnstableIfTraps`


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387464](https://bugs.openjdk.org/browse/JDK-8387464): [lworld] Increase memlimit and unproblemlist TestValueConstruction.java (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2599/head:pull/2599` \
`$ git checkout pull/2599`

Update a local copy of the PR: \
`$ git checkout pull/2599` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2599`

View PR using the GUI difftool: \
`$ git pr show -t 2599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2599.diff">https://git.openjdk.org/valhalla/pull/2599.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2599#issuecomment-4841796133)
</details>
