### PR TITLE
8387488: [lworld] C2: acmp expansion fails with assert(replace != nullptr) failed: must succeed

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -953,6 +953,8 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
       Node* vk_klass = igvn.makecon(vk_klass_type);
 
       // Both must be vk
+      // No need to null-check/checkcast/reload an already scalarized inline type:
+      // its fields are already available directly from the InlineTypeNode.
       if (cur_lhs_inline != nullptr && cur_lhs_inline->inline_klass() == vk) {
         cur_lhs_field = cur_lhs_inline;
       } else {

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -953,8 +953,7 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
       Node* vk_klass = igvn.makecon(vk_klass_type);
 
       // Both must be vk
-      // No need to null-check/checkcast/reload an already scalarized inline type:
-      // its fields are already available directly from the InlineTypeNode.
+      // InlineTypeNodes need no (new) field loads, so we can use the uncasted value below.
       if (cur_lhs_inline != nullptr && cur_lhs_inline->inline_klass() == vk) {
         cur_lhs_field = cur_lhs_inline;
       } else {

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -865,6 +865,8 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
 
       Node* cur_lhs_field = cur_lhs->field_value(field_idx);
       Node* cur_rhs_field = cur_rhs->field_value(field_idx);
+      InlineTypeNode* cur_lhs_inline = cur_lhs_field->isa_InlineType();
+      InlineTypeNode* cur_rhs_inline = cur_rhs_field->isa_InlineType();
 
       Node* preprocess = emit_substitutability_check_pointer(kit, result, cur_lhs_field, cur_rhs_field);
       if (kit->stopped()) {
@@ -951,21 +953,29 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
       Node* vk_klass = igvn.makecon(vk_klass_type);
 
       // Both must be vk
-      Node* not_vk = kit->top();
-      cur_lhs_field = kit->gen_checkcast(cur_lhs_field, vk_klass, &not_vk);
-      if (!not_vk->is_top()) {
-        region->add_req(not_vk);
-        result->add_req(igvn.intcon(0));
+      if (cur_lhs_inline != nullptr && cur_lhs_inline->inline_klass() == vk) {
+        cur_lhs_field = cur_lhs_inline;
+      } else {
+        Node* not_vk = kit->top();
+        cur_lhs_field = kit->gen_checkcast(cur_lhs_field, vk_klass, &not_vk);
+        if (!not_vk->is_top()) {
+          region->add_req(not_vk);
+          result->add_req(igvn.intcon(0));
+        }
+        cur_lhs_field = InlineTypeNode::make_from_oop(kit, cur_lhs_field, vk);
       }
-      cur_lhs_field = InlineTypeNode::make_from_oop(kit, cur_lhs_field, vk);
 
-      not_vk = kit->top();
-      cur_rhs_field = kit->gen_checkcast(cur_rhs_field, vk_klass, &not_vk);
-      if (!not_vk->is_top()) {
-        region->add_req(not_vk);
-        result->add_req(igvn.intcon(0));
+      if (cur_rhs_inline != nullptr && cur_rhs_inline->inline_klass() == vk) {
+        cur_rhs_field = cur_rhs_inline;
+      } else {
+        Node* not_vk = kit->top();
+        cur_rhs_field = kit->gen_checkcast(cur_rhs_field, vk_klass, &not_vk);
+        if (!not_vk->is_top()) {
+          region->add_req(not_vk);
+          result->add_req(igvn.intcon(0));
+        }
+        cur_rhs_field = InlineTypeNode::make_from_oop(kit, cur_rhs_field, vk);
       }
-      cur_rhs_field = InlineTypeNode::make_from_oop(kit, cur_rhs_field, vk);
 
       if (!kit->stopped()) {
         // Push the expanded InlineTypeNodes for processing later

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -5479,4 +5479,33 @@ public class TestLWorld {
             // expected
         }
     }
+
+    static value class ObjectHolder {
+        Object obj = new Object();
+    }
+
+    static value class ObjectHolderHolder {
+        ObjectHolder objectHolder = new ObjectHolder();
+    }
+
+    // Test that acmp expansion works with field of exact Object type
+    @Test
+    @IR(failOn = {STATIC_CALL_OF_METHOD, "isSubstitutable.*"},
+        counts = {IRNode.ALLOC, "= 2"}) // The two Object allocations
+    static boolean testAcmp() {
+        Object lhs = null;
+        Object rhs = null;
+        for (int i = 0; i < 10; i++) {
+            if ((i & 1) == 0) {
+                lhs = new ObjectHolderHolder();
+                rhs = new ObjectHolderHolder();
+            }
+        }
+        return lhs == rhs;
+    }
+
+    @Run(test = "testAcmp")
+    public void runTestAcmp() {
+        Asserts.assertFalse(testAcmp());
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -5480,6 +5480,9 @@ public class TestLWorld {
         }
     }
 
+    // TODO 8376254: C1 bails out if the type of the nullable flat field is uninitialized
+    static ObjectHolderHolder tmp = new ObjectHolderHolder();
+
     static value class ObjectHolder {
         Object obj = new Object();
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -5481,7 +5481,7 @@ public class TestLWorld {
     }
 
     // TODO 8376254: C1 bails out if the type of the nullable flat field is uninitialized
-    static ObjectHolderHolder tmp = new ObjectHolderHolder();
+    static ObjectHolderHolder objectHolderHolder = new ObjectHolderHolder();
 
     static value class ObjectHolder {
         Object obj = new Object();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOptimizePtrCompare.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOptimizePtrCompare.java
@@ -164,6 +164,7 @@ public class TestOptimizePtrCompare {
         return v;
     }
 
+    // TODO 8376254: C1 bails out if the type of the nullable flat field is uninitialized
     @Test(allowNotCompilable = true)
     @IR(applyIfAnd = {"InlineTypePassFieldsAsArgs", "true", "InlineTypeReturnedAsFields", "true"}, failOn = {IRNode.CMP_P_OR_N})
     @IR(applyIfAnd = {"InlineTypePassFieldsAsArgs", "false", "InlineTypeReturnedAsFields", "true"}, counts = {IRNode.CMP_P_OR_N, "4", IRNode.CMP_I, "2"})


### PR DESCRIPTION
When slightly modifying the test that I added for [JDK-8386067](https://bugs.openjdk.org/browse/JDK-8386067), I hit an assert in `CallStaticJavaNode::replace_is_substitutable` because expansion of the substitutability call failed and `emit_substitutability_check` returned `nullptr` although `can_emit_substitutability_check` returned `true`.

In the new test, the problematic field is `ObjectHolder::obj` which, although it is of type `Object`, is always `exact` and therefore can't be a value object and does not require a substitutability test. `InlineTypeNode::can_emit_substitutability_check` correctly returns `true`:
https://github.com/openjdk/valhalla/blob/2ae8e47da016bb4d7718e7923c964c2b91c638e6/src/hotspot/share/opto/inlinetypenode.cpp#L611-L614


However, during recursive expansion, nullable value object fields are null-checked and then compared field-by-field:
https://github.com/openjdk/valhalla/blob/2ae8e47da016bb4d7718e7923c964c2b91c638e6/src/hotspot/share/opto/inlinetypenode.cpp#L910

The code unconditionally rebuilt those fields with `InlineTypeNode::make_from_oop` after the null and type checks because there's a `CastPP` in-between:
https://github.com/openjdk/valhalla/blob/2ae8e47da016bb4d7718e7923c964c2b91c638e6/src/hotspot/share/opto/inlinetypenode.cpp#L955-L960

 If the field was already scalarized, this discarded the existing `InlineTypeNode` and reloaded fields from the oop, losing precise information such as exact Object field Phis. The later Object field comparison then looks non-exact and `emit_substitutability_check_pointer` returns `nullptr`:
https://github.com/openjdk/valhalla/blob/2ae8e47da016bb4d7718e7923c964c2b91c638e6/src/hotspot/share/opto/inlinetypenode.cpp#L722-L724

The fix is to preserve already-scalarized recursive field operands when their inline klass matches the comparison klass, and only checkcast/reload operands that are not scalarized. With the fix, exact type information is preserved and we emit a pointer comparison for the exact object fields:
https://github.com/openjdk/valhalla/blob/2ae8e47da016bb4d7718e7923c964c2b91c638e6/src/hotspot/share/opto/inlinetypenode.cpp#L700-L702

The IR Framework test verifies this successful expansion.

Note: The null and type checks are not immediately folded because by GVN because we need to set `set_delay_transform` here:
https://github.com/openjdk/valhalla/blob/2ae8e47da016bb4d7718e7923c964c2b91c638e6/src/hotspot/share/opto/callnode.cpp#L1412-L1416

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387488](https://bugs.openjdk.org/browse/JDK-8387488): [lworld] C2: acmp expansion fails with assert(replace != nullptr) failed: must succeed (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2602/head:pull/2602` \
`$ git checkout pull/2602`

Update a local copy of the PR: \
`$ git checkout pull/2602` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2602`

View PR using the GUI difftool: \
`$ git pr show -t 2602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2602.diff">https://git.openjdk.org/valhalla/pull/2602.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2602#issuecomment-4844556105)
</details>
