### PR TITLE
8387030: [lworld] two compiler/valhalla/inlinetypes/TestValueClasses.java sub-tests fail test3_verifier and test1_verifier

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -62,7 +62,4 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 #############################################################################
 
 # Valhalla failures start here:
-compiler/valhalla/inlinetypes/TestValueClasses.java#id0 8387030 generic-all
-compiler/valhalla/inlinetypes/TestValueClasses.java#id6 8387030 generic-all
-
 runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8378071 generic-all

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallProjSubsumed.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallProjSubsumed.java
@@ -28,6 +28,7 @@
  * @enablePreview
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-TieredCompilation
  *                   -XX:-UseOnStackReplacement -XX:+AlwaysIncrementalInline ${test.main.class}
+ * @run main {test.main.class}
  */
 
 package compiler.valhalla.inlinetypes;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallProjSubsumed.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallProjSubsumed.java
@@ -28,7 +28,7 @@
  * @enablePreview
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-TieredCompilation
  *                   -XX:-UseOnStackReplacement -XX:+AlwaysIncrementalInline ${test.main.class}
- * @run main {test.main.class}
+ * @run main ${test.main.class}
  */
 
 package compiler.valhalla.inlinetypes;


### PR DESCRIPTION
The wrong execution reported with `TestValueClasses.java` seems to have been fixed by [JDK-8386999](https://bugs.openjdk.org/browse/JDK-8386999). We can therefore remove the problemlisting. I've added an additional flagless run to `TestCallProjSubsumed.java` to get some more coverage.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387030](https://bugs.openjdk.org/browse/JDK-8387030): [lworld] two compiler/valhalla/inlinetypes/TestValueClasses.java sub-tests fail test3_verifier and test1_verifier (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2622/head:pull/2622` \
`$ git checkout pull/2622`

Update a local copy of the PR: \
`$ git checkout pull/2622` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2622`

View PR using the GUI difftool: \
`$ git pr show -t 2622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2622.diff">https://git.openjdk.org/valhalla/pull/2622.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2622#issuecomment-4874914156)
</details>
