### PR TITLE
8387673: [lworld] C2: clone() intrinsic does not throw CloneNotSupportedException for value classes not implementing Cloneable

### DIFF
--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -62,6 +62,10 @@ bool ciInlineKlass::is_empty() {
   return nof_declared_nonstatic_fields() == 0;
 }
 
+bool ciInlineKlass::is_cloneable() const {
+  GUARDED_VM_ENTRY(return get_InlineKlass()->is_cloneable();)
+}
+
 int ciInlineKlass::inline_arg_length() const {
   VM_ENTRY_MARK;
   return get_InlineKlass()->extended_sig()->length();

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -66,6 +66,7 @@ public:
   bool can_be_returned_as_fields() const;
 
   bool is_empty();
+  bool is_cloneable() const;
   int inline_arg_length() const;
   int inline_arg_slots() const;
   bool contains_oops() const;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6026,6 +6026,10 @@ void LibraryCallKit::copy_to_clone(Node* obj, Node* alloc_obj, Node* obj_size, b
 // can be sharply typed as an object array, a type array, or an instance.
 //
 bool LibraryCallKit::inline_native_clone(bool is_virtual) {
+  if (too_many_traps(Deoptimization::Reason_intrinsic)) {
+    return false;
+  }
+
   PhiNode* result_val;
 
   // Set the reexecute bit for the interpreter to reexecute
@@ -6040,8 +6044,14 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
     const TypeOopPtr* obj_type = _gvn.type(obj)->is_oopptr();
     if (obj_type->is_inlinetypeptr()) {
       // If the object to clone is an inline type, we can simply return it (i.e. a nop) since inline types have
-      // no identity.
-      set_result(obj);
+      // no identity. But we first need to check whether the value class is actually implementing the Cloneable
+      // interface. If not, we trap.
+      if (obj_type->inline_klass()->is_cloneable()) {
+        set_result(obj);
+      } else {
+        uncommon_trap(Deoptimization::Reason_intrinsic,
+                      Deoptimization::Action_maybe_recompile);
+      }
       return true;
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1863,6 +1863,36 @@ public class TestIntrinsics {
         }
     }
 
+    static value class MyValueNotCloneable {
+        int x;
+
+        MyValueNotCloneable(int x) {
+            this.x = x;
+        }
+
+        @Override
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+
+    @Test
+    public Object testCloneNotCloneable() throws CloneNotSupportedException {
+        MyValueNotCloneable obj = new MyValueNotCloneable(3);
+        // Throws CloneNotSupportedException because MyValueNotCloneable does not implement Cloneable.
+        return obj.clone();
+    }
+
+    @Run(test = "testCloneNotCloneable")
+    public void testCloneNotCloneable_verifier() {
+        try {
+            testCloneNotCloneable();
+            Asserts.fail("should throw");
+        } catch (CloneNotSupportedException e) {
+            // Expected.
+        }
+    }
+
     // Test correctness of the ValueClass::isNullRestrictedArray intrinsic
     @Test
     @IR(failOn = {STATIC_CALL_OF_METHOD, "jdk.internal.value.ValueClass::isNullRestrictedArray",

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1863,6 +1863,99 @@ public class TestIntrinsics {
         }
     }
 
+    static abstract value class AbstractValueCloneable implements Cloneable {
+        @Override
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+
+    static value class ValueCloneable extends AbstractValueCloneable {
+        int x;
+
+        ValueCloneable(int x) {
+            this.x = x;
+        }
+    }
+
+    static class RefCloneable extends AbstractValueCloneable {
+        int x;
+
+        RefCloneable(int x) {
+            this.x = x;
+        }
+    }
+
+    @Test
+    public Object testCloneAbstract(AbstractValueCloneable o) throws CloneNotSupportedException {
+        return o.clone();
+    }
+
+    @Run(test = "testCloneAbstract")
+    public void testCloneAbstract_verifier() {
+        ValueCloneable val = new ValueCloneable(3);
+        RefCloneable ref = new RefCloneable(3);
+        try {
+            Asserts.assertEQ(testCloneAbstract(val), val);
+            RefCloneable res = (RefCloneable)testCloneAbstract(ref);
+            Asserts.assertEQ(res.x, ref.x);
+        } catch (Exception e) {
+            Asserts.fail("testCloneAbstract() failed", e);
+        }
+    }
+
+    @Test
+    public Object testCloneAbstractVal() throws CloneNotSupportedException {
+        ValueCloneable val = new ValueCloneable(3);
+        RefCloneable ref = new RefCloneable(4);
+        int a = 50;
+        int b = 0;
+        do {
+            a--;
+            b++;
+        } while (a > 0);
+        // b == 50 known after first loop opts pass -> take val.
+        AbstractValueCloneable o = b == 50 ? val : ref;
+        return o.clone();
+    }
+
+    @Run(test = "testCloneAbstractVal")
+    @Warmup(1)
+    public void testCloneAbstractVal_verifier() {
+        try {
+            ValueCloneable res = (ValueCloneable)testCloneAbstractVal();
+            Asserts.assertEQ(res, new ValueCloneable(3));
+        } catch (Exception e) {
+            Asserts.fail("testCloneAbstractVal() failed", e);
+        }
+    }
+
+    @Test
+    public Object testCloneAbstractRef() throws CloneNotSupportedException {
+        ValueCloneable val = new ValueCloneable(3);
+        RefCloneable ref = new RefCloneable(4);
+        int a = 50;
+        int b = 0;
+        do {
+            a--;
+            b++;
+        } while (a > 0);
+        // b == 50 known after first loop opts pass -> take ref.
+        AbstractValueCloneable o = b == 50 ? ref : val;
+        return o.clone();
+    }
+
+    @Run(test = "testCloneAbstractRef")
+    @Warmup(1)
+    public void testCloneAbstractRef_verifier() {
+        try {
+            RefCloneable res = (RefCloneable)testCloneAbstractRef();
+            Asserts.assertEQ(res.x, 4);
+        } catch (Exception e) {
+            Asserts.fail("testCloneAbstractRef() failed", e);
+        }
+    }
+
     static value class MyValueNotCloneable {
         int x;
 


### PR DESCRIPTION
The `clone()` intrinsic directly returns a value object because it has no identity - the clone is trivially a no-op:
https://github.com/openjdk/valhalla/blob/2af7c2350b22ed03850b6b6c146b622ca758f441/src/hotspot/share/opto/library_call.cpp#L6041-L6045

But this is incorrect if the value class does not implement `Cloneable`. In this case, we must throw `CloneNotSupportedException` which is currently missing.

The fix adds a check whether the value class implements `Cloneable`. If it does, we execute the existing code no-op path. Otherwise, we could either do a call to the runtime `clone()` implementation, as done for the existing slow path of this intrinsic, or we simply emit an uncommon trap. I've decided to use the latter approach since it's more straight forward and rather an edge-case situation. I also included a `too_many_traps()` check to avoid repeated recompilations.

Thanks,
Christian
 
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387673](https://bugs.openjdk.org/browse/JDK-8387673): [lworld] C2: clone() intrinsic does not throw CloneNotSupportedException for value classes not implementing Cloneable (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2625/head:pull/2625` \
`$ git checkout pull/2625`

Update a local copy of the PR: \
`$ git checkout pull/2625` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2625`

View PR using the GUI difftool: \
`$ git pr show -t 2625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2625.diff">https://git.openjdk.org/valhalla/pull/2625.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2625#issuecomment-4876420195)
</details>
