### PR TITLE
8388068: [lworld] PhantomReference constructor should use linkplain instead of link in its throws clause javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ public non-sealed class PhantomReference<@jdk.internal.RequiresIdentity T> exten
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IdentityException if the referent is not an
-     *         {@link java.util.Objects#hasIdentity(Object) identity object}
+     *         {@linkplain java.util.Objects#hasIdentity(Object) identity object}
      */
     public PhantomReference(@jdk.internal.RequiresIdentity T referent, ReferenceQueue<? super T> q) {
         super(referent, q);


### PR DESCRIPTION
Can I please get a review of this trivial doc-only change which replaces the use of `{@link}` in the javadoc of `PhantomReference` with a `{@linkplain}`?

This addresses https://bugs.openjdk.org/browse/JDK-8388068 which was brought up during the PR review of JEP-401 https://github.com/openjdk/jdk/pull/31123#pullrequestreview-4503577896



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388068](https://bugs.openjdk.org/browse/JDK-8388068): [lworld] PhantomReference constructor should use linkplain instead of link in its throws clause javadoc (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2637/head:pull/2637` \
`$ git checkout pull/2637`

Update a local copy of the PR: \
`$ git checkout pull/2637` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2637`

View PR using the GUI difftool: \
`$ git pr show -t 2637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2637.diff">https://git.openjdk.org/valhalla/pull/2637.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2637#issuecomment-4934038659)
</details>
