### PR TITLE
8387612: [lworld] C2: assert(array_type->is_flat() || ideal.ctrl()->in(0)->as_If()->is_flat_array_check(&_gvn)) failed: Should be found

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1377,10 +1377,6 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
       return top();
     }
     if (assert_null) {
-      // TODO 8350865 Scalarize here (this leads to failures with TestLWorld::test45)
-      // vtptr = InlineTypeNode::make_null(_gvn, vtptr->type()->inline_klass());
-      // replace_in_map(value, vtptr);
-      // return vtptr;
       replace_in_map(value, null());
       return null();
     }

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -255,12 +255,14 @@ void Parse::array_store(BasicType bt) {
              (!array_type->klass_is_exact() || array_type->is_flat()), "array can't be a flat array");
       // TODO 8350865 Depending on the available layouts, we can avoid this check in below flat/not-flat branches. Also the safe_for_replace arg is now always true.
       array = inline_array_null_guard(array, stored_value_casted, 3, true);
+      // Reload array type which could have been updated by inline_array_null_guard().
+      array_type = _gvn.type(array)->is_aryptr();
       IdealKit ideal(this);
       ideal.if_then(flat_array_test(array, /* flat = */ false)); {
         // Non-flat array
         if (!array_type->is_flat()) {
           sync_kit(ideal);
-          assert(array_type->is_flat() || ideal.ctrl()->in(0)->as_If()->is_flat_array_check(&_gvn), "Should be found");
+          assert(array_type->is_not_flat() || ideal.ctrl()->in(0)->as_If()->is_flat_array_check(&_gvn), "Should be found");
           inc_sp(3);
           access_store_at(array, adr, adr_type, stored_value_casted, elemtype, bt, MO_UNORDERED | IN_HEAP | IS_ARRAY, false);
           dec_sp(3);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1148,7 +1148,7 @@ const Type *Type::meet_helper(const Type *t, bool include_speculative) const {
   if (isa_narrowklass() || t->isa_narrowklass()) {
     return mt;
   }
-  // TODO 8350865 This currently triggers a verification failure, the code around "// Even though MyValue is final" needs adjustments
+  // TODO 8387653 This currently triggers a verification failure, the code around "// Even though MyValue is final" needs adjustments
   if ((this_t->isa_ptr() && this_t->is_ptr()->is_not_flat()) ||
       (this_t->_dual->isa_ptr() && this_t->_dual->is_ptr()->is_not_flat())) return mt;
   this_t->check_symmetrical(t, mt, verify);
@@ -2629,7 +2629,7 @@ bool TypeAry::ary_must_be_exact() const {
     if (tinst->instance_klass()->is_final()) {
       // Even though MyValue is final, [LMyValue is only exact if the array
       // is (not) null-free due to null-free [LMyValue <: null-able [LMyValue.
-      // TODO 8350865 If we know that the array can't be null-free, it's allowed to be exact, right?
+      // TODO 8387653 If we know that the array can't be null-free, it's allowed to be exact, right?
       // If so, we should add '&& !_not_null_free'
       if (tinst->is_inlinetypeptr() && (tinst->ptr() != TypePtr::NotNull)) {
         return false;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStaleArrayTypeInArrayStore.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStaleArrayTypeInArrayStore.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387612
+ * @summary Test that stale
+ * @enablePreview
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::test ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestStaleArrayTypeInArrayStore {
+    static Object[] array = new Object[1];
+    static int iFld;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            iFld = i % 100;
+            test();
+        }
+    }
+
+    static void test() {
+        Object o = array[0];
+        if (iFld == 0) {
+            inline();
+        }
+    }
+
+    static void inline() {
+        array[0] = null;
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStaleArrayTypeInArrayStore.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStaleArrayTypeInArrayStore.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8387612
- * @summary Test that stale
+ * @summary Test that stale array type is correctly updated and the corrected assert works.
  * @enablePreview
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::test ${test.main.class}
  */


### PR DESCRIPTION
The provided test fails with an assertion in `Parse::array_store()` due to checking an old outdated type and the assert being off.

We improve the array type in `inline_array_null_guard()` here because we are storing `null`:
https://github.com/openjdk/valhalla/blob/6adeca933a1361c6f44f51c9c266bd1a20a42380/src/hotspot/share/opto/graphKit.cpp#L4041-L4045

We return the casted array but do not update `array_type` in the caller (i.e. in `Parse::array_store()`). We then continue and hit this assert which also seems wrong:
https://github.com/openjdk/valhalla/blob/6adeca933a1361c6f44f51c9c266bd1a20a42380/src/hotspot/share/opto/parse2.cpp#L263

What we actually want to check is that we either have a known non-flat array, in which case the `BoolNode` for the just emitted `flat_array_test()` folded to a constant, which we can also check over the current array type, or that we find a proper flat array check with a `FlatArrayCheckNode`.

I also squeezed in three unrelated comment updates in `graphKit.cpp` and `type.cpp` provided by @marc-chevalier since it's not worth to file an extra issue just for that.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387612](https://bugs.openjdk.org/browse/JDK-8387612): [lworld] C2: assert(array_type-&gt;is_flat() || ideal.ctrl()-&gt;in(0)-&gt;as_If()-&gt;is_flat_array_check(&amp;_gvn)) failed: Should be found (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Contributors
 * Marc Chevalier `<mchevalier@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2614/head:pull/2614` \
`$ git checkout pull/2614`

Update a local copy of the PR: \
`$ git checkout pull/2614` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2614`

View PR using the GUI difftool: \
`$ git pr show -t 2614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2614.diff">https://git.openjdk.org/valhalla/pull/2614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2614#issuecomment-4864246954)
</details>
