### PR TITLE
8386861: [lworld] emit_opSubstitutabilityCheck speedup

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1597,8 +1597,12 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   Register left  = op->left()->as_register();
   Register right = op->right()->as_register();
 
-  __ cmp(left, right);
-  __ br(Assembler::EQ, L_oops_equal);
+  if (left == right) {
+    __ b(L_oops_equal);
+  } else {
+    __ cmp(left, right);
+    __ br(Assembler::EQ, L_oops_equal);
+  }
 
   // (1) Null check -- if one of the operands is null, the other must not be null (because
   //     the two references are not equal), so they are not substitutable,

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1635,8 +1635,10 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   } else {
     Register tmp1 = op->tmp1()->as_register();
     Register tmp2 = op->tmp2()->as_register();
-    __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
-    __ br(Assembler::EQ, *op->stub()->entry()); // same klass -> do slow check
+    if (left != right) {
+      __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
+      __ br(Assembler::EQ, *op->stub()->entry()); // same klass -> do slow check
+    }
     // fall through to L_oops_not_equal
   }
 

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1597,12 +1597,8 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   Register left  = op->left()->as_register();
   Register right = op->right()->as_register();
 
-  if (left == right) {
-    __ b(L_oops_equal);
-  } else {
-    __ cmp(left, right);
-    __ br(Assembler::EQ, L_oops_equal);
-  }
+  __ cmp(left, right);
+  __ br(Assembler::EQ, L_oops_equal);
 
   // (1) Null check -- if one of the operands is null, the other must not be null (because
   //     the two references are not equal), so they are not substitutable,
@@ -1635,10 +1631,8 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   } else {
     Register tmp1 = op->tmp1()->as_register();
     Register tmp2 = op->tmp2()->as_register();
-    if (left != right) {
-      __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
-      __ br(Assembler::EQ, *op->stub()->entry()); // same klass -> do slow check
-    }
+    __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
+    __ br(Assembler::EQ, *op->stub()->entry()); // same klass -> do slow check
     // fall through to L_oops_not_equal
   }
 

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -3166,13 +3166,9 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   } else {
     Register tmp1 = op->tmp1()->as_register();
     Register tmp2 = op->tmp2()->as_register();
-    if (left == right) { // same operand, so clearly the same klasses, let's save the check
-      __ b(*op->stub()->entry());  //  -> do slow check
-    } else {
-      __ cmp_klasses_from_objects(CR0, left, right, tmp1, tmp2);
-      __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CR0, Assembler::equal),
-                          *op->stub()->entry()); // same klass -> do slow check
-    }
+    __ cmp_klasses_from_objects(CR0, left, right, tmp1, tmp2);
+    __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CR0, Assembler::equal),
+                        *op->stub()->entry()); // same klass -> do slow check
     // fall through to L_oops_not_equal
   }
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1594,10 +1594,6 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
 
   Register left  = op->left()->as_register();
   Register right = op->right()->as_register();
-  if (left == right) {
-    move(op->equal_result(), op->result_opr());
-    return;
-  }
 
   __ cmpptr(left, right);
   __ jcc(Assembler::equal, L_oops_equal);
@@ -1632,10 +1628,8 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   } else {
     Register tmp1 = op->tmp1()->as_register();
     Register tmp2 = op->tmp2()->as_register();
-    if (left != right) {
-      __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
-      __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
-    }
+    __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
+    __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
     // fall through to L_oops_not_equal
   }
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1594,13 +1594,13 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
 
   Register left  = op->left()->as_register();
   Register right = op->right()->as_register();
-
   if (left == right) {
-    __ jmp(L_oops_equal);
-  } else {
-    __ cmpptr(left, right);
-    __ jcc(Assembler::equal, L_oops_equal);
+    move(op->equal_result(), op->result_opr());
+    return;
   }
+
+  __ cmpptr(left, right);
+  __ jcc(Assembler::equal, L_oops_equal);
 
   // (1) Null check -- if one of the operands is null, the other must not be null (because
   //     the two references are not equal), so they are not substitutable,

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1632,8 +1632,10 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   } else {
     Register tmp1 = op->tmp1()->as_register();
     Register tmp2 = op->tmp2()->as_register();
-    __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
-    __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
+    if (left != right) {
+      __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
+      __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
+    }
     // fall through to L_oops_not_equal
   }
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1595,8 +1595,12 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   Register left  = op->left()->as_register();
   Register right = op->right()->as_register();
 
-  __ cmpptr(left, right);
-  __ jcc(Assembler::equal, L_oops_equal);
+  if (left == right) {
+    __ jmp(L_oops_equal);
+  } else {
+    __ cmpptr(left, right);
+    __ jcc(Assembler::equal, L_oops_equal);
+  }
 
   // (1) Null check -- if one of the operands is null, the other must not be null (because
   //     the two references are not equal), so they are not substitutable,
@@ -1628,12 +1632,8 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   } else {
     Register tmp1 = op->tmp1()->as_register();
     Register tmp2 = op->tmp2()->as_register();
-    if (left == right) { // same operand, so clearly the same klasses, let's save the check
-      __ jmp (*op->stub()->entry());  //  -> do slow check
-    } else {
-      __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
-      __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
-    }
+    __ cmp_klasses_from_objects(left, right, tmp1, tmp2);
+    __ jcc(Assembler::equal, *op->stub()->entry()); // same klass -> do slow check
     // fall through to L_oops_not_equal
   }
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3363,6 +3363,11 @@ void LIRGenerator::substitutability_check(If* x, LIRItem& left, LIRItem& right) 
 void LIRGenerator::substitutability_check_common(Value left_val, Value right_val, LIRItem& left, LIRItem& right,
                                                  LIR_Opr equal_result, LIR_Opr not_equal_result, LIR_Opr result,
                                                  CodeEmitInfo* info) {
+  if (left.result() == right.result()) {
+    __ move(equal_result, result);
+    return;
+  }
+
   LIR_Opr tmp1 = LIR_OprFact::illegalOpr;
   LIR_Opr tmp2 = LIR_OprFact::illegalOpr;
 


### PR DESCRIPTION
When `left == right` is known at code generation time, the operands are necessarily the same oop, so we can jump directly to `L_oops_equal`. 
This patch changes both x86 and aarch65 to do that.

I also considered emitting `equal_result` and returning early in that case.
I decided not to do that because `LIR_OpSubstitutabilityCheck::emit_code()` still appends the slow-path stub after `emit_opSubstitutabilityCheck()` returns.
An early return here would skip binding `op->stub()->continuation()`, leaving the appended stub with an unbound continuation label. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8386861](https://bugs.openjdk.org/browse/JDK-8386861): [lworld] emit_opSubstitutabilityCheck speedup (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - no project role)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2628/head:pull/2628` \
`$ git checkout pull/2628`

Update a local copy of the PR: \
`$ git checkout pull/2628` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2628`

View PR using the GUI difftool: \
`$ git pr show -t 2628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2628.diff">https://git.openjdk.org/valhalla/pull/2628.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2628#issuecomment-4879216207)
</details>
