### PR TITLE
8387657: [lworld] Object Tags section of JVMTI spec should make it clear that ObjectFree event is not sent for value objects

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3431,6 +3431,15 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       information.  Objects which have not been tagged have a
       tag of zero.
       Setting a tag to zero makes the object untagged.
+      <p/>
+      If the <eventlink id="ObjectFree"/> event is enabled then an Object Free
+      event is sent for tagged objects when the garbage collector frees the object.
+      When preview features are enabled, the Object Free event is only sent for tagged
+      <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
+      <b>The event is not sent for tagged values objects.</b>
+      All objects are identity objects when preview features are disabled; consequently
+      the Object Free event is sent for all tagged objects when preview features are
+      disabled.
     </intro>
 
     <intro id="heapCallbacks" label="Heap Callback Functions">
@@ -14160,11 +14169,17 @@ myInit() {
       Events are only sent for tagged objects--see
       <internallink id="Heap">heap functions</internallink>.
       <p/>
+      When preview features are enabled, the Object Free event is only sent for tagged
+      <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
+      <b>The event is not sent for tagged values objects.</b>
+      All objects are identity objects when preview features are disabled; consequently
+      the Object Free event is sent for all tagged objects when preview features are
+      disabled.
+      <p/>
       The event handler must not use JNI functions and
       must not use <jvmti/> functions except those which
       specifically allow such use (see the raw monitor, memory management,
       and environment local storage functions).
-      When preview features are enabled, this event does not support value object allocations.
     </description>
     <origin>new</origin>
     <capabilities>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3445,9 +3445,6 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       When preview features are enabled, the Object Free event is only sent for tagged
       <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
       <b>The event is not sent for tagged values objects.</b>
-      All objects are identity objects when preview features are disabled; consequently
-      the Object Free event is sent for all tagged objects when preview features are
-      disabled.
     </intro>
 
     <intro id="heapCallbacks" label="Heap Callback Functions">
@@ -14202,9 +14199,6 @@ myInit() {
       When preview features are enabled, the Object Free event is only sent for tagged
       <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
       <b>The event is not sent for tagged values objects.</b>
-      All objects are identity objects when preview features are disabled; consequently
-      the Object Free event is sent for all tagged objects when preview features are
-      disabled.
       <p/>
       The event handler must not use JNI functions and
       must not use <jvmti/> functions except those which


### PR DESCRIPTION
The Object Tags section introduces object tagging but doesn't say anything about the ObjectFree event and that it is not sent for tagged value objects. 

In the ObjectFree event description the current text is more of a note at the end. This is replaced with a paragraph that makes it clear that the event is not sent for value objects.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387657](https://bugs.openjdk.org/browse/JDK-8387657): [lworld] Object Tags section of JVMTI spec should make it clear that ObjectFree event is not sent for value objects (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2615/head:pull/2615` \
`$ git checkout pull/2615`

Update a local copy of the PR: \
`$ git checkout pull/2615` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2615`

View PR using the GUI difftool: \
`$ git pr show -t 2615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2615.diff">https://git.openjdk.org/valhalla/pull/2615.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2615#issuecomment-4864239166)
</details>
