### PR TITLE
8387540: [lworld] ForceEarlyReturnVoid should fail with OPAQUE_FRAME if target thread's top frame is value class constructor

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3377,14 +3377,14 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       <synopsis>Force Early Return - Void</synopsis>
       <description>
         This function can be used to return from a method with a return type
-        of <code>void</code>, a constructor or a class initializer.
+        of <code>void</code>.
         A constructor is a special method named <code>&lt;init&gt;</code> with
         a return type of <code>void</code>. A class initializer is a special
-        method named named <code>&lt;clinit&gt;</code> with  a return type of
+        method named named <code>&lt;clinit&gt;</code> with a return type of
         <code>void</code>.
         <p/>
-        This function can not be used to return early from the constructor
-        of a value class.
+        When preview features are enabled, this function can not be used to return
+        early from the constructor of a value class.
       </description>
       <origin>new</origin>
       <capabilities>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3401,8 +3401,8 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       <errors>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
           The implementation is unable to force the current frame to return
-          (e.g. current frame is executing a native method or the current frame is the
-          constructor for a value class)
+          (e.g. current frame is executing a native method or if preview features
+           are enabled, the current frame is the constructor for a value class)
         </error>
         <error id="JVMTI_ERROR_TYPE_MISMATCH">
           The called method has a result type.

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3376,11 +3376,15 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
     <function id="ForceEarlyReturnVoid" num="86" since="1.1">
       <synopsis>Force Early Return - Void</synopsis>
       <description>
-        This function can be used to return from a method with no result type.
-        That is, the called method must be declared <code>void</code>.
+        This function can be used to return from a method with a return type
+        of <code>void</code>, a constructor or a class initializer.
+        A constructor is a special method named <code>&lt;init&gt;</code> with
+        a return type of <code>void</code>. A class initializer is a special
+        method named named <code>&lt;clinit&gt;</code> with  a return type of
+        <code>void</code>.
         <p/>
-        An implementation may also allow this function be used to return early
-        from a class initializer or constructor.
+        This function can not be used to return early from the constructor
+        of a value class.
       </description>
       <origin>new</origin>
       <capabilities>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3378,6 +3378,9 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       <description>
         This function can be used to return from a method with no result type.
         That is, the called method must be declared <code>void</code>.
+        <p/>
+        An implementation may also allow this function be used to return early
+        from a class initializer or constructor.
       </description>
       <origin>new</origin>
       <capabilities>
@@ -3394,7 +3397,8 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       <errors>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
           The implementation is unable to force the current frame to return
-          (e.g. current frame is executing a native method).
+          (e.g. current frame is executing a native method or the current frame is the
+          constructor for a value class)
         </error>
         <error id="JVMTI_ERROR_TYPE_MISMATCH">
           The called method has a result type.

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2171,6 +2171,12 @@ JvmtiEnvBase::check_top_frame(Thread* current_thread, JavaThread* java_thread,
     return JVMTI_ERROR_OPAQUE_FRAME;
   }
 
+  // Prevent ForceEarlyReturnVoid from returning early from value class constructor as
+  // the instance fields are strictly-initialized fields.
+  if ((tos == vtos) && jvf->method()->is_object_constructor() && jvf->method()->method_holder()->is_inline_klass()) {
+    return JVMTI_ERROR_OPAQUE_FRAME;
+  }
+
   // If the frame is a compiled one, need to deoptimize it.
   if (jvf->is_compiled_frame()) {
     if (!jvf->fr().can_be_deoptimized()) {

--- a/src/java.se/share/data/jdwp/jdwp.spec
+++ b/src/java.se/share/data/jdwp/jdwp.spec
@@ -2153,7 +2153,8 @@ JDWP "Java(tm) Debug Wire Protocol"
             (Error THREAD_NOT_SUSPENDED)
             (Error OPAQUE_FRAME      "Unable to force the current frame to return "
                                      "(e.g. the current frame is executing a native method or "
-                                     "the current frame is the constructor for a value class).")
+                                     "if preview features are enabled, the current frame is "
+                                     "the constructor for a value class).")
             (Error NO_MORE_FRAMES)
             (Error NOT_IMPLEMENTED)
             (Error TYPE_MISMATCH   "Value is not an appropriate type for the "

--- a/src/java.se/share/data/jdwp/jdwp.spec
+++ b/src/java.se/share/data/jdwp/jdwp.spec
@@ -2129,6 +2129,9 @@ JDWP "Java(tm) Debug Wire Protocol"
         "language method. Forcing return on a thread with only one "
         "frame on the stack causes the thread to exit when resumed. "
         "<p>"
+        "When preview features are enabled, the method can not be the "
+        "constructor of a value class."
+        "<p>"
         "For void methods, the value must be a void value. "
         "For methods that return primitive values, the value's type must "
         "match the return type exactly.  For object values, there must be a "
@@ -2149,7 +2152,8 @@ JDWP "Java(tm) Debug Wire Protocol"
             (Error INVALID_OBJECT    "Thread or value is not a known ID.")
             (Error THREAD_NOT_SUSPENDED)
             (Error OPAQUE_FRAME      "Unable to force the current frame to return "
-                                     "(e.g. the current frame is executing a native method).")
+                                     "(e.g. the current frame is executing a native method or "
+                                     "the current frame is the constructor for a value class).")
             (Error NO_MORE_FRAMES)
             (Error NOT_IMPLEMENTED)
             (Error TYPE_MISMATCH   "Value is not an appropriate type for the "

--- a/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/ForceEarlyReturnValueClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/ForceEarlyReturnValueClass.java
@@ -39,36 +39,123 @@ class ForceEarlyReturnValueClass {
 
     /**
      * Test that ForceEarlyReturnVoid fails with JVMTI_ERROR_OPAQUE_FRAME when the
-     * target thread's top frame is a value class constructor.
+     * target thread's top frame is a value class constructor before super.
      */
     @Test
-    void testForceEarlyReturnConstructor() throws Exception {
+    void testForceEarlyReturnBeforeSuper() throws Exception {
         class TestCase {
-            static volatile boolean started;
+            static volatile boolean initStarted;
+            static volatile boolean initFinished;
             static volatile boolean stop;
-            static volatile boolean finished;
             static value class ValueClass {
                 ValueClass() {
-                    TestCase.started = true;
+                    TestCase.initStarted = true;
                     while (!TestCase.stop) {}
-                    TestCase.finished = true;
+                    super();
+                    TestCase.initFinished = true;
                 }
             }
         }
         Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
+        boolean suspended = false;
         try {
             // wait for target thread to start executing constructor
-            while (!TestCase.started) {
+            while (!TestCase.initStarted) {
                 Thread.sleep(10);
             }
             assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            suspended = true;
+            assertTopFrame(thread, TestCase.ValueClass.class, "<init>");
             assertEquals(JVMTI_ERROR_OPAQUE_FRAME, forceEarlyReturnVoid(thread));
         } finally {
             TestCase.stop = true;
-            resumeThread(thread);
+            if (suspended) resumeThread(thread);
             thread.join();
         }
-        assertTrue(TestCase.finished);  // constructor should have run to end
+        assertTrue(TestCase.initFinished);  // constructor should have run to end
+    }
+
+    /**
+     * Test that ForceEarlyReturnVoid fails with JVMTI_ERROR_OPAQUE_FRAME when the
+     * target thread's top frame is a value class constructor after super.
+     * (This case may be allowed to succeed in the future)
+     */
+    @Test
+    void testForceEarlyReturnAfterSuper() throws Exception {
+        class TestCase {
+            static volatile boolean afterSuperStarted;
+            static volatile boolean initFinished;
+            static volatile boolean stop;
+            static value class ValueClass {
+                ValueClass() {
+                    super();
+                    TestCase.afterSuperStarted = true;
+                    while (!TestCase.stop) {}
+                    TestCase.initFinished = true;
+                }
+            }
+        }
+        Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
+        boolean suspended = false;
+        try {
+            // wait for target thread to start executing code after super
+            while (!TestCase.afterSuperStarted) {
+                Thread.sleep(10);
+            }
+            assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            suspended = true;
+            assertTopFrame(thread, TestCase.ValueClass.class, "<init>");
+            assertEquals(JVMTI_ERROR_OPAQUE_FRAME, forceEarlyReturnVoid(thread));
+        } finally {
+            TestCase.stop = true;
+            if (suspended) resumeThread(thread);
+            thread.join();
+        }
+        assertTrue(TestCase.initFinished);  // constructor should have run to end
+    }
+
+    /**
+     * Test that ForceEarlyReturnVoid succeeds with the target thread's top frame is a
+     * method invoked from the constructor after super.
+     */
+    @Test
+    void testForceEarlyReturnPostInit() throws Exception {
+        class TestCase {
+            static volatile boolean initFinished;
+            static volatile boolean postInitStarted;
+            static volatile boolean postInitFinished;
+            static volatile boolean stop;
+            static value class ValueClass {
+                ValueClass() {
+                    super();
+                    postInit();
+                    TestCase.initFinished = true;
+                }
+                void postInit() {
+                    TestCase.postInitStarted = true;
+                    while (!TestCase.stop) {}
+                    TestCase.postInitFinished = true;
+                }
+            }
+        }
+        Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
+        boolean suspended = false;
+        try {
+            // wait for target thread to start executing postInit method
+            while (!TestCase.postInitStarted) {
+                Thread.sleep(10);
+            }
+            assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            assertTopFrame(thread, TestCase.ValueClass.class, "postInit");
+            suspended = true;
+            assertEquals(JVMTI_ERROR_NONE, forceEarlyReturnVoid(thread));
+        } finally {
+            TestCase.stop = true;
+            if (suspended) resumeThread(thread);
+            thread.join();
+        }
+        assertFalse(TestCase.postInitFinished);  // postInit should not have run to the end
+        assertTrue(TestCase.initFinished);       // constructor should have run to end
     }
 
     /**
@@ -78,32 +165,35 @@ class ForceEarlyReturnValueClass {
     @Test
     void testForceEarlyReturnMethod() throws Exception {
         class TestCase {
-            static volatile boolean started;
+            static volatile boolean runStarted;
+            static volatile boolean runFinished;
             static volatile boolean stop;
-            static volatile boolean finished;
             static value class ValueClass {
                 void run() {
-                    TestCase.started = true;
+                    TestCase.runStarted = true;
                     while (!TestCase.stop) {}
-                    TestCase.finished = true;  // should not get there
+                    TestCase.runFinished = true;  // should not get there
                 }
             }
         }
         var valueObj = new TestCase.ValueClass();
         Thread thread = Thread.ofPlatform().start(valueObj::run);
+        boolean suspended = false;
         try {
             // wait for target thread to start executing method
-            while (!TestCase.started) {
+            while (!TestCase.runStarted) {
                 Thread.sleep(10);
             }
             assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            suspended = true;
+            assertTopFrame(thread, TestCase.ValueClass.class, "run");
             assertEquals(JVMTI_ERROR_NONE, forceEarlyReturnVoid(thread));
         } finally {
             TestCase.stop = true;
-            resumeThread(thread);
+            if (suspended) resumeThread(thread);
             thread.join();
         }
-        assertFalse(TestCase.finished);  // should not have run to the end
+        assertFalse(TestCase.runFinished);  // should not have run to the end
     }
 
     /**
@@ -113,32 +203,44 @@ class ForceEarlyReturnValueClass {
     @Test
     void testForceEarlyReturnClassInitializer() throws Exception {
         class TestCase {
-            static volatile boolean started;
+            static volatile boolean clinitStarted;
             static volatile boolean stop;
-            static volatile boolean finished;
             static value class ValueClass {
                 static final boolean initialized;
                 static {
-                    TestCase.started = true;
+                    TestCase.clinitStarted = true;
                     while (!TestCase.stop) {}
-                    initialized = true;    // should not get there
+                    initialized = true;  // should not get there
                 }
             }
         }
         Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
+        boolean suspended = false;
         try {
             // wait for target thread to start executing class initializer
-            while (!TestCase.started) {
+            while (!TestCase.clinitStarted) {
                 Thread.sleep(10);
             }
             assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            suspended = true;
+            assertTopFrame(thread, TestCase.ValueClass.class, "<clinit>");
             assertEquals(JVMTI_ERROR_NONE, forceEarlyReturnVoid(thread));
         } finally {
             TestCase.stop = true;
-            resumeThread(thread);
+            if (suspended) resumeThread(thread);
             thread.join();
         }
         assertFalse(TestCase.ValueClass.initialized);  // should not have run to the end
+    }
+
+    /**
+     * Asserts that the given thread's top frame is the expected class/method.
+     */
+    private void assertTopFrame(Thread thread, Class<?> clazz, String methodName) {
+        StackTraceElement[] stack = thread.getStackTrace();
+        assertTrue(stack.length > 0);
+        assertEquals(clazz.getName(), stack[0].getClassName());
+        assertEquals(methodName, stack[0].getMethodName());
     }
 
     private static native int suspendThread(Thread thread);

--- a/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/ForceEarlyReturnValueClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/ForceEarlyReturnValueClass.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test ForceEarlyReturnVoid when target thread's top frame is a value class
+ *     constructor or method
+ * @enablePreview
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED -agentlib:ForceEarlyReturnValueClass ${test.main.class}
+ */
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ForceEarlyReturnValueClass {
+
+    private static final int JVMTI_ERROR_NONE = 0;
+    private static final int JVMTI_ERROR_OPAQUE_FRAME = 32;
+
+    /**
+     * Test that ForceEarlyReturnVoid fails with JVMTI_ERROR_OPAQUE_FRAME when the
+     * target thread's top frame is a value class constructor.
+     */
+    @Test
+    void testForceEarlyReturnConstructor() throws Exception {
+        class TestCase {
+            static volatile boolean started;
+            static volatile boolean stop;
+            static volatile boolean finished;
+            static value class ValueClass {
+                ValueClass() {
+                    TestCase.started = true;
+                    while (!TestCase.stop) {}
+                    TestCase.finished = true;
+                }
+            }
+        }
+        Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
+        try {
+            while (!TestCase.started) {
+                Thread.sleep(10);
+            }
+            assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            assertEquals(JVMTI_ERROR_OPAQUE_FRAME, forceEarlyReturnVoid(thread));
+        } finally {
+            TestCase.stop = true;
+            resumeThread(thread);
+        }
+        thread.join();
+        assertTrue(TestCase.finished);
+    }
+
+    /**
+     * Test that ForceEarlyReturnVoid succeeds with the target thread's top frame is a
+     * value class method.
+     */
+    @Test
+    void testForceEarlyReturnMethod() throws Exception {
+        class TestCase {
+            static volatile boolean started;
+            static volatile boolean stop;
+            static volatile boolean finished;
+            static value class ValueClass {
+                void run() {
+                    TestCase.started = true;
+                    while (!TestCase.stop) {}
+                    TestCase.finished = true;  // should not get there
+                }
+            }
+        }
+        var valueObj = new TestCase.ValueClass();
+        Thread thread = Thread.ofPlatform().start(valueObj::run);
+        try {
+            while (!TestCase.started) {
+                Thread.sleep(10);
+            }
+            assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            assertEquals(JVMTI_ERROR_NONE, forceEarlyReturnVoid(thread));
+        } finally {
+            TestCase.stop = true;
+            resumeThread(thread);
+        }
+        thread.join();
+        assertFalse(TestCase.finished);
+    }
+
+    /**
+     * Test that ForceEarlyReturnVoid succeeds with the target thread's top frame is a
+     * value class clinit.
+     */
+    @Test
+    void testForceEarlyReturnClassInitializer() throws Exception {
+        class TestCase {
+            static volatile boolean started;
+            static volatile boolean stop;
+            static value class ValueClass {
+                static final boolean finished;
+                static {
+                    TestCase.started = true;
+                    while (!TestCase.stop) {}
+                    finished = true;    // should not get there
+                }
+            }
+        }
+        Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
+        try {
+            while (!TestCase.started) {
+                Thread.sleep(10);
+            }
+            assertEquals(JVMTI_ERROR_NONE, suspendThread(thread));
+            assertEquals(JVMTI_ERROR_NONE, forceEarlyReturnVoid(thread));
+        } finally {
+            TestCase.stop = true;
+            resumeThread(thread);
+        }
+        thread.join();
+
+        assertFalse(TestCase.ValueClass.finished);
+    }
+
+    private static native int suspendThread(Thread thread);
+    private static native int resumeThread(Thread thread);
+    private static native int forceEarlyReturnVoid(Thread thread);
+    private static native int forceEarlyReturnObject(Thread thread, Object retObject);
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/ForceEarlyReturnValueClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/ForceEarlyReturnValueClass.java
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @summary Test ForceEarlyReturnVoid when target thread's top frame is a value class
- *     constructor or method
+ * @summary Test ForceEarlyReturnVoid when the target thread's top frame is a value class
+ *     constructor, method or class initializer.
  * @enablePreview
  * @run junit/othervm/native --enable-native-access=ALL-UNNAMED -agentlib:ForceEarlyReturnValueClass ${test.main.class}
  */
@@ -57,6 +57,7 @@ class ForceEarlyReturnValueClass {
         }
         Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
         try {
+            // wait for target thread to start executing constructor
             while (!TestCase.started) {
                 Thread.sleep(10);
             }
@@ -65,9 +66,9 @@ class ForceEarlyReturnValueClass {
         } finally {
             TestCase.stop = true;
             resumeThread(thread);
+            thread.join();
         }
-        thread.join();
-        assertTrue(TestCase.finished);
+        assertTrue(TestCase.finished);  // constructor should have run to end
     }
 
     /**
@@ -91,6 +92,7 @@ class ForceEarlyReturnValueClass {
         var valueObj = new TestCase.ValueClass();
         Thread thread = Thread.ofPlatform().start(valueObj::run);
         try {
+            // wait for target thread to start executing method
             while (!TestCase.started) {
                 Thread.sleep(10);
             }
@@ -99,9 +101,9 @@ class ForceEarlyReturnValueClass {
         } finally {
             TestCase.stop = true;
             resumeThread(thread);
+            thread.join();
         }
-        thread.join();
-        assertFalse(TestCase.finished);
+        assertFalse(TestCase.finished);  // should not have run to the end
     }
 
     /**
@@ -113,17 +115,19 @@ class ForceEarlyReturnValueClass {
         class TestCase {
             static volatile boolean started;
             static volatile boolean stop;
+            static volatile boolean finished;
             static value class ValueClass {
-                static final boolean finished;
+                static final boolean initialized;
                 static {
                     TestCase.started = true;
                     while (!TestCase.stop) {}
-                    finished = true;    // should not get there
+                    initialized = true;    // should not get there
                 }
             }
         }
         Thread thread = Thread.ofPlatform().start(TestCase.ValueClass::new);
         try {
+            // wait for target thread to start executing class initializer
             while (!TestCase.started) {
                 Thread.sleep(10);
             }
@@ -132,10 +136,9 @@ class ForceEarlyReturnValueClass {
         } finally {
             TestCase.stop = true;
             resumeThread(thread);
+            thread.join();
         }
-        thread.join();
-
-        assertFalse(TestCase.ValueClass.finished);
+        assertFalse(TestCase.ValueClass.initialized);  // should not have run to the end
     }
 
     private static native int suspendThread(Thread thread);

--- a/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/libForceEarlyReturnValueClass.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/ForceEarlyReturn/libForceEarlyReturnValueClass.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include "jni.h"
+#include "jvmti.h"
+
+static jvmtiEnv *jvmti;
+
+extern "C" {
+
+extern JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  jvmtiError err;
+  jvmtiCapabilities caps;
+
+  if (jvm->GetEnv((void **) &jvmti, JVMTI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+
+  memset(&caps, 0, sizeof(caps));
+  caps.can_suspend = 1;
+  caps.can_force_early_return = 1;
+  err = jvmti->AddCapabilities( &caps);
+  if (err != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+JNIEXPORT jint Java_ForceEarlyReturnValueClass_suspendThread(JNIEnv *env, jclass ignore, jthread target) {
+  return (jint) jvmti->SuspendThread(target);
+}
+
+JNIEXPORT jint Java_ForceEarlyReturnValueClass_resumeThread(JNIEnv *env, jclass ignore, jthread target) {
+  return (jint) jvmti->ResumeThread(target);
+}
+
+JNIEXPORT jint Java_ForceEarlyReturnValueClass_forceEarlyReturnVoid(JNIEnv *env, jclass ignore, jthread target) {
+  return (jint) jvmti->ForceEarlyReturnVoid(target);
+}
+
+}


### PR DESCRIPTION
JVMTI ForceEarlyReturnVoid can be used to return early from a constructor or class initializer. Early return from a constructor with strictly-initialized instance fields is problematic, as is early return from a class initializer when there are strictly-initialized static fields. The proposal for the initial integration is to keep it simple and just disallow ForceEarlyReturnVoid to return early from a value class constructor.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387540](https://bugs.openjdk.org/browse/JDK-8387540): [lworld] ForceEarlyReturnVoid should fail with OPAQUE_FRAME if target thread's top frame is value class constructor (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2604/head:pull/2604` \
`$ git checkout pull/2604`

Update a local copy of the PR: \
`$ git checkout pull/2604` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2604`

View PR using the GUI difftool: \
`$ git pr show -t 2604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2604.diff">https://git.openjdk.org/valhalla/pull/2604.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2604#issuecomment-4847227544)
</details>
