### PR TITLE
8387686: [lworld] Update the JNI specification version for value types

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -99,7 +99,7 @@
 #include "jfr/jfr.hpp"
 #endif
 
-static jint CurrentVersion = JNI_VERSION_24;
+static jint CurrentVersion = JNI_VERSION_28;
 
 #if defined(_WIN32) && !defined(USE_VECTORED_EXCEPTION_HANDLING)
 extern LONG WINAPI topLevelExceptionFilter(_EXCEPTION_POINTERS* );

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1041,6 +1041,7 @@ jboolean Threads::is_supported_jni_version(jint version) {
   if (version == JNI_VERSION_20) return JNI_TRUE;
   if (version == JNI_VERSION_21) return JNI_TRUE;
   if (version == JNI_VERSION_24) return JNI_TRUE;
+  if (version == JNI_VERSION_28) return JNI_TRUE;
   return JNI_FALSE;
 }
 

--- a/src/java.base/share/native/include/jni.h
+++ b/src/java.base/share/native/include/jni.h
@@ -2016,6 +2016,7 @@ JNI_OnUnload(JavaVM *vm, void *reserved);
 #define JNI_VERSION_20  0x00140000
 #define JNI_VERSION_21  0x00150000
 #define JNI_VERSION_24  0x00180000
+#define JNI_VERSION_28  0x001C0000
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/test/hotspot/jtreg/native_sanity/JniVersion.java
+++ b/test/hotspot/jtreg/native_sanity/JniVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,12 @@
  */
 public class JniVersion {
 
-    public static final int JNI_VERSION_24 = 0x00180000;
+    public static final int JNI_VERSION_28 = 0x001C0000;
 
     public static void main(String... args) throws Exception {
         System.loadLibrary("JniVersion");
         int res = getJniVersion();
-        if (res != JNI_VERSION_24) {
+        if (res != JNI_VERSION_28) {
             throw new Exception("Unexpected value returned from getJniVersion(): 0x" + Integer.toHexString(res));
         }
     }


### PR DESCRIPTION
Simple update to JNI_VERSION_28

Testing:
- tiers 1-3 (sanity)

Thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387686](https://bugs.openjdk.org/browse/JDK-8387686): [lworld] Update the JNI specification version for value types (**Enhancement** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2621/head:pull/2621` \
`$ git checkout pull/2621`

Update a local copy of the PR: \
`$ git checkout pull/2621` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2621`

View PR using the GUI difftool: \
`$ git pr show -t 2621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2621.diff">https://git.openjdk.org/valhalla/pull/2621.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2621#issuecomment-4871934240)
</details>
