### PR TITLE
8387405: [lworld] is_always_flat_in_array should be always false

### DIFF
--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -40,11 +40,6 @@ bool ciInlineKlass::maybe_flat_in_array() const {
   GUARDED_VM_ENTRY(return to_InlineKlass()->maybe_flat_in_array();)
 }
 
-// Are arrays containing an instance of this value class always flat?
-bool ciInlineKlass::is_always_flat_in_array() const {
-  GUARDED_VM_ENTRY(return to_InlineKlass()->is_always_flat_in_array();)
-}
-
 // Can this inline type be passed as multiple values?
 bool ciInlineKlass::can_be_passed_as_fields() const {
   GUARDED_VM_ENTRY(return to_InlineKlass()->can_be_passed_as_fields();)

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -57,7 +57,6 @@ public:
   int payload_offset() const;
 
   bool maybe_flat_in_array() const override;
-  bool is_always_flat_in_array() const;
 
   // Scalarized calling convention support: pass/return this inline type as its
   // field components in the calling convention (registers/stack), not as a single oop.

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -152,23 +152,6 @@ bool InlineKlass::maybe_flat_in_array() {
   return true;
 }
 
-bool InlineKlass::is_always_flat_in_array() {
-  if (UseNewCode) {
-    return false;
-  }
-  if (!UseArrayFlattening) {
-    return false;
-  }
-  // Too many embedded oops
-  if ((FlatArrayElementMaxOops >= 0) && (nonstatic_oop_count() > FlatArrayElementMaxOops)) {
-    return false;
-  }
-
-  // An instance is always flat in an array if we have all layouts. Note that this could change in the future when the
-  // flattening policies are updated or if new APIs are added that allow the creation of reference arrays directly.
-  return has_nullable_atomic_layout() && has_null_free_atomic_layout() && has_null_free_non_atomic_layout();
-}
-
 // Inline type arguments are not passed by reference, instead each
 // field of the inline type is passed as an argument. This helper
 // function collects the flat field (recursively)

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -153,6 +153,9 @@ bool InlineKlass::maybe_flat_in_array() {
 }
 
 bool InlineKlass::is_always_flat_in_array() {
+  if (UseNewCode) {
+    return false;
+  }
   if (!UseArrayFlattening) {
     return false;
   }

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -275,7 +275,6 @@ class InlineKlass: public InstanceKlass {
   address payload_addr(oop o) const;
 
   bool maybe_flat_in_array();
-  bool is_always_flat_in_array();
 
   bool contains_oops() const { return nonstatic_oop_map_count() > 0; }
   int nonstatic_oop_count();

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3226,9 +3226,6 @@ TypePtr::FlatInArray TypePtr::compute_flat_in_array(ciInstanceKlass* instance_kl
     return NotFlat;
   }
   if (instance_klass->is_inlinetype()) {
-    if (instance_klass->as_inline_klass()->is_always_flat_in_array()) {
-      return Flat;
-    }
     if (instance_klass->as_inline_klass()->maybe_flat_in_array()) {
       return MaybeFlat;
     }


### PR DESCRIPTION
Nothing is flat! Well... sometimes, things are. But not arrays! Ok, arrays can be flat... but you can never be sure an array is flat from its unrefined type (and current JVM flags). Indeed, the "new" `ValueClass::newReferenceArray`: this allows to bypass `ObjArrayKlass::array_layout_selection(Klass*, ArrayProperties)` and get an array of references from any value class, regardless of the available layouts, thus fooling `InlineKlass::is_always_flat_in_array()`. In general, we can ensure the flatness of an array in only few situations: if we see the allocation, or after having tested the flatness with a runtime check. Thus `InlineKlass::is_always_flat_in_array()` doesn't really make sense... And consequently, it is not correct for `TypePtr::compute_flat_in_array(ciInstanceKlass* instance_klass, bool is_exact)` to ever return `Flat`. Yet, we still need the constructor `Flat` in `FlatInArray`. For instance, it is used in `TypeInstPtr::cast_to_flat_in_array()` which is indirectly used (through `load_from_unknown_flat_array`) in the "flat array" branch of `Parse::array_load(BasicType bt)`:

https://github.com/openjdk/valhalla/blob/a918cc9f5f8dcc35f4f73ed19b439a033fb39883/src/hotspot/share/opto/parse2.cpp#L121-L143

But here, casting to flat is fine since we are under a runtime check that enforces that the array is indeed flat.

Fortunately, I don't think the current usage could have lead to an error: we only use it to compare types: if one is sure to be flat but not the other one, the types can't be the same. It's fine, even if the "sure to be flat" criterion is buggy. Would work with a bit anything. Like "if a type starts with the letter 'A', but the other by the letter 'B', they can't be the same". If we had any tracking of that, it would allow to (very weirdly) prove type inequality even with imprecise types...

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387405](https://bugs.openjdk.org/browse/JDK-8387405): [lworld] is_always_flat_in_array should be always false (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2629/head:pull/2629` \
`$ git checkout pull/2629`

Update a local copy of the PR: \
`$ git checkout pull/2629` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2629`

View PR using the GUI difftool: \
`$ git pr show -t 2629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2629.diff">https://git.openjdk.org/valhalla/pull/2629.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2629#issuecomment-4890597076)
</details>
