### PR TITLE
8387458: [lworld] vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001 failed after JDK-8387389

### DIFF
--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -41,6 +41,3 @@
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#default_gc 8382398 generic-all
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#parallel   8382398 generic-all
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#Z          8382398 generic-all
-
-# Serviceability:
-vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001/TestDescription.java 8387458 generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,9 +188,16 @@ public class modifiers001 extends Log {
             String s_type = classes_for_check[i][2];
             String s_modifiers = classes_for_check[i][1];
             int got_modifiers = refType.modifiers();
-            // Class.getModifiers() will never return ACC_SUPER
-            // but Accessible.modifers() can, so ignore this bit
-            got_modifiers &= ~0x20; // 0x20 == ACC_SUPER
+            boolean previewEnabled =
+                System.getProperty("test.java.opts", "").contains("--enable-preview") ||
+                System.getProperty("test.vm.opts", "").contains("--enable-preview");
+            if (!previewEnabled) {
+                // With preview enabled 0x20 is ACC_IDENTITY.
+                // When not enabled 0x20 is ACC_SUPER.
+                // Class.getModifiers() will never return ACC_SUPER
+                // but Accessible.modifers() can, so ignore this bit.
+                got_modifiers &= ~0x20; // 0x20 == ACC_SUPER
+            }
             logHandler.display("");
             if ( got_modifiers != expected_modifiers ) {
                 logHandler.complain("##> modifiers001: UNEXPECTED modifiers() method result ("


### PR DESCRIPTION
When in preview mode 0x20 is ACC_IDENTITY, not ACC_SUPER, and is expected to be set. So only clear 0x20 when not in preview mode.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387458](https://bugs.openjdk.org/browse/JDK-8387458): [lworld] vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001 failed after JDK-8387389 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2613/head:pull/2613` \
`$ git checkout pull/2613`

Update a local copy of the PR: \
`$ git checkout pull/2613` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2613`

View PR using the GUI difftool: \
`$ git pr show -t 2613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2613.diff">https://git.openjdk.org/valhalla/pull/2613.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2613#issuecomment-4861295714)
</details>
