### PR TITLE
8386602: [lworld] C2: assert(n != top() || r->in(pnum) == top()) failed: live value must not be garbage

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2412,6 +2412,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   Node* io_taken = nullptr;
   if (btest == BoolTest::eq) {
     PreserveJVMState pjvms(this);
+    // Also merges branch block.
     do_if(btest, subst_cmp, can_trap, false, nullptr, &mem_taken, &io_taken);
     if (!stopped()) {
       ctl = control();
@@ -2432,18 +2433,25 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   ne_io_phi->init_req(5, io_taken);
   ne_mem_phi->init_req(5, mem_taken);
 
+  // BoolTest::eq: ne_region is fall-through block.
+  // BoolTest::ne: ne_region is branch block -> merge below.
   record_for_igvn(ne_region);
   set_control(_gvn.transform(ne_region));
   set_i_o(_gvn.transform(ne_io_phi));
   set_all_memory(_gvn.transform(ne_mem_phi));
 
   if (btest == BoolTest::ne) {
-    {
+    int target_bci = iter().get_dest();
+    if (!stopped()) {
       PreserveJVMState pjvms(this);
-      int target_bci = iter().get_dest();
       merge(target_bci);
+    } else if (C->eliminate_boxing()) {
+      // Mark the branch block as parsed.
+      Block* branch_block = successor_for_bci(target_bci);
+      branch_block->next_path_num();
     }
 
+    // Fall-through block.
     record_for_igvn(eq_region);
     set_control(_gvn.transform(eq_region));
     set_i_o(_gvn.transform(eq_io_phi));

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpEdgeCases.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAcmpEdgeCases.java
@@ -40,6 +40,7 @@
 
 package compiler.valhalla.inlinetypes;
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;
 
 public class TestAcmpEdgeCases {
@@ -337,6 +338,12 @@ public class TestAcmpEdgeCases {
         return v1 == v2;
     }
 
+    public static Integer thirtyFour = 34;
+
+    public static boolean testNeRegionDeadInAcmp(Integer i) {
+        return i == 34 && i == thirtyFour;
+    }
+
     public static void main(String[] args) {
 
         for (int k = 0; k < 10_000; ++k) {
@@ -459,6 +466,11 @@ public class TestAcmpEdgeCases {
                     }
                 }
             }
+        }
+
+        for (int k = 0; k < 10_000; k++) {
+            Asserts.assertTrue(testNeRegionDeadInAcmp(34));
+            Asserts.assertFalse(testNeRegionDeadInAcmp(35));
         }
     }
 }


### PR DESCRIPTION
In the test case, we are trying to merge a dead path in a live target block which is unexpected and we fail with an assertion failure.

We call `Parse::do_acmp()` with `BoolTest::ne`. This means that the target block is reached over `ne_region`, which collects all the branching paths, and the fall-through block is `eq_region`, which collects all the fall-through paths. 

We emit several checks to see if we need to branch off and capture those in `ne_region`. In the test case, we either fold such a branch directly with the available information or we emit an uncommon trap in which case we also will not branch off to the target block. At the end of `do_acmp`, we only collected dead paths in the `ne_region` and thus are left with only `top` inputs. This means that we will not branch off to the target block and will fall through. We transform the `ne_region` with `top` inputs only, get `top` back and set it as current control:
https://github.com/openjdk/valhalla/blob/6adeca933a1361c6f44f51c9c266bd1a20a42380/src/hotspot/share/opto/parse2.cpp#L2436
Nothing unusual, this is perfectly fine to signal that this path is dead. So far, so good.

Since `do_acmp` handles both the `BoolTest::ne` and `BoolTest::eq` case, we actually need to swap the fall-through control to be the `eq_region` instead:
https://github.com/openjdk/valhalla/blob/6adeca933a1361c6f44f51c9c266bd1a20a42380/src/hotspot/share/opto/parse2.cpp#L2447-L2450

Before doing that, we merge the `ne_region` into the target block:
https://github.com/openjdk/valhalla/blob/6adeca933a1361c6f44f51c9c266bd1a20a42380/src/hotspot/share/opto/parse2.cpp#L2441-L2445

However, if the target block is live by already having merged another block as in the test case, we will merge a dead path with a live path. This is not anticipated by `merge()` and we fail with an assertion failure: The caller needs to make sure to only call `merge()` with live paths.

The solution is straight forward: Only `merge()` if we have not `stopped()`. Otherwise, mark the block as handled and do nothing.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386602](https://bugs.openjdk.org/browse/JDK-8386602): [lworld] C2: assert(n != top() || r-&gt;in(pnum) == top()) failed: live value must not be garbage (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2618/head:pull/2618` \
`$ git checkout pull/2618`

Update a local copy of the PR: \
`$ git checkout pull/2618` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2618`

View PR using the GUI difftool: \
`$ git pr show -t 2618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2618.diff">https://git.openjdk.org/valhalla/pull/2618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2618#issuecomment-4866380805)
</details>
