### PR TITLE
8386499: [lworld] java/util/Arrays/ArraysEqCmpTest.java fails with unexpected layoutKind 5

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2690,8 +2690,7 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
          layout_type->get_con() < static_cast<int>(LayoutKind::UNKNOWN),
          "invalid layoutKind %d", layout_type->get_con());
   LayoutKind layout = static_cast<LayoutKind>(layout_type->get_con());
-  assert(layout == LayoutKind::REFERENCE || layout == LayoutKind::NULL_FREE_NON_ATOMIC_FLAT ||
-         layout == LayoutKind::NULL_FREE_ATOMIC_FLAT || layout == LayoutKind::NULLABLE_ATOMIC_FLAT,
+  assert(layout == LayoutKind::REFERENCE || LayoutKindHelper::is_flat(layout),
          "unexpected layoutKind %d", layout_type->get_con());
 
   null_check(argument(0));

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetFlatValueNullableNonAtomic.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetFlatValueNullableNonAtomic.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8386499
- * @summary Test C2 Unsafe.getFlatValue with a nullable non-atomic flat layout
+ * @summary Test C2 Unsafe.getFlatValue with a nullable non-atomic flat layout.
+ * @library /test/lib /
  * @requires vm.compiler2.enabled
  * @enablePreview
  * @modules java.base/jdk.internal.misc
@@ -40,57 +41,32 @@ package compiler.valhalla.inlinetypes;
 import java.lang.reflect.Field;
 
 import jdk.internal.misc.Unsafe;
+import jdk.test.lib.Asserts;
 
-public class TestGetFlatValueNullableNonAtomic {
+public value class TestGetFlatValueNullableNonAtomic {
     static final Unsafe U = Unsafe.getUnsafe();
-    static final Container CONTAINER = new Container(new Value(1, 2));
     static final long OFFSET;
     static final int LAYOUT;
 
     static {
         try {
-            Field f = Container.class.getDeclaredField("value");
+            Field f = TestGetFlatValueNullableNonAtomic.class.getDeclaredField("value");
             OFFSET = U.objectFieldOffset(f);
             LAYOUT = U.fieldLayout(f);
+            Asserts.assertEQ(LAYOUT, 5, "Unexpected layout");
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }
 
-    static value class Value {
-        int x;
-        int y;
+    Integer value = 42;
 
-        Value(int x, int y) {
-            this.x = x;
-            this.y = y;
-        }
-
-        int sum() {
-            return x + y;
-        }
-    }
-
-    static value class Container {
-        Value value;
-
-        Container(Value value) {
-            this.value = value;
-        }
-    }
-
-    static int test() {
-        Value v = U.getFlatValue(CONTAINER, OFFSET, LAYOUT, Value.class);
-        return v.sum();
+    int test() {
+        return U.getFlatValue(this, OFFSET, LAYOUT, Integer.class);
     }
 
     public static void main(String[] args) {
-        if (LAYOUT != 5) {
-            throw new AssertionError("expected nullable non-atomic flat layout 5, got " + LAYOUT);
-        }
-        int result = test();
-        if (result != 3) {
-            throw new AssertionError(result);
-        }
+        TestGetFlatValueNullableNonAtomic t = new TestGetFlatValueNullableNonAtomic();
+        Asserts.assertEQ(t.test(), 42);
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetFlatValueNullableNonAtomic.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetFlatValueNullableNonAtomic.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8386499
+ * @summary Test C2 Unsafe.getFlatValue with a nullable non-atomic flat layout
+ * @requires vm.compiler2.enabled
+ * @enablePreview
+ * @modules java.base/jdk.internal.misc
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+UseFieldFlattening -XX:+UseNullableNonAtomicValueFlattening
+ *                   -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.lang.reflect.Field;
+
+import jdk.internal.misc.Unsafe;
+
+public class TestGetFlatValueNullableNonAtomic {
+    static final Unsafe U = Unsafe.getUnsafe();
+    static final Container CONTAINER = new Container(new Value(1, 2));
+    static final long OFFSET;
+    static final int LAYOUT;
+
+    static {
+        try {
+            Field f = Container.class.getDeclaredField("value");
+            OFFSET = U.objectFieldOffset(f);
+            LAYOUT = U.fieldLayout(f);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static value class Value {
+        int x;
+        int y;
+
+        Value(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        int sum() {
+            return x + y;
+        }
+    }
+
+    static value class Container {
+        Value value;
+
+        Container(Value value) {
+            this.value = value;
+        }
+    }
+
+    static int test() {
+        Value v = U.getFlatValue(CONTAINER, OFFSET, LAYOUT, Value.class);
+        return v.sum();
+    }
+
+    public static void main(String[] args) {
+        if (LAYOUT != 5) {
+            throw new AssertionError("expected nullable non-atomic flat layout 5, got " + LAYOUT);
+        }
+        int result = test();
+        if (result != 3) {
+            throw new AssertionError(result);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetFlatValueNullableNonAtomic.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetFlatValueNullableNonAtomic.java
@@ -53,7 +53,6 @@ public value class TestGetFlatValueNullableNonAtomic {
             Field f = TestGetFlatValueNullableNonAtomic.class.getDeclaredField("value");
             OFFSET = U.objectFieldOffset(f);
             LAYOUT = U.fieldLayout(f);
-            Asserts.assertEQ(LAYOUT, 5, "Unexpected layout");
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -719,7 +719,6 @@ tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java 83
 
 java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java 8375778 macosx-aarch64
 
-java/util/Arrays/ArraysEqCmpTest.java 8386499 generic-all
 java/util/Arrays/largeMemory/ParallelPrefix.java 8386501 generic-all
 
 sun/tools/jhsdb/JStackStressTest.java 8247940 macosx-aarch64


### PR DESCRIPTION
C2’s Unsafe.get/putFlatValue intrinsic asserts because it does not expect the layout `LayoutKind::NULLABLE_NON_ATOMIC_FLAT` added by [JDK-8374800](https://bugs.openjdk.org/browse/JDK-8374800). I just fixed the assert because the implementation already handles the layout correctly.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386499](https://bugs.openjdk.org/browse/JDK-8386499): [lworld] java/util/Arrays/ArraysEqCmpTest.java fails with unexpected layoutKind 5 (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2619/head:pull/2619` \
`$ git checkout pull/2619`

Update a local copy of the PR: \
`$ git checkout pull/2619` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2619`

View PR using the GUI difftool: \
`$ git pr show -t 2619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2619.diff">https://git.openjdk.org/valhalla/pull/2619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2619#issuecomment-4866604770)
</details>
