### PR TITLE
8387495: [lworld] Typo in javadoc of jdk/internal/util/ReferencedKeyMap.java

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,9 +49,11 @@ import jdk.internal.misc.CDS;
  * remove entries automatically when the key is garbage collected. This is
  * accomplished by using a backing map where the keys are either a
  * {@link WeakReference} or a {@link SoftReference}.
- * Keys must be {@linkplain Class#isIdentity() identity objects.}
  * <p>
- * To create a {@link ReferencedKeyMap} the user must provide a {@link Supplier}
+ * Keys in {@code ReferencedKeyMap} must be
+ * {@linkplain java.util.Objects#hasIdentity identity objects}.
+ * <p>
+ * To create a {@code ReferencedKeyMap} the user must provide a {@link Supplier}
  * of the backing map and whether {@link WeakReference} or
  * {@link SoftReference} is to be used.
  *


### PR DESCRIPTION
Can I get a review of this doc-only change which fixes a typo in the javadoc of the internal `ReferencedKeyMap` class?

I borrowed the phrasing from the recent updates we did to the WeakHashMap class.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387495](https://bugs.openjdk.org/browse/JDK-8387495): [lworld] Typo in javadoc of jdk/internal/util/ReferencedKeyMap.java (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2603/head:pull/2603` \
`$ git checkout pull/2603`

Update a local copy of the PR: \
`$ git checkout pull/2603` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2603`

View PR using the GUI difftool: \
`$ git pr show -t 2603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2603.diff">https://git.openjdk.org/valhalla/pull/2603.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2603#issuecomment-4845745275)
</details>
