### PR TITLE
8386874: [lworld] Clarify documentation of InstanceKlass layout in instanceKlass.hpp

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -55,10 +55,11 @@ class RecordComponent;
 
 //  InstanceKlass embedded field layout (after declared fields):
 //    [EMBEDDED Java vtable             ] size in words = vtable_len
+//    [EMBEDDED Java itable             ] size in words = itable_len
 //    [EMBEDDED nonstatic oop-map blocks] size in words = nonstatic_oop_map_size
 //      The embedded nonstatic oop-map blocks are short pairs (offset, length)
 //      indicating where oops are located in instances of this klass.
-//    [EMBEDDED implementor of the interface] only exist for interface
+//    [EMBEDDED implementor of the interface] only exists for interface
 //    [EMBEDDED InlineKlass::Members] only if is an InlineKlass instance
 
 
@@ -334,19 +335,6 @@ class InstanceKlass: public Klass {
 
   // Located here because sub-klasses can't have their own C++ fields
   address _adr_inline_klass_members;
-
-  // embedded Java vtable follows here
-  // embedded Java itables follows here
-  // embedded static fields follows here
-  // embedded nonstatic oop-map blocks follows here
-  // embedded implementor of this interface follows here
-  //   The embedded implementor only exists if the current klass is an
-  //   interface. The possible values of the implementor fall into following
-  //   three cases:
-  //     null: no implementor.
-  //     A Klass* that's not itself: one implementor.
-  //     Itself: more than one implementors.
-  //
 
   friend class SystemDictionary;
 
@@ -1006,6 +994,13 @@ public:
 #endif
 
   // Access to the implementor of an interface.
+  //   The embedded implementor only exists if the current klass is an
+  //   interface. The possible values of the implementor fall into following
+  //   three cases:
+  //     null: no implementor.
+  //     A Klass* that's not itself: one implementor.
+  //     Itself: more than one implementors.
+  //
   InstanceKlass* implementor() const;
   void set_implementor(InstanceKlass* ik);
   int  nof_implementors() const;


### PR DESCRIPTION
Please review a trivial comment correction and removing duplicate and wrong comment in instanceKlass.hpp.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386874](https://bugs.openjdk.org/browse/JDK-8386874): [lworld] Clarify documentation of InstanceKlass layout in instanceKlass.hpp (**Enhancement** - P4)


### Reviewers
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2606/head:pull/2606` \
`$ git checkout pull/2606`

Update a local copy of the PR: \
`$ git checkout pull/2606` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2606`

View PR using the GUI difftool: \
`$ git pr show -t 2606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2606.diff">https://git.openjdk.org/valhalla/pull/2606.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2606#issuecomment-4853737128)
</details>
