### PR TITLE
8387682: [lworld] Mention preview API in description of can_support_value_objects capability

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -10731,6 +10731,9 @@ myInit() {
           events are sent for value objects when the following two events are enabled:
           <eventlink id="VMObjectAlloc"></eventlink>,
           <eventlink id="SampledObjectAlloc"></eventlink>.
+          <b> can_support_value_objects is a preview API of the Java platform. </b>
+          <i>Preview features may be removed in a future release, or upgraded to
+          permanent features of the Java platform.</i> 
         </description>
       </capabilityfield>
     </capabilitiestypedef>


### PR DESCRIPTION
This is a minor JVMTI spec update for the `can_support_value_objects` capability needed for `repo-valhalla` pre-integration. It is just to clarify about the preview API.

Testing: N/A


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387682](https://bugs.openjdk.org/browse/JDK-8387682): [lworld] Mention preview API in description of can_support_value_objects capability (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2620/head:pull/2620` \
`$ git checkout pull/2620`

Update a local copy of the PR: \
`$ git checkout pull/2620` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2620`

View PR using the GUI difftool: \
`$ git pr show -t 2620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2620.diff">https://git.openjdk.org/valhalla/pull/2620.diff</a>

</details>
