### PR TITLE
8387556: [lworld] Update the JVMTI GetObjectMonitorUsage spec with a clarification on value objects impact

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -8311,16 +8311,15 @@ class C2 extends C1 implements I2 {
         The fields of the <functionlink id="jvmtiMonitorUsage"></functionlink> structure
         are filled in with information about usage of the monitor.
         <p/>
+        When preview features are enabled, this function can be used to get
+        information for objects that have no identity. The fields of the returned
+        <functionlink id="jvmtiMonitorUsage"></functionlink> structure will always
+        be filled in with null values and zeros.
+        <p/>
         <b> This function does not support getting information about an object's monitor
             when it is owned by a virtual thread. It also does not support returning a
             reference to virtual threads that are waiting to own a monitor or waiting to
             be notified.
-        </b>
-        <p/>
-        <b> When preview features are enabled, this function can be used to get
-            information for objects that have no identity. The fields of the returned
-            <functionlink id="jvmtiMonitorUsage"></functionlink> structure will always
-            be filled in with null values and zeros.
         </b>
           <todo>
             Decide and then clarify suspend requirements.

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -8311,8 +8311,9 @@ class C2 extends C1 implements I2 {
         The fields of the <functionlink id="jvmtiMonitorUsage"></functionlink> structure
         are filled in with information about usage of the monitor.
         <p/>
-        When preview features are enabled, this function can be used to get
-        information for objects that have no identity. The fields of the returned
+        When preview features are enabled, this function can be used for value objects.
+        It is not possible to synchronize on a value object, so there is no monitor
+        usage information to return. The fields of the returned
         <functionlink id="jvmtiMonitorUsage"></functionlink> structure will always
         be filled in with null values and zeros.
         <p/>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -8316,6 +8316,11 @@ class C2 extends C1 implements I2 {
             reference to virtual threads that are waiting to own a monitor or waiting to
             be notified.
         </b>
+        <b> When preview features are enabled, this function can be used to get
+            information for objects that have no identity. The fileds of the returned
+            <functionlink id="jvmtiMonitorUsage"></functionlink> structure will be
+            always filled in with nulls and zeros.
+        </b>
           <todo>
             Decide and then clarify suspend requirements.
           </todo>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -8311,7 +8311,7 @@ class C2 extends C1 implements I2 {
         The fields of the <functionlink id="jvmtiMonitorUsage"></functionlink> structure
         are filled in with information about usage of the monitor.
         <p/>
-        When preview features are enabled, this function can be used for value objects.
+        When preview features are enabled, the object to query may be a value object.
         It is not possible to synchronize on a value object, so there is no monitor
         usage information to return. The fields of the returned
         <functionlink id="jvmtiMonitorUsage"></functionlink> structure will always

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -8316,10 +8316,11 @@ class C2 extends C1 implements I2 {
             reference to virtual threads that are waiting to own a monitor or waiting to
             be notified.
         </b>
+        <p/>
         <b> When preview features are enabled, this function can be used to get
-            information for objects that have no identity. The fileds of the returned
-            <functionlink id="jvmtiMonitorUsage"></functionlink> structure will be
-            always filled in with nulls and zeros.
+            information for objects that have no identity. The fields of the returned
+            <functionlink id="jvmtiMonitorUsage"></functionlink> structure will always
+            be filled in with null values and zeros.
         </b>
           <todo>
             Decide and then clarify suspend requirements.

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectMonitorUsage/libValueGetObjectMonitorUsage.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectMonitorUsage/libValueGetObjectMonitorUsage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,14 @@ Java_ValueGetObjectMonitorUsage_nTestGetObjectMonitorUsage(JNIEnv *jni, jclass t
 
   if (info.owner != nullptr) {
     LOG("ERROR: owner is not nullptr\n");
+    result = false;
+  }
+  if (info.waiters != nullptr) {
+    LOG("ERROR: waiters is not nullptr\n");
+    result = false;
+  }
+  if (info.notify_waiters != nullptr) {
+    LOG("ERROR: notify_waiters is not nullptr\n");
     result = false;
   }
   if (info.entry_count != 0) {


### PR DESCRIPTION
This JVMTI `GetObjectMonitorUsage` spec update is for Valhalla pre-integration. It is just a minor clarification on the value objects impact when preview features are enabled.

The fix also includes a minor fix for the Valhalla `GetObjectMonitorUsage` test by adding a couple of more checks:
  `test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectMonitorUsage/libValueGetObjectMonitorUsage.cpp`

Testing:
 - Ran the test `test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectMonitorUsage` locally
 - TBD: Submit mach5 tiers 1-3 to be completely safe.
 
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387556](https://bugs.openjdk.org/browse/JDK-8387556): [lworld] Update the JVMTI GetObjectMonitorUsage spec with a clarification on value objects impact (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2609/head:pull/2609` \
`$ git checkout pull/2609`

Update a local copy of the PR: \
`$ git checkout pull/2609` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2609`

View PR using the GUI difftool: \
`$ git pr show -t 2609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2609.diff">https://git.openjdk.org/valhalla/pull/2609.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2609#issuecomment-4850538555)
</details>
