### PR TITLE
8387709: [lworld] Split Valhalla tests from tier1_compiler_3 to avoid task timeouts

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -227,6 +227,14 @@ tier1_compiler_3 = \
   -compiler/runtime/Test6826736.java \
   -compiler/valhalla/inlinetypes/TestVirtualThreads.java
 
+tier1_compiler_3_no_valhalla = \
+  :tier1_compiler_3 \
+  -compiler/valhalla
+
+tier1_compiler_3_valhalla = \
+  :tier1_compiler_3 \
+  -:tier1_compiler_3_no_valhalla
+
 tier2_compiler = \
   compiler/allocation/ \
   compiler/arguments/ \
@@ -261,8 +269,7 @@ tier3_compiler = \
 tier1_compiler_no_valhalla = \
   :tier1_compiler_1 \
   :tier1_compiler_2 \
-  :tier1_compiler_3 \
-  -compiler/valhalla
+  :tier1_compiler_3_no_valhalla
 
 ctw_1 = \
   applications/ctw/modules/ \


### PR DESCRIPTION
We added a large number of new Valhalla compiler tests that are now part of `tier1_compiler_3`. Let's split those out to avoid task timeouts.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387709](https://bugs.openjdk.org/browse/JDK-8387709): [lworld] Split Valhalla tests from tier1_compiler_3 to avoid task timeouts (**Enhancement** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2626/head:pull/2626` \
`$ git checkout pull/2626`

Update a local copy of the PR: \
`$ git checkout pull/2626` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2626`

View PR using the GUI difftool: \
`$ git pr show -t 2626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2626.diff">https://git.openjdk.org/valhalla/pull/2626.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2626#issuecomment-4876695808)
</details>
