### PR TITLE
8387800: [lworld] PPC64 field flattening bugs in JEP 401

### DIFF
--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -2450,7 +2450,7 @@ void InterpreterMacroAssembler::write_flat_field(Register entry, Register tmp1, 
   payload_address(value, value, tmp1, tmp2);
 
   Register layout_info = field_offset;
-  lbz(tmp1, in_bytes(ResolvedFieldEntry::field_index_offset()), entry);
+  lhz(tmp1, in_bytes(ResolvedFieldEntry::field_index_offset()), entry);
   ld(tmp2, in_bytes(ResolvedFieldEntry::field_holder_offset()), entry);
   inline_layout_info(tmp2, tmp1, layout_info);
 

--- a/src/hotspot/cpu/ppc/jniFastGetField_ppc.cpp
+++ b/src/hotspot/cpu/ppc/jniFastGetField_ppc.cpp
@@ -99,7 +99,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->try_resolve_jobject_in_native(masm, Robj, R3_ARG1, R4_ARG2, Rtmp, slow);
 
-  __ srwi(Rtmp, R5_ARG3, jfieldIDWorkaround::offset_shift); // offset
+  __ srdi(Rtmp, R5_ARG3, jfieldIDWorkaround::offset_shift); // offset
 
   assert(count < LIST_CAPACITY, "LIST_CAPACITY too small");
   speculative_load_pclist[count] = __ pc();   // Used by the segfault handler

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -2609,7 +2609,8 @@ void TemplateTable::jvmti_post_field_access(Register Rcache, Register Rscratch, 
       // Restore object pointer.
       __ pop_ptr(R17_tos);
       __ verify_oop(R17_tos);
-    } else {
+    }
+    if (Rcache.is_volatile()) {
       // Cache is still needed to get class or obj.
       __ load_field_entry(Rcache, Rscratch);
     }
@@ -3322,7 +3323,7 @@ void TemplateTable::fast_storefield(TosState state) {
     {
       Label is_flat, done;
       __ test_field_is_flat(Rflags, is_flat);
-      __ null_check_throw(Rclass_or_obj, -1, Rscratch);
+      __ null_check_throw(R17_tos, -1, Rscratch);
       do_oop_store(_masm, Rclass_or_obj, Roffset, R17_tos, Rscratch, Rscratch2, Rscratch3, IN_HEAP);
       __ b(done);
       __ bind(is_flat);
@@ -3384,7 +3385,7 @@ void TemplateTable::fast_accessfield(TosState state) {
   Label LisVolatile;
   ByteSize cp_base_offset = ConstantPoolCache::base_offset();
 
-  const Register Rcache        = R3_ARG1,
+  const Register Rcache        = R31, // Needs to survive C call.
                  Rclass_or_obj = R17_tos,
                  Roffset       = R22_tmp2,
                  Rflags        = R23_tmp3,


### PR DESCRIPTION
Some small bug fixes related to UseFieldFlattening. Can also be recreated for jdk master. Just posting it here for reference.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387800](https://bugs.openjdk.org/browse/JDK-8387800): [lworld] PPC64 field flattening bugs in JEP 401 (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2630/head:pull/2630` \
`$ git checkout pull/2630`

Update a local copy of the PR: \
`$ git checkout pull/2630` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2630`

View PR using the GUI difftool: \
`$ git pr show -t 2630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2630.diff">https://git.openjdk.org/valhalla/pull/2630.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2630#issuecomment-4897617143)
</details>
