### PR TITLE
8387997: [lworld] Add JVMTI general spec clarification about value objects

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -925,6 +925,18 @@ Agent_OnUnload_L(JavaVM *vm)</example>
     and/or its affiliates, in the U.S. and other countries.
   </intro>
 
+  <intro id="identityAndValueObjects" label="Identity and Value Objects">
+    When preview features are enabled, JVMTI may observe both identity objects and value objects.
+    JVMTI treats both kinds of objects in the same manner as JNI. Agents can use the JNI
+    <externallink id="jni/functions.html#hasidentity"><code>HasIdentity</code></externallink>
+    function to determine whether a JNI object reference denotes an object with identity.
+    JNI functions whose semantics depend on identity, including
+    <externallink id="jni/functions.html#issameobject"><code>IsSameObject</code></externallink>
+    and
+    <externallink id="jni/functions.html#newweakglobalref"><code>NewWeakGlobalRef</code></externallink>,
+    specify the JNI behavior for value objects. Any additional JVMTI-specific behavior
+    is specified by the affected JVMTI function or event.
+  </intro>
 
 <functionsection label="Functions">
   <intro id="jvmtiEnvAccess" label="Accessing Functions">
@@ -3444,7 +3456,7 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       event is sent for tagged objects when the garbage collector frees the object.
       When preview features are enabled, the Object Free event is only sent for tagged
       <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
-      <b>The event is not sent for tagged values objects.</b>
+      <b>The event is not sent for tagged value objects.</b>
     </intro>
 
     <intro id="heapCallbacks" label="Heap Callback Functions">
@@ -14211,7 +14223,7 @@ myInit() {
       <p/>
       When preview features are enabled, the Object Free event is only sent for tagged
       <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
-      <b>The event is not sent for tagged values objects.</b>
+      <b>The event is not sent for tagged value objects.</b>
       <p/>
       The event handler must not use JNI functions and
       must not use <jvmti/> functions except those which

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -926,16 +926,10 @@ Agent_OnUnload_L(JavaVM *vm)</example>
   </intro>
 
   <intro id="identityAndValueObjects" label="Identity and Value Objects">
-    When preview features are enabled, JVMTI may observe both identity and value objects.
-    JVMTI treats both kinds of objects in the same manner as JNI. Agents can use the JNI
-    <externallink id="jni/functions.html#hasidentity"><code>HasIdentity</code></externallink>
-    function to determine whether a JNI object reference denotes an object with identity.
-    JNI functions whose semantics depend on identity, including
-    <externallink id="jni/functions.html#issameobject"><code>IsSameObject</code></externallink>
-    and
-    <externallink id="jni/functions.html#newweakglobalref"><code>NewWeakGlobalRef</code></externallink>,
-    specify the JNI behavior for value objects. Any additional JVMTI-specific behavior
-    is specified by the affected JVMTI functions or events.
+    If preview features are enabled then some Java objects will have identity and others
+    (instances of value classes) will not. <jvmti/> makes no distinction between these cases
+    in general, but some specific functions will behave differently if invoked upon
+    a Java object that does not have identity.
   </intro>
 
 <functionsection label="Functions">

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -929,7 +929,19 @@ Agent_OnUnload_L(JavaVM *vm)</example>
     If preview features are enabled then some Java objects will have identity and others
     (instances of value classes) will not. <jvmti/> makes no distinction between these cases
     in general, but some specific functions will behave differently if invoked upon
-    a Java object that does not have identity.
+    a Java object that does not have identity. Such differences in behavior are described
+    by the individual functions and events where they apply.
+    <p/>
+    In summary, tags for value objects use value equality semantics, and tagged value
+    objects are kept alive while tagged, <i>unlike tagged identity objects</i>. As a result,
+    the <eventlink id="ObjectFree"/> event is not sent for tagged value objects.
+    The <eventlink id="VMObjectAlloc"/> and <eventlink id="SampledObjectAlloc"/> events
+    are not sent for value objects unless the
+    <fieldlink id="can_support_value_objects" struct="jvmtiCapabilities"/>
+    capability is possessed.
+    <p/>
+    Value objects can also affect class and interface property queries, monitor information,
+    and <jvmti/> functions that operate on value class constructor frames.
   </intro>
 
 <functionsection label="Functions">
@@ -3450,7 +3462,7 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       event is sent for tagged objects when the garbage collector frees the object.
       When preview features are enabled, the Object Free event is only sent for tagged
       <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
-      <b>The event is not sent for tagged value objects.</b>
+      <b>The event is not sent for tagged value objects because they are kept alive while tagged.</b>
     </intro>
 
     <intro id="heapCallbacks" label="Heap Callback Functions">

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -935,7 +935,7 @@ Agent_OnUnload_L(JavaVM *vm)</example>
     and
     <externallink id="jni/functions.html#newweakglobalref"><code>NewWeakGlobalRef</code></externallink>,
     specify the JNI behavior for value objects. Any additional JVMTI-specific behavior
-    is specified by the affected JVMTI function or event.
+    is specified by the affected JVMTI functions or events.
   </intro>
 
 <functionsection label="Functions">

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -926,7 +926,7 @@ Agent_OnUnload_L(JavaVM *vm)</example>
   </intro>
 
   <intro id="identityAndValueObjects" label="Identity and Value Objects">
-    When preview features are enabled, JVMTI may observe both identity objects and value objects.
+    When preview features are enabled, JVMTI may observe both identity and value objects.
     JVMTI treats both kinds of objects in the same manner as JNI. Agents can use the JNI
     <externallink id="jni/functions.html#hasidentity"><code>HasIdentity</code></externallink>
     function to determine whether a JNI object reference denotes an object with identity.

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -932,11 +932,10 @@ Agent_OnUnload_L(JavaVM *vm)</example>
     a Java object that does not have identity. Such differences in behavior are described
     by the individual functions and events where they apply.
     <p/>
-    In summary, tags for value objects use value equality semantics, and tagged value
-    objects are kept alive while tagged, <i>unlike tagged identity objects</i>. As a result,
+    In summary, tags for value objects use value equality semantics, and
     the <eventlink id="ObjectFree"/> event is not sent for tagged value objects.
     The <eventlink id="VMObjectAlloc"/> and <eventlink id="SampledObjectAlloc"/> events
-    are not sent for value objects unless the
+    are only sent for value objects if the
     <fieldlink id="can_support_value_objects" struct="jvmtiCapabilities"/>
     capability is possessed.
     <p/>
@@ -3462,7 +3461,7 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
       event is sent for tagged objects when the garbage collector frees the object.
       When preview features are enabled, the Object Free event is only sent for tagged
       <externallink id="jni/functions.html#hasidentity">identity objects</externallink>.
-      <b>The event is not sent for tagged value objects because they are kept alive while tagged.</b>
+      <b>The event is not sent for tagged value objects.</b>
     </intro>
 
     <intro id="heapCallbacks" label="Heap Callback Functions">


### PR DESCRIPTION
This update is for `repo-valhalla` pre-integration. It adds a special intro section to the `jvmti.xml` with a general clarification related to value objects. Also, it fixes a couple of small typos.

Testing: N/A

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387997](https://bugs.openjdk.org/browse/JDK-8387997): [lworld] Add JVMTI general spec clarification about value objects (**Enhancement** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - Committer)


### Contributors
 * David Holmes `<dholmes@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2634/head:pull/2634` \
`$ git checkout pull/2634`

Update a local copy of the PR: \
`$ git checkout pull/2634` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2634`

View PR using the GUI difftool: \
`$ git pr show -t 2634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2634.diff">https://git.openjdk.org/valhalla/pull/2634.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2634#issuecomment-4921402765)
</details>
