### PR TITLE
8388113: [lworld] JDI and JDWP spec update: ObjectReference summary, Value class clarification, strict field initialization clarification

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -55,31 +55,15 @@ import com.sun.jdi.event.VMDisconnectEvent;
  * <div class="preview-block">
  *      <div class="preview-comment">
  * <h2><a id=valueObjects>Value Objects</a></h2>
- * When preview features are enabled, JDI supports value objects and classes
- * in a manner consistent with <cite>The Java Language Specification</cite> and
- * <cite>The Java Virtual Machine Specification</cite>, with one exception noted
- * below. In particular, two value objects are considered to be the same if both
- * refer to statewise-equivalent value objects (x == y has the value {@code true}).
- * {@link ObjectReference#equals} has always been defined to return true if
- * applying the "==" operator on the mirrored objects in the target VM
- * evaluates to true. That has not changed with value objects. See Sections
- * {@jls value-objects-8.1.1.5 Value Classes} and
- * {@jls value-objects-15.21.3 Object Equality Operators} of
- * <cite>The Java Language Specification</cite>, and Section
- * {@jvms value-objects-6.5 if_acmp_cond} of the
- * <cite>The Java Virtual Machine Specification</cite>.
+ *If preview features are enabled, JDI supports value objects and classes.
+ * However, the support does in some cases deviate from identity object
+ * support in behavior or expectations as noted below:
  * <p>
- * Where JDI does differ from the JLS is in allowing the user to obtain an
- * ObjectReference to a value object under construction (while in the "larval"
- * state). For example, the JDI user could fetch 'this' after hitting a
- * breakpoint in the value object contructor. This could lead to confusing
- * behavior for the JDI user. In particular, the value object may change after
- * the ObjectReference is obtained, even though value objects are considered
- * to be immutable. Because of this, if 'this' is fetched from a value object
- * constructor, an ObjectReference representing a statewise-equivalent "snapshot"
- * is returned instead, and this ObjectReference will not reflect changes to the
- * value object that happen later during construction. See
- * {@link StackFrame#thisObject}.
+ * If an ObjectReference is obtained for a value object under construction,
+ * it will be for a <em>snapshot</em> of the value object at that point in time.
+ * Any further changes to the initialization state of the value object will not
+ * be reflected in this ObjectReference. A new ObjectReference would need to
+ * be obtained to see the updated state. See {@link StackFrame#thisObject}.
  *      </div>
  * </div>
  * @author Robert Field
@@ -116,6 +100,12 @@ public interface ObjectReference extends Value {
      * The Field must be valid for this ObjectReference;
      * that is, it must be from
      * the mirrored object's class or a superclass of that class.
+     * <div class="preview-block">
+     *      <div class="preview-comment">
+     * If preview features are enabled, this method does not prevent a
+     * strictly-initialized field from being read before it has been initialized.
+     *      </div>
+     * </div>
      *
      * @param sig the field containing the requested value
      * @return the {@link Value} of the instance field.
@@ -129,6 +119,12 @@ public interface ObjectReference extends Value {
      * The Fields must be valid for this ObjectReference;
      * that is, they must be from
      * the mirrored object's class or a superclass of that class.
+     * <div class="preview-block">
+     *      <div class="preview-comment">
+     * If preview features are enabled, this method does not prevent a
+     * strictly-initialized field from being read before it has been initialized.
+     *      </div>
+     * </div>
      *
      * @param fields a list of {@link Field} objects containing the
      * requested values.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -65,7 +65,7 @@ import com.sun.jdi.event.VMDisconnectEvent;
  * evaluates to true. That has not changed with value objects. See Sections
  * {@jls value-objects-8.1.1.5 Value Classes} and
  * {@jls value-objects-15.21.3 Object Equality Operators} of
- * <cite>The Java Language Specification</cite>, and Section 
+ * <cite>The Java Language Specification</cite>, and Section
  * {@jvms value-objects-6.5 if_acmp_cond} of the
  * <cite>The Java Virtual Machine Specification</cite>.
  * <p>

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -55,7 +55,7 @@ import com.sun.jdi.event.VMDisconnectEvent;
  * <div class="preview-block">
  *      <div class="preview-comment">
  * <h2><a id=valueObjects>Value Objects</a></h2>
- *If preview features are enabled, JDI supports value objects and classes.
+ * If preview features are enabled, JDI supports value objects and classes.
  * However, the support does in some cases deviate from identity object
  * support in behavior or expectations as noted below:
  * <p>

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -73,7 +73,7 @@ import com.sun.jdi.event.VMDisconnectEvent;
  * ObjectReference to a value object under construction (while in the "larval"
  * state). For example, the JDI user could fetch 'this' after hitting a
  * breakpoint in the value object contructor. This could lead to confusing
- * behavior for the JDI user. In particlar, the value object may change after
+ * behavior for the JDI user. In particular, the value object may change after
  * the ObjectReference is obtained, even though value objects are considered
  * to be immutable. Because of this, if 'this' is fetched from a value object
  * constructor, an ObjectReference representing a statewise-equivalent "snapshot"

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -52,7 +52,36 @@ import com.sun.jdi.event.VMDisconnectEvent;
  * takes <code>ObjectReference</code> as parameter may throw
  * {@link ObjectCollectedException} if the mirrored object has been
  * garbage collected.
- *
+ * <div class="preview-block">
+ *      <div class="preview-comment">
+ * <h2><a id=valueObjects>Value Objects</a></h2>
+ * When preview features are enabled, JDI supports value objects and classes
+ * in a manner consistent with <cite>The Java Language Specification</cite> and
+ * <cite>The Java Virtual Machine Specification</cite>, with one exception noted
+ * below. In particular, two value objects are considered to be the same if both
+ * refer to statewise-equivalent value objects (x == y has the value {@code true}).
+ * {@link ObjectReference#equals} has always been defined to return true if
+ * applying the "==" operator on the mirrored objects in the target VM
+ * evaluates to true. That has not changed with value objects. See Sections
+ * {@jls value-objects-8.1.1.5 Value Classes} and
+ * {@jls value-objects-15.21.3 Object Equality Operators} of
+ * <cite>The Java Language Specification</cite>, and Section 
+ * {@jvms value-objects-6.5 if_acmp_cond} of the
+ * <cite>The Java Virtual Machine Specification</cite>.
+ * <p>
+ * Where JDI does differ from the JLS is in allowing the user to obtain an
+ * ObjectReference to a value object under construction (while in the "larval"
+ * state). For example, the JDI user could fetch 'this' after hitting a
+ * breakpoint in the value object contructor. This could lead to confusing
+ * behavior for the JDI user. In particlar, the value object may change after
+ * the ObjectReference is obtained, even though value objects are considered
+ * to be immutable. Because of this, if 'this' is fetched from a value object
+ * constructor, an ObjectReference representing a statewise-equivalent "snapshot"
+ * is returned instead, and this ObjectReference will not reflect changes to the
+ * value object that happen later during construction. See
+ * {@link StackFrame#thisObject}.
+ *      </div>
+ * </div>
  * @author Robert Field
  * @author Gordon Hirsch
  * @author James McIlree

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ReferenceType.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ReferenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -519,7 +519,12 @@ public interface ReferenceType
      * The Field must be valid for this type;
      * that is, it must be declared in this type, a superclass, a
      * superinterface, or an implemented interface.
-     *
+     * <div class="preview-block">
+     *      <div class="preview-comment">
+     * If preview features are enabled, this method does not prevent a
+     * strictly-initialized field from being read before it has been initialized.
+     *      </div>
+     * </div>
      * @param field the field containing the requested value
      * @return the {@link Value} of the instance field.
      * @throws java.lang.IllegalArgumentException if the field is not valid for
@@ -533,6 +538,12 @@ public interface ReferenceType
      * The Fields must be valid for this type;
      * that is, they must be declared in this type, a superclass, a
      * superinterface, or an implemented interface.
+     * <div class="preview-block">
+     *      <div class="preview-comment">
+     * If preview features are enabled, this method does not prevent a
+     * strictly-initialized field from being read before it has been initialized.
+     *      </div>
+     * </div>
      *
      * @param fields a list of {@link Field} objects containing the
      * requested values.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/StackFrame.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/StackFrame.java
@@ -100,7 +100,7 @@ public interface StackFrame extends Mirror, Locatable {
      * If 'this' is a {@linkplain
      * ObjectReference##valueObjects value object<sup class="preview-mark">PREVIEW</sup>}
      * under construction, the returned {@code ObjectReference} will refer to a
-     * statewise-equivalent <em>snapshot</em> of the value object, not a reference
+     * <em>snapshot</em> of the value object, not a reference
      * to the actual value object under construction. Consequently, the returned
      * {@code ObjectReference} will not reflect changes to the value object that
      * happen later during construction.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/StackFrame.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/StackFrame.java
@@ -97,10 +97,11 @@ public interface StackFrame extends Mirror, Locatable {
      * The {@link ObjectReference} for 'this' is only available for
      * non-native instance methods.
      * <p>
-     * If 'this' is a {@linkplain Class#isValue() value object} under
-     * construction, the returned {@code ObjectReference} will refer to a
-     * <em>snapshot</em> of the value object, not a reference to the actual value
-     * object under construction. Consequently, the returned
+     * If 'this' is a {@linkplain
+     * ObjectReference##valueObjects value object<sup class="preview-mark">PREVIEW</sup>}
+     * under construction, the returned {@code ObjectReference} will refer to a
+     * statewise-equivalent <em>snapshot</em> of the value object, not a reference
+     * to the actual value object under construction. Consequently, the returned
      * {@code ObjectReference} will not reflect changes to the value object that
      * happen later during construction.
      *

--- a/src/jdk.jdi/share/classes/com/sun/jdi/Value.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,16 @@ import com.sun.jdi.event.ModificationWatchpointEvent;
  * The mirror for a value in the target VM.
  * This interface is the root of a
  * value hierarchy encompassing primitive values and object values.
+ * <div class="preview-block">
+ *      <div class="preview-comment">
+ * When preview features are enabled, JDI supports value classes. A "value class"
+ * as supported in the Java language is not related to the JDI Value class.
+ * A "value class" is a class declared with the "value" modifier. The JDI
+ * Value class is used by JDI to mirror a value in the debuggee VM. For more
+ * information on value classes, see Section {@jls value-objects-8.1.1.5 Value Classes}
+ * of <cite>The Java Language Specification</cite>.
+ *      </div>
+ * </div>
  * <P>
  * Some examples of where values may be accessed:
  * <BLOCKQUOTE><TABLE role="presentation">

--- a/src/jdk.jdi/share/classes/com/sun/jdi/Value.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/Value.java
@@ -34,9 +34,9 @@ import com.sun.jdi.event.ModificationWatchpointEvent;
  * <div class="preview-block">
  *      <div class="preview-comment">
  * When preview features are enabled, JDI supports value classes. A "value class"
- * as supported in the Java language is not related to the JDI Value class.
+ * as supported in the Java language is not related to the JDI Value interface.
  * A "value class" is a class declared with the "value" modifier. The JDI
- * Value class is used by JDI to mirror a value in the debuggee VM. For more
+ * Value interface is used by JDI to mirror a value in the debuggee VM. For more
  * information on value classes, see Section {@jls value-objects-8.1.1.5 Value Classes}
  * of <cite>The Java Language Specification</cite>.
  *      </div>


### PR DESCRIPTION
The following spec edits were made (no code changes):
- a brief value object summary in the ObjectReference overview section
- A clarification on the difference between "value classes/objects" and the JDI Value class
- Specifying where JDI ignores strict field initialization rules.

The JBS issue contains screenshots of the rendered relevant javadoc.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388113](https://bugs.openjdk.org/browse/JDK-8388113): [lworld] JDI and JDWP spec update: ObjectReference summary, Value class clarification, strict field initialization clarification (**Bug** - P2)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer) ⚠️ Review applies to [54eb553e](https://git.openjdk.org/valhalla/pull/2639/files/54eb553e0747ba9f7571fac02aa69c1760302514)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - Committer)
 * [Dan Smith](https://openjdk.org/census#dlsmith) (@dansmithcode - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2639/head:pull/2639` \
`$ git checkout pull/2639`

Update a local copy of the PR: \
`$ git checkout pull/2639` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2639`

View PR using the GUI difftool: \
`$ git pr show -t 2639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2639.diff">https://git.openjdk.org/valhalla/pull/2639.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2639#issuecomment-4941057417)
</details>
