### PR TITLE
8252185: [lworld] Improve performance of identityHashCode for value objects

### DIFF
--- a/src/hotspot/share/ci/ciInstance.cpp
+++ b/src/hotspot/share/ci/ciInstance.cpp
@@ -235,6 +235,14 @@ ciConstant ciInstance::field_value_by_offset(int field_offset) {
   return field_value(field);
 }
 
+intptr_t ciInstance::hash() const {
+  VM_ENTRY_MARK;
+  oop obj = get_oop();
+  markWord mark = obj->mark();
+  if (mark.is_marked()) return markWord::no_hash;
+  if (!UseObjectMonitorTable && mark.has_monitor()) return markWord::no_hash;
+  return mark.hash();
+}
 // ------------------------------------------------------------------
 // ciInstance::print_impl
 //

--- a/src/hotspot/share/ci/ciInstance.hpp
+++ b/src/hotspot/share/ci/ciInstance.hpp
@@ -67,6 +67,8 @@ public:
   // Constant value of a field at the specified offset.
   ciConstant field_value_by_offset(int field_offset);
 
+  intptr_t hash() const;
+
   ciKlass* java_lang_Class_klass();
   char* java_lang_String_str(char* buf, size_t buflen);
 };

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -698,6 +698,26 @@ bool ciInstanceKlass::has_object_fields() const {
     );
 }
 
+int ciInstanceKlass::number_of_nonoop_entries_in_acmp_map() const {
+  VM_ENTRY_MARK;
+  return get_instanceKlass()->acmp_maps_array()->at(0);
+}
+int ciInstanceKlass::number_of_oop_entries_in_acmp_map() const {
+  VM_ENTRY_MARK;
+  const Array<int>* acmp_maps = get_instanceKlass()->acmp_maps_array();
+  int number_of_nonoop_entries = acmp_maps->at(0);
+  return acmp_maps->length() - number_of_nonoop_entries * 2 - 1;
+}
+AcmpMapSegment ciInstanceKlass::get_nonoop_segment_of_acmp_map(int i) const {
+  VM_ENTRY_MARK;
+  const Array<int>* acmp_maps = get_instanceKlass()->acmp_maps_array();
+  int number_of_nonoop_entries = acmp_maps->at(0);
+  assert(0 <= i && i < number_of_nonoop_entries, "illegal index, should be in range [0, %d)", number_of_nonoop_entries);
+  int offset = acmp_maps->at(2 * i + 1);
+  int size = acmp_maps->at(2 * i + 2);
+  return AcmpMapSegment(offset, size);
+}
+
 bool ciInstanceKlass::compute_has_trusted_loader() {
   ASSERT_IN_VM;
   oop loader_oop = loader();

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -267,7 +267,6 @@ public:
   int number_of_nonoop_entries_in_acmp_map() const;
   AcmpMapSegment get_nonoop_segment_of_acmp_map(int i) const;
 
-
   ciInstanceKlass* unique_concrete_subklass();
   bool has_finalizable_subclass();
 

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -29,6 +29,7 @@
 #include "ci/ciFlags.hpp"
 #include "ci/ciKlass.hpp"
 #include "ci/ciSymbol.hpp"
+#include "classfile/classFileParser.hpp"
 #include "oops/instanceKlass.hpp"
 
 // ciInstanceKlass
@@ -261,6 +262,11 @@ public:
     assert(_nonstatic_fields != nullptr, "");
     return _nonstatic_fields->at(i);
   }
+
+  int number_of_oop_entries_in_acmp_map() const;
+  int number_of_nonoop_entries_in_acmp_map() const;
+  AcmpMapSegment get_nonoop_segment_of_acmp_map(int i) const;
+
 
   ciInstanceKlass* unique_concrete_subklass();
   bool has_finalizable_subclass();

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5439,15 +5439,19 @@ void ClassFileParser::set_fast_acmp_members(InlineKlass* vk) const {
 
 void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
   if (_layout_info->_oop_acmp_map->length() > 0) {  // Oops are not allowed in the fast path
-    tty->print("Too many oops (%d): ", _layout_info->_oop_acmp_map->length());
-    vk->name()->print();
-    tty->cr();
+    if (UseNewCode2) {
+      tty->print("Too many oops (%d): ", _layout_info->_oop_acmp_map->length());
+      vk->name()->print();
+      tty->cr();
+    }
     return;
   }
   if (_layout_info->_nonoop_acmp_map->length() >= 2) {
-    tty->print("Too many segments (%d): ", _layout_info->_nonoop_acmp_map->length());
-    vk->name()->print();
-    tty->cr();
+    if (UseNewCode2) {
+      tty->print("Too many segments (%d): ", _layout_info->_nonoop_acmp_map->length());
+      vk->name()->print();
+      tty->cr();
+    }
     return;
   }
 
@@ -5456,14 +5460,16 @@ void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
 #ifdef VM_LITTLE_ENDIAN
     vk->set_fast_hashcode_shift(0);
 
-    tty->print("Fast hashcode: ");
-    vk->name()->print();
-    tty->cr();
+    if (UseNewCode2) {
+      tty->print("Fast hashcode: ");
+      vk->name()->print();
+      tty->cr();
 
-    tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
-    tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
-    tty->cr();
-    tty->cr();
+      tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
+      tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
+      tty->cr();
+      tty->cr();
+    }
 #else
     vk->set_fast_hashcode_mask(0);
 #endif // VM_LITTLE_ENDIAN
@@ -5474,9 +5480,11 @@ void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
 
   int piece_size = _layout_info->_nonoop_acmp_map->at(0)._size;
   if (piece_size != 1 && piece_size != 2 && piece_size != 4 && piece_size != 8) {
-    tty->print("Segment has annoying size (%d): ", piece_size);
-    vk->name()->print();
-    tty->cr();
+    if (UseNewCode2) {
+      tty->print("Segment has annoying size (%d): ", piece_size);
+      vk->name()->print();
+      tty->cr();
+    }
     return;
   }
 
@@ -5485,16 +5493,18 @@ void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
 #ifdef VM_LITTLE_ENDIAN
   vk->set_fast_hashcode_shift(BitsPerByte * (BytesPerLong - piece_size));
 
-  tty->print("Fast hashcode: ");
-  vk->name()->print();
-  tty->cr();
+  if (UseNewCode2) {
+    tty->print("Fast hashcode: ");
+    vk->name()->print();
+    tty->cr();
 
-  tty->print_cr("  start: %d", piece_start);
-  tty->print_cr("  size: %d", piece_size);
-  tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
-  tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
-  tty->cr();
-  tty->cr();
+    tty->print_cr("  start: %d", piece_start);
+    tty->print_cr("  size: %d", piece_size);
+    tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
+    tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
+    tty->cr();
+    tty->cr();
+  }
 #else
   vk->set_fast_hashcode_mask(right_n_bits<int64_t>(piece_size * BitsPerByte));
 #endif // VM_LITTLE_ENDIAN

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5437,6 +5437,69 @@ void ClassFileParser::set_fast_acmp_members(InlineKlass* vk) const {
 #endif // VM_LITTLE_ENDIAN
 }
 
+void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
+  if (_layout_info->_oop_acmp_map->length() > 0) {  // Oops are not allowed in the fast path
+    tty->print("Too many oops (%d): ", _layout_info->_oop_acmp_map->length());
+    vk->name()->print();
+    tty->cr();
+    return;
+  }
+  if (_layout_info->_nonoop_acmp_map->length() >= 2) {
+    tty->print("Too many segments (%d): ", _layout_info->_nonoop_acmp_map->length());
+    vk->name()->print();
+    tty->cr();
+    return;
+  }
+
+  if (_layout_info->_nonoop_acmp_map->length() == 0) {
+    vk->set_fast_hashcode_offset(0);
+#ifdef VM_LITTLE_ENDIAN
+    vk->set_fast_hashcode_shift(0);
+
+    tty->print("Fast hashcode: ");
+    vk->name()->print();
+    tty->cr();
+
+    tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
+    tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
+    tty->cr();
+    tty->cr();
+#else
+    vk->set_fast_hashcode_mask(0);
+#endif // VM_LITTLE_ENDIAN
+    return;
+  }
+
+  assert(_layout_info->_nonoop_acmp_map->length() == 1, "trivial");
+
+  int piece_size = _layout_info->_nonoop_acmp_map->at(0)._size;
+  if (piece_size != 1 && piece_size != 2 && piece_size != 4 && piece_size != 8) {
+    tty->print("Segment has annoying size (%d): ", piece_size);
+    vk->name()->print();
+    tty->cr();
+    return;
+  }
+
+  int piece_start = _layout_info->_nonoop_acmp_map->at(0)._offset;
+  vk->set_fast_hashcode_offset(piece_start - (BytesPerLong - piece_size));
+#ifdef VM_LITTLE_ENDIAN
+  vk->set_fast_hashcode_shift(BitsPerByte * (BytesPerLong - piece_size));
+
+  tty->print("Fast hashcode: ");
+  vk->name()->print();
+  tty->cr();
+
+  tty->print_cr("  start: %d", piece_start);
+  tty->print_cr("  size: %d", piece_size);
+  tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
+  tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
+  tty->cr();
+  tty->cr();
+#else
+  vk->set_fast_hashcode_mask(right_n_bits<int64_t>(piece_size * BitsPerByte));
+#endif // VM_LITTLE_ENDIAN
+}
+
 void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
                                           bool changed_by_loadhook,
                                           const ClassInstanceInfo& cl_inst_info,
@@ -5674,6 +5737,10 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
 
     if (UseAcmpFastPath) {
       set_fast_acmp_members(vk);
+    }
+
+    if (UseHashcodeFastPath) {
+      set_fast_hashcode_members(vk);
     }
 
     vk->initialize_calling_convention(CHECK);

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5437,21 +5437,13 @@ void ClassFileParser::set_fast_acmp_members(InlineKlass* vk) const {
 #endif // VM_LITTLE_ENDIAN
 }
 
+// See the declarations of _fast_hashcode_offset, _fast_hashcode_shift and _fast_hashcode_mask in InlineKlass::Members
+// for details about the fast path logic, and the meaning of these values.
 void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
   if (_layout_info->_oop_acmp_map->length() > 0) {  // Oops are not allowed in the fast path
-    if (UseNewCode2) {
-      tty->print("Too many oops (%d): ", _layout_info->_oop_acmp_map->length());
-      vk->name()->print();
-      tty->cr();
-    }
     return;
   }
-  if (_layout_info->_nonoop_acmp_map->length() >= 2) {
-    if (UseNewCode2) {
-      tty->print("Too many segments (%d): ", _layout_info->_nonoop_acmp_map->length());
-      vk->name()->print();
-      tty->cr();
-    }
+  if (_layout_info->_nonoop_acmp_map->length() >= 2) {  // We handle at most one segment...
     return;
   }
 
@@ -5459,32 +5451,16 @@ void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
     vk->set_fast_hashcode_offset(0);
 #ifdef VM_LITTLE_ENDIAN
     vk->set_fast_hashcode_shift(0);
-
-    if (UseNewCode2) {
-      tty->print("Fast hashcode: ");
-      vk->name()->print();
-      tty->cr();
-
-      tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
-      tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
-      tty->cr();
-      tty->cr();
-    }
 #else
     vk->set_fast_hashcode_mask(0);
 #endif // VM_LITTLE_ENDIAN
     return;
   }
 
-  assert(_layout_info->_nonoop_acmp_map->length() == 1, "trivial");
+  assert(_layout_info->_nonoop_acmp_map->length() == 1, "trivially");
 
   int piece_size = _layout_info->_nonoop_acmp_map->at(0)._size;
-  if (piece_size != 1 && piece_size != 2 && piece_size != 4 && piece_size != 8) {
-    if (UseNewCode2) {
-      tty->print("Segment has annoying size (%d): ", piece_size);
-      vk->name()->print();
-      tty->cr();
-    }
+  if (piece_size != 1 && piece_size != 2 && piece_size != 4 && piece_size != 8) {  // ...and it must have a convenient size
     return;
   }
 
@@ -5492,19 +5468,6 @@ void ClassFileParser::set_fast_hashcode_members(InlineKlass* vk) const {
   vk->set_fast_hashcode_offset(piece_start - (BytesPerLong - piece_size));
 #ifdef VM_LITTLE_ENDIAN
   vk->set_fast_hashcode_shift(BitsPerByte * (BytesPerLong - piece_size));
-
-  if (UseNewCode2) {
-    tty->print("Fast hashcode: ");
-    vk->name()->print();
-    tty->cr();
-
-    tty->print_cr("  start: %d", piece_start);
-    tty->print_cr("  size: %d", piece_size);
-    tty->print_cr("  offset: %d", vk->fast_hashcode_offset());
-    tty->print_cr("  shift: %d", vk->fast_hashcode_shift());
-    tty->cr();
-    tty->cr();
-  }
 #else
   vk->set_fast_hashcode_mask(right_n_bits<int64_t>(piece_size * BitsPerByte));
 #endif // VM_LITTLE_ENDIAN

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -543,6 +543,7 @@ class ClassFileParser {
 
   void create_acmp_maps(InstanceKlass* ik, TRAPS);
   void set_fast_acmp_members(InlineKlass* vk) const;
+  void set_fast_hashcode_members(InlineKlass* vk) const;
 
  public:
   ClassFileParser(ClassFileStream* stream,

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -74,8 +74,14 @@ InlineKlass::Members::Members()
     _nullable_non_atomic_size_in_bytes(-1),
     _null_marker_offset(-1),
     _fast_acmp_offset(-1),
-    _fast_acmp_mask(0) {
-}
+    _fast_acmp_mask(0),
+    _fast_hashcode_offset(-1),
+#ifdef VM_LITTLE_ENDIAN
+    _fast_hashcode_shift(0)
+#else
+    _fast_hashcode_mask(0)
+#endif
+{}
 
 InlineKlass::InlineKlass() {
   assert(CDSConfig::is_dumping_archive() || UseSharedSpaces, "only for CDS");
@@ -590,6 +596,12 @@ void InlineKlass::Members::print_on(outputStream* st) const {
   st->print_cr(BULLET"null marker offset:                %d", _null_marker_offset);
   st->print_cr(BULLET"fast acmp offset:                  %d", _fast_acmp_offset);
   st->print_cr(BULLET"fast acmp mask:                    " INT64_FORMAT_X_0, _fast_acmp_mask);
+  st->print_cr(BULLET"fast hashcode offset:              %d", _fast_hashcode_offset);
+#ifdef VM_LITTLE_ENDIAN
+  st->print_cr(BULLET"fast hashcode shift:               %d", _fast_hashcode_shift);
+#else
+  st->print_cr(BULLET"fast hashcode mask:                " INT64_FORMAT_X_0, _fast_hashcode_mask);
+#endif
 }
 
 #undef BULLET

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -114,6 +114,13 @@ class InlineKlass: public InstanceKlass {
     int _fast_acmp_offset;    // if < 0, fast acmp doesn't apply
     int64_t _fast_acmp_mask;  // can be 0 for empty value classes
 
+    int _fast_hashcode_offset;   // if < 0, fast hashcode doesn't apply
+#ifdef VM_LITTLE_ENDIAN
+    int _fast_hashcode_shift;
+#else
+    int64_t _fast_hashcode_mask;
+#endif
+
     Members();
 
     void print_on(outputStream* st) const;
@@ -211,6 +218,17 @@ class InlineKlass: public InstanceKlass {
 
   int64_t fast_acmp_mask() const                              { return members()._fast_acmp_mask; }
   void set_fast_acmp_mask(int64_t mask)                       { members()._fast_acmp_mask = mask; }
+
+  int fast_hashcode_offset() const                                { return members()._fast_hashcode_offset; }
+  void set_fast_hashcode_offset(int offset)                       { members()._fast_hashcode_offset = offset; }
+
+#ifdef VM_LITTLE_ENDIAN
+  int fast_hashcode_shift() const                              { return members()._fast_hashcode_shift; }
+  void set_fast_hashcode_shift(int shift)                       { members()._fast_hashcode_shift = shift; }
+#else
+  int64_t fast_hashcode_mask() const                              { return members()._fast_hashcode_mask; }
+  void set_fast_hashcode_mask(int64_t mask)                       { members()._fast_hashcode_mask = mask; }
+#endif
 
   bool supports_nullable_layouts() const {
     return has_nullable_non_atomic_layout() || has_nullable_atomic_layout();
@@ -334,6 +352,19 @@ class InlineKlass: public InstanceKlass {
   static ByteSize fast_acmp_mask_offset() {
     return byte_offset_of(Members, _fast_acmp_mask);
   }
+
+  static ByteSize fast_hashcode_offset_offset() {
+    return byte_offset_of(Members, _fast_hashcode_offset);
+  }
+#ifdef VM_LITTLE_ENDIAN
+  static ByteSize fast_hashcode_shift_offset() {
+    return byte_offset_of(Members, _fast_hashcode_shift);
+  }
+#else
+  static ByteSize fast_hashcode_mask_offset() {
+    return byte_offset_of(Members, _fast_hashcode_mask);
+  }
+#endif
 
   oop null_reset_value() const;
   void set_null_reset_value(oop val);

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -114,9 +114,9 @@ class InlineKlass: public InstanceKlass {
     int _fast_acmp_offset;    // if < 0, fast acmp doesn't apply
     int64_t _fast_acmp_mask;  // can be 0 for empty value classes
 
-    // When we can't intrinsify the identityHashCode, we can still aboid the Java call at runtim if the value object is nice
+    // When we can't intrinsify the identityHashCode, we can still avoid the Java call at runtime if the value object is nice
     // enough. This fast path basically implements the method ValueObjectMethods::valueObjectHashCode in a special case. This
-    // special case is when there is at most one no-oop segment in the acmp maps, that this segment (if it exsits) is 1, 2 4
+    // special case is when there is at most one no-oop segment in the acmp maps, that this segment (if it exists) is 1, 2, 4
     // or 8 byte long, and there is no oop in the acmp maps. Basically, valueObjectHashCode makes 0 or 1 iteration of the big
     // outer loop, and one iteration of one of the inner loops. The fast path loads a long at the given offset, isolates the
     // numeric value we are interested in, and does the arithmetic.
@@ -127,11 +127,11 @@ class InlineKlass: public InstanceKlass {
     // 3. the object has one segment: we set _fast_hashcode_offset according to where we should load.
     //
     // Alike for the acmp fast path, we must not load further than the object, and we use the same trick as for acmp, and we
-    // load possibly some part of the header. The cases 2. and 3. cannot collide since loading loading at offset 0 would read
-    // only the header, and no payload.
+    // load possibly some part of the header. The cases 2. and 3. cannot collide since loading at offset 0 would read only the
+    // header, and no payload.
     //
     // But unlike acmp, we need the actual arithmetic value, and resetting irrelevant bits is not correct. To do that, we need
-    // to have a different logic wrt. endianness. Moreover, the fast path needs to handle differently a when the segment is 8-byte
+    // to have a different logic wrt. endianness. Moreover, the fast path needs to handle differently when the segment is 8-byte
     // long, just as valueObjectHashCode does, while the arithmetic for segments of size 1, 2 or 4 is the same. This is also known
     // by a endianness-dependent test.
     int _fast_hashcode_offset;   // if < 0, fast hashcode doesn't apply
@@ -162,7 +162,7 @@ class InlineKlass: public InstanceKlass {
     // This field is storing the mask. Since we keep 1, 2, 4 or 8 bytes, the legal values of _fast_hashcode_mask
     // are 0xff ff ff ff ff ff ff ff, 0x00 00 00 00 ff ff ff ff, 0x00 00 00 00 00 00 ff ff or 0x00 00 00 00 00 00 00 ff
     //
-    // The fast path is aware we are loading a long if the shift is (long)-1.
+    // The fast path is aware we are loading a long if the mask is (long)-1.
     // Value is not specified (and does not matter) if _fast_hashcode_offset <= 0
     int64_t _fast_hashcode_mask;
 #endif

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -264,15 +264,15 @@ class InlineKlass: public InstanceKlass {
   int64_t fast_acmp_mask() const                              { return members()._fast_acmp_mask; }
   void set_fast_acmp_mask(int64_t mask)                       { members()._fast_acmp_mask = mask; }
 
-  int fast_hashcode_offset() const                                { return members()._fast_hashcode_offset; }
-  void set_fast_hashcode_offset(int offset)                       { members()._fast_hashcode_offset = offset; }
+  int fast_hashcode_offset() const                            { return members()._fast_hashcode_offset; }
+  void set_fast_hashcode_offset(int offset)                   { members()._fast_hashcode_offset = offset; }
 
 #ifdef VM_LITTLE_ENDIAN
-  int fast_hashcode_shift() const                              { return members()._fast_hashcode_shift; }
-  void set_fast_hashcode_shift(int shift)                       { members()._fast_hashcode_shift = shift; }
+  int fast_hashcode_shift() const                             { return members()._fast_hashcode_shift; }
+  void set_fast_hashcode_shift(int shift)                     { members()._fast_hashcode_shift = shift; }
 #else
-  int64_t fast_hashcode_mask() const                              { return members()._fast_hashcode_mask; }
-  void set_fast_hashcode_mask(int64_t mask)                       { members()._fast_hashcode_mask = mask; }
+  int64_t fast_hashcode_mask() const                          { return members()._fast_hashcode_mask; }
+  void set_fast_hashcode_mask(int64_t mask)                   { members()._fast_hashcode_mask = mask; }
 #endif
 
   bool supports_nullable_layouts() const {

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -105,7 +105,7 @@ class InlineKlass: public InstanceKlass {
     //
     // This doesn't always apply, for instance, if there are oops among the fields, we shouldn't carelessly load and compare:
     // the GC might move the object in between.
-    // To signal this fast path cannot be done on this current class, simply put 0 in _fast_acmp_mask.
+    // To signal this fast path cannot be done on this current class, simply put -1 in _fast_acmp_offset.
     //
     // We also should take care of not loading further than the object, even if it means reading part of the header.
     // For this reason, we can't use _payload_offset, but we need our special offset.
@@ -114,10 +114,55 @@ class InlineKlass: public InstanceKlass {
     int _fast_acmp_offset;    // if < 0, fast acmp doesn't apply
     int64_t _fast_acmp_mask;  // can be 0 for empty value classes
 
+    // When we can't intrinsify the identityHashCode, we can still aboid the Java call at runtim if the value object is nice
+    // enough. This fast path basically implements the method ValueObjectMethods::valueObjectHashCode in a special case. This
+    // special case is when there is at most one no-oop segment in the acmp maps, that this segment (if it exsits) is 1, 2 4
+    // or 8 byte long, and there is no oop in the acmp maps. Basically, valueObjectHashCode makes 0 or 1 iteration of the big
+    // outer loop, and one iteration of one of the inner loops. The fast path loads a long at the given offset, isolates the
+    // numeric value we are interested in, and does the arithmetic.
+    //
+    // There are cases:
+    // 1. hashcode fast path doesn't apply: we set _fast_hashcode_offset < 0
+    // 2. the object has no segments (i.e. it is empty): we set _fast_hashcode_offset = 0
+    // 3. the object has one segment: we set _fast_hashcode_offset according to where we should load.
+    //
+    // Alike for the acmp fast path, we must not load further than the object, and we use the same trick as for acmp, and we
+    // load possibly some part of the header. The cases 2. and 3. cannot collide since loading loading at offset 0 would read
+    // only the header, and no payload.
+    //
+    // But unlike acmp, we need the actual arithmetic value, and resetting irrelevant bits is not correct. To do that, we need
+    // to have a different logic wrt. endianness. The fast path needs to handle differently a when the segment is 8 byte long,
+    // just as valueObjectHashCode does. This is also known by a endianness-dependent test.
     int _fast_hashcode_offset;   // if < 0, fast hashcode doesn't apply
 #ifdef VM_LITTLE_ENDIAN
+    // In little endian, the memory layout, with a 4-byte segment whose value (as returned by getInt) would be 0x01 02 03 04. The
+    // memory layout of the object would be something like:
+    //                v- start of payload
+    // ....header.... | 04 03 02 01
+    //    \___________|___________/
+    // Not to load to far, we load at offset "start of payload" - 4, so, we get some header bytes, and we get the long value
+    // 0x01 02 03 04 HH HH HH HH, where HH are header bytes. To get the integer value, we can simply do a unsigned shift right,
+    // by 4 bytes (32 bits) in this case.
+    // This field is saying by how much we need to shift. Since we keep 1, 2, 4 or 8 bytes, the legal values of _fast_hashcode_shift
+    // are 8 * (8 - (1, 2, 4, 8)) = 8 * (7, 6, 4, 0) = 56, 48, 32, 0.
+    //
+    // The fast path is aware we are loading a long if the shift is 0.
+    // Value is not specified (and does not matter) if _fast_hashcode_offset <= 0
     int _fast_hashcode_shift;
 #else
+    // In little endian, the memory layout, with a 4-byte segment whose value (as returned by getInt) would be 0x01 02 03 04. The
+    // memory layout of the object would be something like:
+    //                v- start of payload
+    // ....header.... | 01 02 03 04
+    //    \___________|___________/
+    // Not to load to far, we load at offset "start of payload" - 4, so, we get some header bytes, and we get the long value
+    // 0xHH HH HH HH 01 02 03 04, where HH are header bytes. To get the integer value, we can simply filter out the upper bits, with
+    // the mask 0x00 00 00 00 ff ff ff ff in this case.
+    // This field is storing the mask. Since we keep 1, 2, 4 or 8 bytes, the legal values of _fast_hashcode_mask
+    // are 0xff ff ff ff ff ff ff ff, 0x00 00 00 00 ff ff ff ff, 0x00 00 00 00 00 00 ff ff or 0x00 00 00 00 00 00 00 ff
+    //
+    // The fast path is aware we are loading a long if the shift is (long)-1.
+    // Value is not specified (and does not matter) if _fast_hashcode_offset <= 0
     int64_t _fast_hashcode_mask;
 #endif
 

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -131,8 +131,9 @@ class InlineKlass: public InstanceKlass {
     // only the header, and no payload.
     //
     // But unlike acmp, we need the actual arithmetic value, and resetting irrelevant bits is not correct. To do that, we need
-    // to have a different logic wrt. endianness. The fast path needs to handle differently a when the segment is 8 byte long,
-    // just as valueObjectHashCode does. This is also known by a endianness-dependent test.
+    // to have a different logic wrt. endianness. Moreover, the fast path needs to handle differently a when the segment is 8-byte
+    // long, just as valueObjectHashCode does, while the arithmetic for segments of size 1, 2 or 4 is the same. This is also known
+    // by a endianness-dependent test.
     int _fast_hashcode_offset;   // if < 0, fast hashcode doesn't apply
 #ifdef VM_LITTLE_ENDIAN
     // In little endian, the memory layout, with a 4-byte segment whose value (as returned by getInt) would be 0x01 02 03 04. The
@@ -140,7 +141,7 @@ class InlineKlass: public InstanceKlass {
     //                v- start of payload
     // ....header.... | 04 03 02 01
     //    \___________|___________/
-    // Not to load to far, we load at offset "start of payload" - 4, so, we get some header bytes, and we get the long value
+    // Not to load too far, we load at offset "start of payload" - 4, so, we get some header bytes, and we get the long value
     // 0x01 02 03 04 HH HH HH HH, where HH are header bytes. To get the integer value, we can simply do a unsigned shift right,
     // by 4 bytes (32 bits) in this case.
     // This field is saying by how much we need to shift. Since we keep 1, 2, 4 or 8 bytes, the legal values of _fast_hashcode_shift
@@ -150,12 +151,12 @@ class InlineKlass: public InstanceKlass {
     // Value is not specified (and does not matter) if _fast_hashcode_offset <= 0
     int _fast_hashcode_shift;
 #else
-    // In little endian, the memory layout, with a 4-byte segment whose value (as returned by getInt) would be 0x01 02 03 04. The
+    // In big endian, the memory layout, with a 4-byte segment whose value (as returned by getInt) would be 0x01 02 03 04. The
     // memory layout of the object would be something like:
     //                v- start of payload
     // ....header.... | 01 02 03 04
     //    \___________|___________/
-    // Not to load to far, we load at offset "start of payload" - 4, so, we get some header bytes, and we get the long value
+    // Not to load too far, we load at offset "start of payload" - 4, so, we get some header bytes, and we get the long value
     // 0xHH HH HH HH 01 02 03 04, where HH are header bytes. To get the integer value, we can simply filter out the upper bits, with
     // the mask 0x00 00 00 00 ff ff ff ff in this case.
     // This field is storing the mask. Since we keep 1, 2, 4 or 8 bytes, the legal values of _fast_hashcode_mask

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -33,6 +33,8 @@
 #include "interpreter/interpreter.hpp"
 #include "opto/callGenerator.hpp"
 #include "opto/callnode.hpp"
+
+#include "library_call.hpp"
 #include "opto/castnode.hpp"
 #include "opto/convertnode.hpp"
 #include "opto/escape.hpp"
@@ -1409,6 +1411,26 @@ Node* CallStaticJavaNode::replace_identity_hash_code(PhaseIterGVN* igvn) {
   Node* arg = in(TypeFunc::Parms);
   intptr_t klass_hash;
   if (!InlineTypeNode::can_emit_identity_hash_code(*igvn, arg, klass_hash)) {
+    // We can't expand, but now, maybe we can also tell the fast path won't work
+    const Type* arg_type = igvn->type(arg);
+    if (UseHashcodeFastPath && igvn->type(arg)->is_inlinetypeptr()) {
+      ciInlineKlass* vk = arg_type->inline_klass();
+      bool fast_path_wont_work = false;
+      fast_path_wont_work = fast_path_wont_work || vk->number_of_oop_entries_in_acmp_map() > 0;
+      fast_path_wont_work = fast_path_wont_work || vk->number_of_nonoop_entries_in_acmp_map() > 1;
+      if (vk->number_of_nonoop_entries_in_acmp_map() == 1) {
+        int size = vk->get_nonoop_segment_of_acmp_map(0)._size;
+        fast_path_wont_work = fast_path_wont_work || (size != 1 && size != 2 && size != 4 && size != 8);
+      }
+      if (fast_path_wont_work) {
+        IfNode* fast_path_if = LibraryCallKit::hashcode_fast_path_if_from_identity_hash_code_call(igvn, this);
+        if (fast_path_if != nullptr) {
+          fast_path_if->set_req(1, igvn->intcon(1));
+          igvn->_worklist.push(fast_path_if);
+          return this;
+        }
+      }
+    }
     return nullptr;
   }
 
@@ -1420,6 +1442,15 @@ Node* CallStaticJavaNode::replace_identity_hash_code(PhaseIterGVN* igvn) {
   Node* replace = InlineTypeNode::emit_identity_hash_code(&kit, arg, klass_hash);
   igvn->set_delay_transform(false);
   assert(replace != nullptr, "must succeed");
+
+  if (UseHashcodeFastPath) {
+    // Sabotage the fast hashcode path
+    IfNode* fast_path_if = LibraryCallKit::hashcode_fast_path_if_from_identity_hash_code_call(igvn, this);
+    if (fast_path_if != nullptr) {
+      fast_path_if->set_req(1, igvn->intcon(1));
+      igvn->_worklist.push(fast_path_if);
+    }
+  }
 
   // Kill exception projections and return a tuple that will replace the call
   CallProjections* projs = extract_projections(false /*separate_io_proj*/);

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1196,12 +1196,20 @@ Node* CallStaticJavaNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
   // Try to replace the runtime call to the substitutability test emitted by acmp if we can reason
   // about the operands
-  if (can_reshape && !control()->is_top() && !memory()->is_top() && method() != nullptr &&
-      method()->holder() == phase->C->env()->ValueObjectMethods_klass() &&
-      method()->name() == ciSymbols::isSubstitutable_name()) {
-    Node* res = replace_is_substitutable(phase->is_IterGVN());
-    if (res != nullptr) {
-      return res;
+  if (can_reshape && !control()->is_top() && !memory()->is_top() && method() != nullptr) {
+    if (method()->holder() == phase->C->env()->ValueObjectMethods_klass() &&
+        method()->name() == ciSymbols::isSubstitutable_name()) {
+      Node* res = replace_is_substitutable(phase->is_IterGVN());
+      if (res != nullptr) {
+        return res;
+      }
+    }
+    else if (method()->holder() == phase->C->env()->System_klass() &&
+        method()->name() == ciSymbols::identityHashCode_name()) {
+      Node* res = replace_identity_hash_code(phase->is_IterGVN());
+      if (res != nullptr) {
+        return res;
+      }
     }
   }
 
@@ -1395,6 +1403,41 @@ bool CallStaticJavaNode::remove_unknown_flat_array_load(PhaseIterGVN* igvn, Node
   igvn->add_input_to(igvn->C->root(), halt);
 
   return true;
+}
+
+Node* CallStaticJavaNode::replace_identity_hash_code(PhaseIterGVN* igvn) {
+  Node* arg = in(TypeFunc::Parms);
+  intptr_t klass_hash;
+  if (!InlineTypeNode::can_emit_identity_hash_code(*igvn, arg, klass_hash)) {
+    return nullptr;
+  }
+
+  // Delay IGVN during macro expansion
+  assert(!igvn->delay_transform(), "must not delay during Ideal");
+  igvn->set_delay_transform(true);
+  GraphKit kit(this, *igvn);
+
+  Node* replace = InlineTypeNode::emit_identity_hash_code(&kit, arg, klass_hash);
+  igvn->set_delay_transform(false);
+  assert(replace != nullptr, "must succeed");
+
+  // Kill exception projections and return a tuple that will replace the call
+  CallProjections* projs = extract_projections(false /*separate_io_proj*/);
+  if (projs->fallthrough_catchproj != nullptr) {
+    igvn->replace_node(projs->fallthrough_catchproj, kit.control());
+  }
+  if (projs->catchall_memproj != nullptr) {
+    igvn->replace_node(projs->catchall_memproj, igvn->C->top());
+  }
+  if (projs->catchall_ioproj != nullptr) {
+    igvn->replace_node(projs->catchall_ioproj, igvn->C->top());
+  }
+  if (projs->catchall_catchproj != nullptr) {
+    igvn->replace_node(projs->catchall_catchproj, igvn->C->top());
+  }
+  Node* new_mem = kit.reset_memory();
+  assert(in(TypeFunc::Memory) == new_mem, "must not modify memory");
+  return TupleNode::make(tf()->range_cc(), igvn->C->top(), kit.i_o(), new_mem, kit.frameptr(), kit.returnadr(), replace);
 }
 
 // Try to replace a runtime call to the substitutability test by either a simple pointer comparison

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -33,12 +33,11 @@
 #include "interpreter/interpreter.hpp"
 #include "opto/callGenerator.hpp"
 #include "opto/callnode.hpp"
-
-#include "library_call.hpp"
 #include "opto/castnode.hpp"
 #include "opto/convertnode.hpp"
 #include "opto/escape.hpp"
 #include "opto/inlinetypenode.hpp"
+#include "opto/library_call.hpp"
 #include "opto/locknode.hpp"
 #include "opto/machnode.hpp"
 #include "opto/matcher.hpp"

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -905,6 +905,7 @@ class CallStaticJavaNode : public CallJavaNode {
 
   bool remove_unknown_flat_array_load(PhaseIterGVN* igvn, Node* ctl, Node* mem, Node* unc_arg);
   Node* replace_is_substitutable(PhaseIterGVN* igvn);
+  Node* replace_identity_hash_code(PhaseIterGVN* igvn);
 
 public:
   CallStaticJavaNode(Compile* C, const TypeFunc* tf, address addr, ciMethod* method)

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1423,7 +1423,7 @@ const TypePtr *Compile::flatten_alias_type( const TypePtr *tj ) const {
 
   // Process weird unsafe references.
   if (offset == Type::OffsetBot && (tj->isa_instptr() /*|| tj->isa_klassptr()*/)) {
-    assert(InlineUnsafeOps || StressReflectiveCode || UseAcmpFastPath, "indeterminate pointers come only from unsafe ops");
+    assert(InlineUnsafeOps || StressReflectiveCode || UseAcmpFastPath || UseHashcodeFastPath, "indeterminate pointers come only from unsafe ops");
     assert(!is_known_inst, "scalarizable allocation should not have unsafe references");
     tj = TypeOopPtr::BOTTOM;
     ptr = tj->ptr();

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -345,6 +345,7 @@ class GraphKit : public Phase {
   Node* DivI(Node* ctl, Node* l, Node* r)     { return _gvn.transform(new DivINode(ctl, l, r));  }
 
   Node* AndI(Node* l, Node* r)                { return _gvn.transform(new AndINode(l, r));       }
+  Node* AndL(Node* l, Node* r)                { return _gvn.transform(new AndLNode(l, r));       }
   Node* OrI(Node* l, Node* r)                 { return _gvn.transform(new OrINode(l, r));        }
   Node* XorI(Node* l, Node* r)                { return _gvn.transform(new XorINode(l, r));       }
 
@@ -354,11 +355,15 @@ class GraphKit : public Phase {
   Node* LShiftI(Node* l, Node* r)             { return _gvn.transform(new LShiftINode(l, r));    }
   Node* RShiftI(Node* l, Node* r)             { return _gvn.transform(new RShiftINode(l, r));    }
   Node* URShiftI(Node* l, Node* r)            { return _gvn.transform(new URShiftINode(l, r));   }
+  Node* URShiftL(Node* l, Node* r)            { return _gvn.transform(new URShiftLNode(l, r));   }
+  Node* URShiftX(Node* l, Node* r)            { return _gvn.transform(new URShiftXNode(l, r));   }
 
   Node* CmpI(Node* l, Node* r)                { return _gvn.transform(new CmpINode(l, r));       }
   Node* CmpL(Node* l, Node* r)                { return _gvn.transform(new CmpLNode(l, r));       }
   Node* CmpP(Node* l, Node* r)                { return _gvn.transform(new CmpPNode(l, r));       }
   Node* Bool(Node* cmp, BoolTest::mask relop) { return _gvn.transform(new BoolNode(cmp, relop)); }
+  Node* BoolCmpI(Node* l, BoolTest::mask relop, Node* r)       { return Bool(CmpI(l, r), relop); }
+  Node* BoolCmpL(Node* l, BoolTest::mask relop, Node* r)       { return Bool(CmpL(l, r), relop); }
 
   Node* AddP(Node* b, Node* a, Node* o)       { return _gvn.transform(AddPNode::make_with_base(b, a, o)); }
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -994,6 +994,113 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
   return result;
 }
 
+// Check if a substitutability check between 'lhs' and 'rhs' can be implemented in IR
+bool InlineTypeNode::can_emit_identity_hash_code(const PhaseIterGVN& igvn, Node* arg, intptr_t& klass_hash) {
+  if (!arg->bottom_type()->isa_ptr()) {
+    return false;
+  }
+
+  if (!arg->is_InlineType()) {
+    return false;
+  }
+
+  InlineTypeNode* arg_inline = arg->as_InlineType();
+
+  if (check_cycle(arg_inline->inline_klass())) {
+    return false;
+  }
+
+  const Type* arg_type = igvn.type(arg);
+  ciInlineKlass* vk = arg_type->inline_klass();
+  klass_hash = vk->java_mirror()->hash();
+  if (klass_hash == markWord::no_hash) {
+    tty->print_cr("In %s: no hash", igvn.C->method()->name()->as_quoted_ascii());
+    return false;
+  }
+  if (vk->number_of_oop_entries_in_acmp_map() > 0) {
+    tty->print_cr("In %s: oops", igvn.C->method()->name()->as_quoted_ascii());
+    return false;
+  }
+
+  for (uint i = 0; i < arg_inline->field_count(); i++) {
+    ciType* ft = arg_inline->field(i)->type();
+    if (!ft->is_primitive_type()) {
+      tty->print_cr("In %s: wrong type", igvn.C->method()->name()->as_quoted_ascii());
+      return false;
+    }
+  }
+
+  tty->print_cr("In %s: going to expand", igvn.C->method()->name()->as_quoted_ascii());
+  return true;
+}
+
+Node* InlineTypeNode::emit_identity_hash_code(GraphKit* kit, Node* arg, intptr_t klass_hash) {
+  if (!kit->C->allow_macro_nodes()) {
+    // After macro expansion, InlineTypeNodes are also eliminated, creation of new ones then is not
+    // allowed
+    return nullptr;
+  }
+  PhaseIterGVN& igvn = *kit->gvn().is_IterGVN();
+
+  RegionNode* compute_region = new RegionNode(3);
+  igvn.register_new_node_with_optimizer(compute_region);
+
+  const Type* arg_type = igvn.type(arg);
+  assert(!arg_type->maybe_null(), "must check null beforehand");
+
+  ciInlineKlass* vk = arg_type->inline_klass();
+  int number_of_nonoop_entries = vk->number_of_nonoop_entries_in_acmp_map();
+  assert(vk->number_of_oop_entries_in_acmp_map() == 0, "cannot have oops here");
+
+  auto make_load = [&](int offset, const Type* type, BasicType bt) -> Node* {
+    ciField* field = vk->get_field_by_offset(offset, false);
+    // If the load is by chance not a mismatch, let mark it so. This way, loading the field can be simplified
+    bool is_mismatch = field == nullptr || field->type()->basic_type() != bt;
+    Node* adr = kit->basic_plus_adr(arg, offset);
+    return kit->make_load(kit->control(), adr, type, bt, MemNode::unordered, LoadNode::DependsOnlyOnTest, false, false, is_mismatch, is_mismatch);
+  };
+
+  Node* const thirty_one = kit->intcon(31);
+  Node* result = kit->intcon(checked_cast<jint>(klass_hash));
+  for (int i = 0; i < number_of_nonoop_entries; i++) {
+    AcmpMapSegment segment = vk->get_nonoop_segment_of_acmp_map(i);
+    int offset = segment._offset;
+    int size = segment._size;
+    int nlong = size / 8;
+    for (int j = 0; j < nlong; j++) {
+      Node* la = make_load(offset, TypeLong::LONG, T_LONG);
+      result = kit->AddI(kit->MulI(thirty_one, result), kit->ConvL2I(la));
+      result = kit->AddI(kit->MulI(thirty_one, result), kit->ConvL2I(kit->URShiftL(la, kit->intcon(32))));
+      offset += 8;
+    }
+    size -= nlong * 8;
+    int nint = size / 4;
+    for (int j = 0; j < nint; j++) {
+      Node* ia = make_load(offset, TypeInt::INT, T_INT);
+      result = kit->AddI(kit->MulI(thirty_one, result), ia);
+      offset += 4;
+    }
+    size -= nint * 4;
+    int nshort = size / 2;
+    for (int j = 0; j < nshort; j++) {
+      Node* sa = make_load(offset, TypeInt::SHORT, T_SHORT);
+      result = kit->AddI(kit->MulI(thirty_one, result), sa);
+      offset += 2;
+    }
+    size -= nshort * 2;
+    for (int j = 0; j < size; j++) {
+      Node* ba = make_load(offset, TypeInt::BYTE, T_BYTE);
+      result = kit->AddI(kit->MulI(thirty_one, result), ba);
+      offset++;
+    }
+  }
+  result = kit->AndI(result, kit->intcon(markWord::hash_mask));
+
+  tty->print_cr("In %s, expanded hashcode of %s.", igvn.C->method()->name()->as_quoted_ascii(), vk->name()->as_quoted_ascii());
+
+  return result;
+}
+
 InlineTypeNode* InlineTypeNode::buffer(GraphKit* kit, bool safe_for_replace) {
   if (is_allocated(&kit->gvn())) {
     // Already buffered

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -994,7 +994,7 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
   return result;
 }
 
-// Check if a substitutability check between 'lhs' and 'rhs' can be implemented in IR.
+// Check if identityHashCode of 'arg' can be implemented in IR.
 // Set klass_hash to be used as the seed of the hash. It might not be available later,
 // and we want emit_identity_hash_code not to fail on that.
 bool InlineTypeNode::can_emit_identity_hash_code(const PhaseIterGVN& igvn, Node* arg, intptr_t& klass_hash) {

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -994,29 +994,21 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
   return result;
 }
 
-// Check if a substitutability check between 'lhs' and 'rhs' can be implemented in IR
+// Check if a substitutability check between 'lhs' and 'rhs' can be implemented in IR.
+// Set klass_hash to be used as the seed of the hash. It might not be available later,
+// and we want emit_identity_hash_code not to fail on that.
 bool InlineTypeNode::can_emit_identity_hash_code(const PhaseIterGVN& igvn, Node* arg, intptr_t& klass_hash) {
   const Type* arg_type = igvn.type(arg);
   if (!arg_type->is_inlinetypeptr()) {
     return false;
   }
   ciInlineKlass* vk = arg_type->inline_klass();
+  if (vk->number_of_oop_entries_in_acmp_map() > 0) {
+    return false;
+  }
   klass_hash = vk->java_mirror()->hash();
   if (klass_hash == markWord::no_hash) {
-    if (UseNewCode2) {
-      tty->print_cr("In %s: no hash", igvn.C->method()->name()->as_quoted_ascii());
-    }
     return false;
-  }
-  if (vk->number_of_oop_entries_in_acmp_map() > 0) {
-    if (UseNewCode2) {
-      tty->print_cr("In %s: oops", igvn.C->method()->name()->as_quoted_ascii());
-    }
-    return false;
-  }
-
-  if (UseNewCode2) {
-    tty->print_cr("In %s: going to expand", igvn.C->method()->name()->as_quoted_ascii());
   }
   return true;
 }
@@ -1087,10 +1079,6 @@ Node* InlineTypeNode::emit_identity_hash_code(GraphKit* kit, Node* arg, intptr_t
     }
   }
   result = kit->AndI(result, kit->intcon(markWord::hash_mask));
-
-  if (UseNewCode2) {
-    tty->print_cr("In %s, expanded hashcode of %s.", igvn.C->method()->name()->as_quoted_ascii(), vk->name()->as_quoted_ascii());
-  }
 
   return result;
 }

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -996,41 +996,28 @@ Node* InlineTypeNode::emit_substitutability_check(GraphKit* kit, Node* lhs, Node
 
 // Check if a substitutability check between 'lhs' and 'rhs' can be implemented in IR
 bool InlineTypeNode::can_emit_identity_hash_code(const PhaseIterGVN& igvn, Node* arg, intptr_t& klass_hash) {
-  if (!arg->bottom_type()->isa_ptr()) {
-    return false;
-  }
-
-  if (!arg->is_InlineType()) {
-    return false;
-  }
-
-  InlineTypeNode* arg_inline = arg->as_InlineType();
-
-  if (check_cycle(arg_inline->inline_klass())) {
-    return false;
-  }
-
   const Type* arg_type = igvn.type(arg);
+  if (!arg_type->is_inlinetypeptr()) {
+    return false;
+  }
   ciInlineKlass* vk = arg_type->inline_klass();
   klass_hash = vk->java_mirror()->hash();
   if (klass_hash == markWord::no_hash) {
-    tty->print_cr("In %s: no hash", igvn.C->method()->name()->as_quoted_ascii());
+    if (UseNewCode2) {
+      tty->print_cr("In %s: no hash", igvn.C->method()->name()->as_quoted_ascii());
+    }
     return false;
   }
   if (vk->number_of_oop_entries_in_acmp_map() > 0) {
-    tty->print_cr("In %s: oops", igvn.C->method()->name()->as_quoted_ascii());
+    if (UseNewCode2) {
+      tty->print_cr("In %s: oops", igvn.C->method()->name()->as_quoted_ascii());
+    }
     return false;
   }
 
-  for (uint i = 0; i < arg_inline->field_count(); i++) {
-    ciType* ft = arg_inline->field(i)->type();
-    if (!ft->is_primitive_type()) {
-      tty->print_cr("In %s: wrong type", igvn.C->method()->name()->as_quoted_ascii());
-      return false;
-    }
+  if (UseNewCode2) {
+    tty->print_cr("In %s: going to expand", igvn.C->method()->name()->as_quoted_ascii());
   }
-
-  tty->print_cr("In %s: going to expand", igvn.C->method()->name()->as_quoted_ascii());
   return true;
 }
 
@@ -1053,10 +1040,15 @@ Node* InlineTypeNode::emit_identity_hash_code(GraphKit* kit, Node* arg, intptr_t
   assert(vk->number_of_oop_entries_in_acmp_map() == 0, "cannot have oops here");
 
   auto make_load = [&](int offset, const Type* type, BasicType bt) -> Node* {
+    Node* adr = kit->basic_plus_adr(arg, offset);
     ciField* field = vk->get_field_by_offset(offset, false);
     // If the load is by chance not a mismatch, let mark it so. This way, loading the field can be simplified
     bool is_mismatch = field == nullptr || field->type()->basic_type() != bt;
-    Node* adr = kit->basic_plus_adr(arg, offset);
+    if (bt == T_BYTE && field != nullptr && field->type()->basic_type() == T_BOOLEAN) {
+      is_mismatch = false;
+      bt = T_BOOLEAN;
+      type = TypeInt::BOOL;
+    }
     return kit->make_load(kit->control(), adr, type, bt, MemNode::unordered, LoadNode::DependsOnlyOnTest, false, false, is_mismatch, is_mismatch);
   };
 
@@ -1096,7 +1088,9 @@ Node* InlineTypeNode::emit_identity_hash_code(GraphKit* kit, Node* arg, intptr_t
   }
   result = kit->AndI(result, kit->intcon(markWord::hash_mask));
 
-  tty->print_cr("In %s, expanded hashcode of %s.", igvn.C->method()->name()->as_quoted_ascii(), vk->name()->as_quoted_ascii());
+  if (UseNewCode2) {
+    tty->print_cr("In %s, expanded hashcode of %s.", igvn.C->method()->name()->as_quoted_ascii(), vk->name()->as_quoted_ascii());
+  }
 
   return result;
 }

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -135,6 +135,10 @@ public:
   static bool can_emit_substitutability_check(Node* lhs, Node* rhs);
   static Node* emit_substitutability_check(GraphKit* kit, Node* lhs, Node* rhs);
 
+  // Implementation of the substitutability check for acmp
+  static bool can_emit_identity_hash_code(const PhaseIterGVN& igvn, Node* arg, intptr_t& klass_hash);
+  static Node* emit_identity_hash_code(GraphKit* kit, Node* arg, intptr_t klass_hash);
+
   // Allocates the inline type (if not yet allocated)
   InlineTypeNode* buffer(GraphKit* kit, bool safe_for_replace = true);
   bool is_allocated(PhaseGVN* phase) const;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5607,54 +5607,51 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
           if (control()->is_IfFalse()) {
             fast_path_iff = control()->in(0)->as_If();
           }
-
-          Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
-          Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
-#ifdef VM_LITTLE_ENDIAN
-          // *(obj + offset) >>> shift
-          Node* shift_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_shift_offset()));
-          Node* shift = make_load(control(), shift_addr, TypeInt::INT, T_INT, MemNode::unordered);
-          Node* obj_extracted = URShiftL(obj_payload, shift);
-#else
-          // *(obj + offset) & mask
-          Node* mask_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_mask_offset()));
-          Node* mask = make_load(control(), mask_addr, TypeLong::LONG, T_LONG, MemNode::unordered);
-          Node* obj_extracted = AndL(obj_payload, mask);
-#endif
-
           Node* klass_header_addr = off_heap_plus_addr(load_mirror_from_klass(obj_klass), oopDesc::mark_offset_in_bytes());
           Node* klass_header = make_load(no_ctrl, klass_header_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
           hashcode_is_safe_to_read(klass_header, slow_region);
           if (!stopped()) {
-            Node* result = get_hashcode_from_header(klass_header, slow_region);
+            Node* result_empty = get_hashcode_from_header(klass_header, slow_region);
+            if (!stopped()) {
+              RegionNode* unmasked_region = new RegionNode(4);
+              Node* unmasked_result = new PhiNode(unmasked_region, TypeInt::INT);
 
-            RegionNode* long_not_long_region = new RegionNode(4);
-            Node* fast_path_result = new PhiNode(long_not_long_region, TypeInt::INT);
+              Node* bol_empty_object = BoolCmpI(offset, BoolTest::eq, zerocon(T_INT));
+              IfNode* iff_is_empty_object = create_and_map_if(control(), bol_empty_object, PROB_FAIR, COUNT_UNKNOWN);
+              unmasked_region->init_req(1, IfTrue(iff_is_empty_object));
+              unmasked_result->init_req(1, result_empty);
 
-            Node* bol_empty_object = BoolCmpI(offset, BoolTest::eq, zerocon(T_INT));
+              set_control(IfFalse(iff_is_empty_object));
+
+              Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
+              Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
 #ifdef VM_LITTLE_ENDIAN
-            Node* is_long_payload_bol = BoolCmpI(shift, BoolTest::eq, intcon(0));
+              // *(obj + offset) >>> shift
+              Node* shift_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_shift_offset()));
+              Node* shift = make_load(control(), shift_addr, TypeInt::INT, T_INT, MemNode::unordered);
+              Node* obj_extracted = URShiftL(obj_payload, shift);
+              Node* is_long_payload_bol = BoolCmpI(shift, BoolTest::eq, intcon(0));
 #else
-            Node* is_long_payload_bol = BoolCmpI(mask, BoolTest::eq, longcon(-1));
+              // *(obj + offset) & mask
+              Node* mask_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_mask_offset()));
+              Node* mask = make_load(control(), mask_addr, TypeLong::LONG, T_LONG, MemNode::unordered);
+              Node* obj_extracted = AndL(obj_payload, mask);
+              Node* is_long_payload_bol = BoolCmpI(mask, BoolTest::eq, longcon(-1));
 #endif
-            IfNode* iff_is_empty_object = create_and_map_if(control(), bol_empty_object, PROB_FAIR, COUNT_UNKNOWN);
-            IfNode* iff_is_long_payload = create_and_map_if(IfFalse(iff_is_empty_object), is_long_payload_bol, PROB_FAIR, COUNT_UNKNOWN);
+              IfNode* iff_is_long_payload = create_and_map_if(control(), is_long_payload_bol, PROB_FAIR, COUNT_UNKNOWN);
 
-            fast_path_result->init_req(1, result);
-            long_not_long_region->init_req(1, IfTrue(iff_is_empty_object));
+              Node* result_int = AddI(MulI(intcon(31), result_empty), ConvL2I(obj_extracted));
+              unmasked_region->init_req(2, IfFalse(iff_is_long_payload));
+              unmasked_result->init_req(2, result_int);
 
-            result = AddI(MulI(intcon(31), result), ConvL2I(obj_extracted));
-            fast_path_result->init_req(2, result);
-            long_not_long_region->init_req(2, IfFalse(iff_is_long_payload));
+              Node* result_long = AddI(MulI(intcon(31), result_int), ConvL2I(URShiftL(obj_extracted, intcon(32))));
+              unmasked_region->init_req(3, IfTrue(iff_is_long_payload));
+              unmasked_result->init_req(3, result_long);
 
-            result = AddI(MulI(intcon(31), result), ConvL2I(URShiftL(obj_extracted, intcon(32))));
-            fast_path_result->init_req(3, result);
-            long_not_long_region->init_req(3, IfTrue(iff_is_long_payload));
-
-            fast_path_result = AndI(_gvn.transform(fast_path_result), intcon(markWord::hash_mask));
-
-            result_reg->init_req(_inline_fast_path, _gvn.transform(long_not_long_region));
-            result_val->init_req(_inline_fast_path, fast_path_result);
+              Node* fast_path_result = AndI(_gvn.transform(unmasked_result), intcon(markWord::hash_mask));
+              result_reg->init_req(_inline_fast_path, _gvn.transform(unmasked_region));
+              result_val->init_req(_inline_fast_path, fast_path_result);
+            }
           }
         }
       }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5596,13 +5596,7 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
       Node* is_not_value = inline_type_test(obj, false);
       generate_slow_guard(is_not_value, slow_region);
       if (!stopped()) {
-        /* load 8 bytes from appropriate offset
-         * mask to keep 1, 2, 4 or 8 bytes if mask is 0 => slow path
-         * load hash from klass if none => slow path
-         * shift by 7, 6, 4 or 0 bytes
-         * if shift is 0 => 31 * (31 * klass_hash + shifted[31:0]) + shifted[63:32]
-         * else => 31 * klass_hash + shifted
-         */
+        // See InlineKlass::Members::_fast_hashcode_offset et seqq. for details on the fast path logic
         Node* members_addr = off_heap_plus_addr(obj_klass, in_bytes(InlineKlass::adr_members_offset()));
         Node* members = make_load(control(), members_addr, TypeRawPtr::BOTTOM, T_ADDRESS, MemNode::unordered);
         Node* offset_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_offset_offset()));
@@ -5614,7 +5608,6 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
             fast_path_iff = control()->in(0)->as_If();
           }
 
-          // See ClassFileParser::set_fast_hashcode_members
           Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
           Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
 #ifdef VM_LITTLE_ENDIAN

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5644,9 +5644,16 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
           if (!stopped()) {
             Node* result_empty = get_hashcode_from_header(klass_header, slow_region);
             if (!stopped()) {
+              // Now that we know fast path applies, there are 3 cases to distinguish here,
+              // that unmasked_region/unmasked_result merge:
+              // 1. the object has no segment, the hash is simply the hash of the class object
+              // 2. the object has one segment of size smaller that 8 (1, 2, 4)
+              // 3. the object has one segment of size 8 (long-sized)
+              // See inlineKlass.hpp on why and how to tell them apart.
               RegionNode* unmasked_region = new RegionNode(4);
               Node* unmasked_result = new PhiNode(unmasked_region, TypeInt::INT);
 
+              // Case 1. no segment
               Node* bol_empty_object = BoolCmpI(offset, BoolTest::eq, zerocon(T_INT));
               IfNode* iff_is_empty_object = create_and_map_if(control(), bol_empty_object, PROB_FAIR, COUNT_UNKNOWN);
               unmasked_region->init_req(1, IfTrue(iff_is_empty_object));
@@ -5671,10 +5678,12 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
 #endif
               IfNode* iff_is_long_payload = create_and_map_if(control(), is_long_payload_bol, PROB_FAIR, COUNT_UNKNOWN);
 
+              // Case 2. one segment, less than 8-byte long
               Node* result_int = AddI(MulI(intcon(31), result_empty), ConvL2I(obj_extracted));
               unmasked_region->init_req(2, IfFalse(iff_is_long_payload));
               unmasked_result->init_req(2, result_int);
 
+              // Case 3. one segment, 8-byte long
               Node* result_long = AddI(MulI(intcon(31), result_int), ConvL2I(URShiftL(obj_extracted, intcon(32))));
               unmasked_region->init_req(3, IfTrue(iff_is_long_payload));
               unmasked_result->init_req(3, result_long);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5466,11 +5466,50 @@ LibraryCallKit::generate_method_call(vmIntrinsicID method_id, bool is_virtual, b
  * be virtual (invokevirtual) or bound (invokespecial). For each case we generate
  * slightly different code.
  */
+void LibraryCallKit::hashcode_is_safe_to_read(Node* header, RegionNode* unsafe) {
+  if (!UseObjectMonitorTable) {
+    // Test the header to see if it is safe to read w.r.t. locking.
+    // We cannot use the inline type mask as this may check bits that are overridden
+    // by an object monitor's pointer when inflating locking.
+    Node *lock_mask      = _gvn.MakeConX(markWord::lock_mask_in_place);
+    Node *lmasked_header = _gvn.transform(new AndXNode(header, lock_mask));
+    Node *monitor_val   = _gvn.MakeConX(markWord::monitor_value);
+    Node *chk_monitor   = _gvn.transform(new CmpXNode(lmasked_header, monitor_val));
+    Node *test_monitor  = _gvn.transform(new BoolNode(chk_monitor, BoolTest::eq));
+
+    generate_slow_guard(test_monitor, unsafe);
+  }
+}
+
+Node* LibraryCallKit::get_hashcode_from_header(Node* header, RegionNode* unset_region) {
+  // Get the hash value and check to see that it has been properly assigned.
+  // We depend on hash_mask being at most 32 bits and avoid the use of
+  // hash_mask_in_place because it could be larger than 32 bits in a 64-bit
+  // vm: see markWord.hpp.
+  Node* hash_mask      = _gvn.intcon(markWord::hash_mask);
+  Node* hash_shift     = _gvn.intcon(markWord::hash_shift);
+  Node* hshifted_header= _gvn.transform(new URShiftXNode(header, hash_shift));
+  // This hack lets the hash bits live anywhere in the mark object now, as long
+  // as the shift drops the relevant bits into the low 32 bits.  Note that
+  // Java spec says that HashCode is an int so there's no point in capturing
+  // an 'X'-sized hashcode (32 in 32-bit build or 64 in 64-bit build).
+  hshifted_header      = ConvX2I(hshifted_header);
+  Node* hash_val       = _gvn.transform(new AndINode(hshifted_header, hash_mask));
+
+  Node* no_hash_val    = _gvn.intcon(markWord::no_hash);
+  Node* chk_assigned   = _gvn.transform(new CmpINode( hash_val, no_hash_val));
+  Node* test_assigned  = _gvn.transform(new BoolNode( chk_assigned, BoolTest::eq));
+
+  generate_slow_guard(test_assigned, unset_region);
+
+  return hash_val;
+}
+
 bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   assert(is_static == callee()->is_static(), "correct intrinsic selection");
   assert(!(is_virtual && is_static), "either virtual, special, or static");
 
-  enum { _slow_path = 1, _fast_path, _null_path, PATH_LIMIT };
+  enum { _slow_path = 1, _cache_path, _null_path, _inline_fast_path, PATH_LIMIT };
 
   RegionNode* result_reg = new RegionNode(PATH_LIMIT);
   PhiNode*    result_val = new PhiNode(result_reg, TypeInt::INT);
@@ -5480,8 +5519,15 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
 
   // Don't intrinsify hashcode on inline types for now.
   // The "is locked" runtime check also subsumes the inline type check (as inline types cannot be locked) and goes to the slow path.
-  if (gvn().type(obj)->is_inlinetypeptr()) {
+  if (!UseNewCode && gvn().type(obj)->is_inlinetypeptr()) {
     return false;
+  }
+
+  if (obj->is_InlineType()) {
+    PreserveReexecuteState preexecs(this);
+    inc_sp(2);
+    jvms()->set_should_reexecute(true);
+    obj = obj->as_InlineType()->buffer(this);
   }
 
   if (!is_static) {
@@ -5507,10 +5553,13 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
     return true;
   }
 
-  // We only go to the fast case code if we pass a number of guards.  The
-  // paths which do not pass are accumulated in the slow_region.
+  // We only go to the cache case code if we pass a number of guards.  The
+  // paths which do not pass are accumulated in the compute_region. The compute
+  // region tries to use the fast path for inline types. That also needs a lot
+  // of guards to be met. The paths which do not pass are accumulated in the
+  // slow_region, where we do the runtime call, which is the last resort.
+  RegionNode* compute_region = new RegionNode(1);
   RegionNode* slow_region = new RegionNode(1);
-  record_for_igvn(slow_region);
 
   // If this is a virtual call, we generate a funny guard.  We pull out
   // the vtable entry corresponding to hashCode() from the target object.
@@ -5518,9 +5567,9 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   // Object hashCode() method, we pass the guard.  We do not need this
   // guard for non-virtual calls -- the caller is known to be the native
   // Object hashCode().
+  // After null check, get the object's klass.
+  Node* obj_klass = load_object_klass(obj);
   if (is_virtual) {
-    // After null check, get the object's klass.
-    Node* obj_klass = load_object_klass(obj);
     generate_virtual_guard(obj_klass, slow_region);
   }
 
@@ -5531,48 +5580,101 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   Node* no_ctrl = nullptr;
   Node* header = make_load(no_ctrl, header_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
 
-  if (!UseObjectMonitorTable) {
-    // Test the header to see if it is safe to read w.r.t. locking.
-    // We cannot use the inline type mask as this may check bits that are overridden
-    // by an object monitor's pointer when inflating locking.
-    Node *lock_mask      = _gvn.MakeConX(markWord::lock_mask_in_place);
-    Node *lmasked_header = _gvn.transform(new AndXNode(header, lock_mask));
-    Node *monitor_val   = _gvn.MakeConX(markWord::monitor_value);
-    Node *chk_monitor   = _gvn.transform(new CmpXNode(lmasked_header, monitor_val));
-    Node *test_monitor  = _gvn.transform(new BoolNode(chk_monitor, BoolTest::eq));
+  RegionNode* cache_region = new RegionNode(1);
 
-    generate_slow_guard(test_monitor, slow_region);
+  // If inline type, directly go to cache region
+  Node* is_value = inline_type_test(obj);
+  generate_slow_guard(is_value, cache_region);
+
+  hashcode_is_safe_to_read(header, compute_region);
+  cache_region->add_req(control());
+
+  set_control(_gvn.transform(cache_region));
+  Node* hash_val = get_hashcode_from_header(header, compute_region);
+
+  result_val->init_req(_cache_path, hash_val);
+  result_reg->init_req(_cache_path, control());
+
+  set_control(_gvn.transform(compute_region));
+  if (!stopped()) {
+    if (UseHashcodeFastPath) {
+      Node* is_not_value = inline_type_test(obj, false);
+      generate_slow_guard(is_not_value, slow_region);
+
+      /* load 8 bytes from appropriate offset
+       * mask to keep 1, 2, 4 or 8 bytes if mask is 0 => slow path
+       * load hash from klass if none => slow path
+       * shift by 7, 6, 4 or 0 bytes (big endian only?) = max_julong >> ((BitsPerByte - n) << LogBitsPerByte)
+       * if shift is 0 => 31 * (31 * klass_hash + shifted[31:0]) + shifted[63:32]
+       * else => 31 * klass_hash + shifted
+       */
+      Node* members_addr = off_heap_plus_addr(obj_klass, in_bytes(InlineKlass::adr_members_offset()));
+      Node* members = make_load(control(), members_addr, TypeRawPtr::BOTTOM, T_ADDRESS, MemNode::unordered);
+      Node* offset_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_offset_offset()));
+      Node* offset = make_load(control(), offset_addr, TypeInt::INT, T_INT, MemNode::unordered);
+      Node* bol_no_fast_path = BoolCmpI(offset, BoolTest::lt, zerocon(T_INT));
+      generate_slow_guard(bol_no_fast_path, slow_region);
+
+      // See ClassFileParser::set_fast_hashcode_members
+#ifdef VM_LITTLE_ENDIAN
+      // *(obj + offset) >>> shift
+      Node* shift_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_shift_offset()));
+      Node* shift = make_load(control(), shift_addr, TypeInt::INT, T_INT, MemNode::unordered);
+      Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
+      Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
+      Node* obj_extracted = URShiftL(obj_payload, shift);
+#else
+      // *(obj + offset) & mask
+      Node* mask_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_mask_offset()));
+      Node* mask = make_load(control(), mask_addr, TypeLong::LONG, T_LONG, MemNode::unordered);
+      Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
+      Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
+      Node* obj_extracted = AndL(obj_payload, mask);
+#endif
+
+      Node* klass_header_addr = off_heap_plus_addr(load_mirror_from_klass(obj_klass), oopDesc::mark_offset_in_bytes());
+      Node* klass_header = make_load(no_ctrl, klass_header_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
+      hashcode_is_safe_to_read(klass_header, slow_region);
+      Node* result = get_hashcode_from_header(klass_header, slow_region);
+
+      RegionNode* long_not_long_region = new RegionNode(4);
+      Node* fast_path_result = new PhiNode(long_not_long_region, TypeInt::INT);
+
+      Node* bol_empty_object = BoolCmpI(offset, BoolTest::eq, zerocon(T_INT));
+#ifdef VM_LITTLE_ENDIAN
+      Node* is_long_payload_bol = BoolCmpI(shift, BoolTest::eq, intcon(0));
+#else
+      Node* is_long_payload_bol = BoolCmpI(mask, BoolTest::eq, longcon(-1));
+#endif
+      IfNode* iff_is_empty_object = create_and_map_if(control(), bol_empty_object, PROB_FAIR, COUNT_UNKNOWN);
+      IfNode* iff_is_long_payload = create_and_map_if(IfFalse(iff_is_empty_object), is_long_payload_bol, PROB_FAIR, COUNT_UNKNOWN);
+
+      fast_path_result->init_req(1, result);
+      long_not_long_region->init_req(1, IfTrue(iff_is_empty_object));
+
+      result = AddI(MulI(intcon(31), result), ConvL2I(obj_extracted));
+      fast_path_result->init_req(2, result);
+      long_not_long_region->init_req(2, IfFalse(iff_is_long_payload));
+
+      result = AddI(MulI(intcon(31), result), ConvL2I(URShiftL(obj_extracted, intcon(32))));
+      fast_path_result->init_req(3, result);
+      long_not_long_region->init_req(3, IfTrue(iff_is_long_payload));
+
+      fast_path_result = AndI(_gvn.transform(fast_path_result), intcon(markWord::hash_mask));
+
+      result_reg->init_req(_inline_fast_path, _gvn.transform(long_not_long_region));
+      result_val->init_req(_inline_fast_path, fast_path_result);
+    } else {
+      slow_region->add_req(control());
+    }
   }
-
-  // Get the hash value and check to see that it has been properly assigned.
-  // We depend on hash_mask being at most 32 bits and avoid the use of
-  // hash_mask_in_place because it could be larger than 32 bits in a 64-bit
-  // vm: see markWord.hpp.
-  Node *hash_mask      = _gvn.intcon(markWord::hash_mask);
-  Node *hash_shift     = _gvn.intcon(markWord::hash_shift);
-  Node *hshifted_header= _gvn.transform(new URShiftXNode(header, hash_shift));
-  // This hack lets the hash bits live anywhere in the mark object now, as long
-  // as the shift drops the relevant bits into the low 32 bits.  Note that
-  // Java spec says that HashCode is an int so there's no point in capturing
-  // an 'X'-sized hashcode (32 in 32-bit build or 64 in 64-bit build).
-  hshifted_header      = ConvX2I(hshifted_header);
-  Node *hash_val       = _gvn.transform(new AndINode(hshifted_header, hash_mask));
-
-  Node *no_hash_val    = _gvn.intcon(markWord::no_hash);
-  Node *chk_assigned   = _gvn.transform(new CmpINode( hash_val, no_hash_val));
-  Node *test_assigned  = _gvn.transform(new BoolNode( chk_assigned, BoolTest::eq));
-
-  generate_slow_guard(test_assigned, slow_region);
-
   Node* init_mem = reset_memory();
-  // fill in the rest of the null path:
   result_io ->init_req(_null_path, i_o());
   result_mem->init_req(_null_path, init_mem);
-
-  result_val->init_req(_fast_path, hash_val);
-  result_reg->init_req(_fast_path, control());
-  result_io ->init_req(_fast_path, i_o());
-  result_mem->init_req(_fast_path, init_mem);
+  result_io ->init_req(_cache_path, i_o());
+  result_mem->init_req(_cache_path, init_mem);
+  result_io  ->set_req(_inline_fast_path, i_o());
+  result_mem ->set_req(_inline_fast_path, init_mem);
 
   // Generate code for the slow case.  We make a call to hashCode().
   set_control(_gvn.transform(slow_region));
@@ -5581,6 +5683,7 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
     set_all_memory(init_mem);
     vmIntrinsics::ID hashCode_id = is_static ? vmIntrinsics::_identityHashCode : vmIntrinsics::_hashCode;
     CallJavaNode* slow_call = generate_method_call(hashCode_id, is_virtual, is_static, false);
+    slow_call->set_req(TypeFunc::Parms, obj);
     Node* slow_result = set_results_for_java_call(slow_call);
     // this->control() comes from set_results_for_java_call
     result_reg->init_req(_slow_path, control());

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5471,11 +5471,11 @@ void LibraryCallKit::hashcode_is_safe_to_read(Node* header, RegionNode* unsafe) 
     // Test the header to see if it is safe to read w.r.t. locking.
     // We cannot use the inline type mask as this may check bits that are overridden
     // by an object monitor's pointer when inflating locking.
-    Node *lock_mask      = _gvn.MakeConX(markWord::lock_mask_in_place);
-    Node *lmasked_header = _gvn.transform(new AndXNode(header, lock_mask));
-    Node *monitor_val   = _gvn.MakeConX(markWord::monitor_value);
-    Node *chk_monitor   = _gvn.transform(new CmpXNode(lmasked_header, monitor_val));
-    Node *test_monitor  = _gvn.transform(new BoolNode(chk_monitor, BoolTest::eq));
+    Node* lock_mask = _gvn.MakeConX(markWord::lock_mask_in_place);
+    Node* lmasked_header = _gvn.transform(new AndXNode(header, lock_mask));
+    Node* monitor_val = _gvn.MakeConX(markWord::monitor_value);
+    Node* chk_monitor = _gvn.transform(new CmpXNode(lmasked_header, monitor_val));
+    Node* test_monitor = _gvn.transform(new BoolNode(chk_monitor, BoolTest::eq));
 
     generate_slow_guard(test_monitor, unsafe);
   }
@@ -5486,30 +5486,61 @@ Node* LibraryCallKit::get_hashcode_from_header(Node* header, RegionNode* unset_r
   // We depend on hash_mask being at most 32 bits and avoid the use of
   // hash_mask_in_place because it could be larger than 32 bits in a 64-bit
   // vm: see markWord.hpp.
-  Node* hash_mask      = _gvn.intcon(markWord::hash_mask);
-  Node* hash_shift     = _gvn.intcon(markWord::hash_shift);
-  Node* hshifted_header= _gvn.transform(new URShiftXNode(header, hash_shift));
+  Node* hash_mask = _gvn.intcon(markWord::hash_mask);
+  Node* hash_shift = _gvn.intcon(markWord::hash_shift);
+  Node* hshifted_header = _gvn.transform(new URShiftXNode(header, hash_shift));
   // This hack lets the hash bits live anywhere in the mark object now, as long
   // as the shift drops the relevant bits into the low 32 bits.  Note that
   // Java spec says that HashCode is an int so there's no point in capturing
   // an 'X'-sized hashcode (32 in 32-bit build or 64 in 64-bit build).
-  hshifted_header      = ConvX2I(hshifted_header);
-  Node* hash_val       = _gvn.transform(new AndINode(hshifted_header, hash_mask));
+  hshifted_header = ConvX2I(hshifted_header);
+  Node* hash_val = _gvn.transform(new AndINode(hshifted_header, hash_mask));
 
-  Node* no_hash_val    = _gvn.intcon(markWord::no_hash);
-  Node* chk_assigned   = _gvn.transform(new CmpINode( hash_val, no_hash_val));
-  Node* test_assigned  = _gvn.transform(new BoolNode( chk_assigned, BoolTest::eq));
+  Node* no_hash_val = _gvn.intcon(markWord::no_hash);
+  Node* chk_assigned = _gvn.transform(new CmpINode( hash_val, no_hash_val));
+  Node* test_assigned = _gvn.transform(new BoolNode( chk_assigned, BoolTest::eq));
 
   generate_slow_guard(test_assigned, unset_region);
 
   return hash_val;
 }
 
+/* The overall logic is something like
+ *
+ * null_path:
+ * if receiver is null {
+ *   if static { return 0 } else { null pointer exception }
+ * }
+ *
+ * cache_path:
+ * if header is not safe to read { goto compute }
+ * hash = read_hash_from_header()
+ * if hash is empty { goto compute }
+ * return hash
+ *
+ * inline_fast_path (for static call, goto slow otherwise):
+ * if not value object { goto slow }
+ * if value klass has no fast path { goto slow }
+ * if klass header is not safe to read { goto slow }
+ * k_hash = read_hash_from_klass_header()
+ * if k_hash is empty { goto slow }
+ * return fast_hashcode_path...
+ *
+ * slow:
+ * runtime call to hash function
+ *
+ */
 bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   assert(is_static == callee()->is_static(), "correct intrinsic selection");
   assert(!(is_virtual && is_static), "either virtual, special, or static");
 
-  enum { _slow_path = 1, _cache_path, _null_path, _inline_fast_path, PATH_LIMIT };
+  enum {
+    _slow_path = 1,  // Actually perform the runtime call
+    _cache_path,  // Get the hash from the header
+    _null_path,  // If object is null, hash is 0.
+    _inline_fast_path,  // Fast path for value objects only (see InlineKlass::Members::_fast_hashcode_offset et seqq.)
+    PATH_LIMIT,
+  };
 
   RegionNode* result_reg = new RegionNode(PATH_LIMIT);
   PhiNode*    result_val = new PhiNode(result_reg, TypeInt::INT);
@@ -5552,7 +5583,7 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   // region tries to use the fast path for inline types. That also needs a lot
   // of guards to be met. The paths which do not pass are accumulated in the
   // slow_region, where we do the runtime call, which is the last resort.
-  RegionNode* compute_region = new RegionNode(1);
+  RegionNode* inline_fast_path_region = new RegionNode(1);
   RegionNode* slow_region = new RegionNode(1);
 
   // If this is a virtual call, we generate a funny guard.  We pull out
@@ -5578,23 +5609,23 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
 
   // If inline type, directly go to cache region
   Node* is_value = inline_type_test(obj);
-  generate_slow_guard(is_value, cache_region);
+  generate_fair_guard(is_value, cache_region);
 
-  hashcode_is_safe_to_read(header, compute_region);
+  hashcode_is_safe_to_read(header, inline_fast_path_region);
   cache_region->add_req(control());
 
   set_control(_gvn.transform(cache_region));
-  Node* hash_val = get_hashcode_from_header(header, compute_region);
+  Node* hash_val = get_hashcode_from_header(header, inline_fast_path_region);
 
   result_val->init_req(_cache_path, hash_val);
   result_reg->init_req(_cache_path, control());
 
-  set_control(_gvn.transform(compute_region));
+  set_control(_gvn.transform(inline_fast_path_region));
   IfNode* fast_path_iff = nullptr;
   if (!stopped()) {
-    if (UseHashcodeFastPath && !_gvn.type(obj)->is_inlinetypeptr()) {
+    if (UseHashcodeFastPath && is_static && !_gvn.type(obj)->is_inlinetypeptr()) {
       Node* is_not_value = inline_type_test(obj, false);
-      generate_slow_guard(is_not_value, slow_region);
+      generate_fair_guard(is_not_value, slow_region);
       if (!stopped()) {
         // See InlineKlass::Members::_fast_hashcode_offset et seqq. for details on the fast path logic
         Node* members_addr = off_heap_plus_addr(obj_klass, in_bytes(InlineKlass::adr_members_offset()));
@@ -5674,7 +5705,7 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
     set_all_memory(init_mem);
     vmIntrinsics::ID hashCode_id = is_static ? vmIntrinsics::_identityHashCode : vmIntrinsics::_hashCode;
     CallJavaNode* slow_call = generate_method_call(hashCode_id, is_virtual, is_static, false);
-    slow_call->set_req(TypeFunc::Parms, obj);
+    slow_call->set_req(TypeFunc::Parms, obj);  // This obj is not null
     Node* slow_result = set_results_for_java_call(slow_call);
     assert(hashcode_fast_path_if_from_identity_hash_code_call(&_gvn, slow_call) == fast_path_iff, "");
     // this->control() comes from set_results_for_java_call

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5517,12 +5517,6 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   PhiNode*    result_mem = new PhiNode(result_reg, Type::MEMORY, TypePtr::BOTTOM);
   Node* obj = argument(0);
 
-  // Don't intrinsify hashcode on inline types for now.
-  // The "is locked" runtime check also subsumes the inline type check (as inline types cannot be locked) and goes to the slow path.
-  if (!UseNewCode && gvn().type(obj)->is_inlinetypeptr()) {
-    return false;
-  }
-
   if (obj->is_InlineType()) {
     PreserveReexecuteState preexecs(this);
     inc_sp(2);
@@ -5596,74 +5590,81 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   result_reg->init_req(_cache_path, control());
 
   set_control(_gvn.transform(compute_region));
+  IfNode* fast_path_iff = nullptr;
   if (!stopped()) {
-    if (UseHashcodeFastPath) {
+    if (UseHashcodeFastPath && !_gvn.type(obj)->is_inlinetypeptr()) {
       Node* is_not_value = inline_type_test(obj, false);
       generate_slow_guard(is_not_value, slow_region);
+      if (!stopped()) {
+        /* load 8 bytes from appropriate offset
+         * mask to keep 1, 2, 4 or 8 bytes if mask is 0 => slow path
+         * load hash from klass if none => slow path
+         * shift by 7, 6, 4 or 0 bytes
+         * if shift is 0 => 31 * (31 * klass_hash + shifted[31:0]) + shifted[63:32]
+         * else => 31 * klass_hash + shifted
+         */
+        Node* members_addr = off_heap_plus_addr(obj_klass, in_bytes(InlineKlass::adr_members_offset()));
+        Node* members = make_load(control(), members_addr, TypeRawPtr::BOTTOM, T_ADDRESS, MemNode::unordered);
+        Node* offset_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_offset_offset()));
+        Node* offset = make_load(control(), offset_addr, TypeInt::INT, T_INT, MemNode::unordered);
+        Node* bol_no_fast_path = BoolCmpI(offset, BoolTest::lt, zerocon(T_INT));
+        generate_slow_guard(bol_no_fast_path, slow_region);
+        if (!stopped()) {
+          if (control()->is_IfFalse()) {
+            fast_path_iff = control()->in(0)->as_If();
+          }
 
-      /* load 8 bytes from appropriate offset
-       * mask to keep 1, 2, 4 or 8 bytes if mask is 0 => slow path
-       * load hash from klass if none => slow path
-       * shift by 7, 6, 4 or 0 bytes (big endian only?) = max_julong >> ((BitsPerByte - n) << LogBitsPerByte)
-       * if shift is 0 => 31 * (31 * klass_hash + shifted[31:0]) + shifted[63:32]
-       * else => 31 * klass_hash + shifted
-       */
-      Node* members_addr = off_heap_plus_addr(obj_klass, in_bytes(InlineKlass::adr_members_offset()));
-      Node* members = make_load(control(), members_addr, TypeRawPtr::BOTTOM, T_ADDRESS, MemNode::unordered);
-      Node* offset_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_offset_offset()));
-      Node* offset = make_load(control(), offset_addr, TypeInt::INT, T_INT, MemNode::unordered);
-      Node* bol_no_fast_path = BoolCmpI(offset, BoolTest::lt, zerocon(T_INT));
-      generate_slow_guard(bol_no_fast_path, slow_region);
-
-      // See ClassFileParser::set_fast_hashcode_members
+          // See ClassFileParser::set_fast_hashcode_members
+          Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
+          Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
 #ifdef VM_LITTLE_ENDIAN
-      // *(obj + offset) >>> shift
-      Node* shift_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_shift_offset()));
-      Node* shift = make_load(control(), shift_addr, TypeInt::INT, T_INT, MemNode::unordered);
-      Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
-      Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
-      Node* obj_extracted = URShiftL(obj_payload, shift);
+          // *(obj + offset) >>> shift
+          Node* shift_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_shift_offset()));
+          Node* shift = make_load(control(), shift_addr, TypeInt::INT, T_INT, MemNode::unordered);
+          Node* obj_extracted = URShiftL(obj_payload, shift);
 #else
-      // *(obj + offset) & mask
-      Node* mask_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_mask_offset()));
-      Node* mask = make_load(control(), mask_addr, TypeLong::LONG, T_LONG, MemNode::unordered);
-      Node* obj_payload_addr = basic_plus_adr(obj, ConvI2L(offset));
-      Node* obj_payload = make_load(control(), obj_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
-      Node* obj_extracted = AndL(obj_payload, mask);
+          // *(obj + offset) & mask
+          Node* mask_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_hashcode_mask_offset()));
+          Node* mask = make_load(control(), mask_addr, TypeLong::LONG, T_LONG, MemNode::unordered);
+          Node* obj_extracted = AndL(obj_payload, mask);
 #endif
 
-      Node* klass_header_addr = off_heap_plus_addr(load_mirror_from_klass(obj_klass), oopDesc::mark_offset_in_bytes());
-      Node* klass_header = make_load(no_ctrl, klass_header_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
-      hashcode_is_safe_to_read(klass_header, slow_region);
-      Node* result = get_hashcode_from_header(klass_header, slow_region);
+          Node* klass_header_addr = off_heap_plus_addr(load_mirror_from_klass(obj_klass), oopDesc::mark_offset_in_bytes());
+          Node* klass_header = make_load(no_ctrl, klass_header_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
+          hashcode_is_safe_to_read(klass_header, slow_region);
+          if (!stopped()) {
+            Node* result = get_hashcode_from_header(klass_header, slow_region);
 
-      RegionNode* long_not_long_region = new RegionNode(4);
-      Node* fast_path_result = new PhiNode(long_not_long_region, TypeInt::INT);
+            RegionNode* long_not_long_region = new RegionNode(4);
+            Node* fast_path_result = new PhiNode(long_not_long_region, TypeInt::INT);
 
-      Node* bol_empty_object = BoolCmpI(offset, BoolTest::eq, zerocon(T_INT));
+            Node* bol_empty_object = BoolCmpI(offset, BoolTest::eq, zerocon(T_INT));
 #ifdef VM_LITTLE_ENDIAN
-      Node* is_long_payload_bol = BoolCmpI(shift, BoolTest::eq, intcon(0));
+            Node* is_long_payload_bol = BoolCmpI(shift, BoolTest::eq, intcon(0));
 #else
-      Node* is_long_payload_bol = BoolCmpI(mask, BoolTest::eq, longcon(-1));
+            Node* is_long_payload_bol = BoolCmpI(mask, BoolTest::eq, longcon(-1));
 #endif
-      IfNode* iff_is_empty_object = create_and_map_if(control(), bol_empty_object, PROB_FAIR, COUNT_UNKNOWN);
-      IfNode* iff_is_long_payload = create_and_map_if(IfFalse(iff_is_empty_object), is_long_payload_bol, PROB_FAIR, COUNT_UNKNOWN);
+            IfNode* iff_is_empty_object = create_and_map_if(control(), bol_empty_object, PROB_FAIR, COUNT_UNKNOWN);
+            IfNode* iff_is_long_payload = create_and_map_if(IfFalse(iff_is_empty_object), is_long_payload_bol, PROB_FAIR, COUNT_UNKNOWN);
 
-      fast_path_result->init_req(1, result);
-      long_not_long_region->init_req(1, IfTrue(iff_is_empty_object));
+            fast_path_result->init_req(1, result);
+            long_not_long_region->init_req(1, IfTrue(iff_is_empty_object));
 
-      result = AddI(MulI(intcon(31), result), ConvL2I(obj_extracted));
-      fast_path_result->init_req(2, result);
-      long_not_long_region->init_req(2, IfFalse(iff_is_long_payload));
+            result = AddI(MulI(intcon(31), result), ConvL2I(obj_extracted));
+            fast_path_result->init_req(2, result);
+            long_not_long_region->init_req(2, IfFalse(iff_is_long_payload));
 
-      result = AddI(MulI(intcon(31), result), ConvL2I(URShiftL(obj_extracted, intcon(32))));
-      fast_path_result->init_req(3, result);
-      long_not_long_region->init_req(3, IfTrue(iff_is_long_payload));
+            result = AddI(MulI(intcon(31), result), ConvL2I(URShiftL(obj_extracted, intcon(32))));
+            fast_path_result->init_req(3, result);
+            long_not_long_region->init_req(3, IfTrue(iff_is_long_payload));
 
-      fast_path_result = AndI(_gvn.transform(fast_path_result), intcon(markWord::hash_mask));
+            fast_path_result = AndI(_gvn.transform(fast_path_result), intcon(markWord::hash_mask));
 
-      result_reg->init_req(_inline_fast_path, _gvn.transform(long_not_long_region));
-      result_val->init_req(_inline_fast_path, fast_path_result);
+            result_reg->init_req(_inline_fast_path, _gvn.transform(long_not_long_region));
+            result_val->init_req(_inline_fast_path, fast_path_result);
+          }
+        }
+      }
     } else {
       slow_region->add_req(control());
     }
@@ -5685,6 +5686,7 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
     CallJavaNode* slow_call = generate_method_call(hashCode_id, is_virtual, is_static, false);
     slow_call->set_req(TypeFunc::Parms, obj);
     Node* slow_result = set_results_for_java_call(slow_call);
+    assert(hashcode_fast_path_if_from_identity_hash_code_call(&_gvn, slow_call) == fast_path_iff, "");
     // this->control() comes from set_results_for_java_call
     result_reg->init_req(_slow_path, control());
     result_val->init_req(_slow_path, slow_result);
@@ -5698,6 +5700,73 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
 
   set_result(result_reg, result_val);
   return true;
+}
+IfNode* LibraryCallKit::hashcode_fast_path_if_from_identity_hash_code_call(PhaseGVN* phase, CallJavaNode* call) {
+  auto is_con_offset = [](Node* node, ByteSize n) -> bool {
+    if (!node->is_Con()) return false;
+    TypeNode* con = node->as_Type();
+    assert(con->type()->is_intptr_t(), "");
+    return con->type()->is_intptr_t()->is_con(in_bytes(n));
+  };
+
+  assert(call->in(TypeFunc::Control) != nullptr, "");
+  if (!call->in(TypeFunc::Control)->is_Region()) return nullptr;
+  RegionNode* region = call->in(TypeFunc::Control)->as_Region();
+  for (uint i = 1; i < region->req(); i++) {
+    assert(region->in(i) != nullptr, "");
+    if (!region->in(i)->is_IfProj()) continue;
+    IfProjNode* if_proj = region->in(i)->as_IfProj();
+    if (if_proj->_con != 1) continue;
+
+    assert(if_proj->in(0) != nullptr, "");
+    assert(if_proj->in(0)->is_If(), "");
+    IfNode* iff = if_proj->in(0)->as_If();
+
+    assert(iff->in(1) != nullptr, "");
+    if (!iff->in(1)->is_Bool()) continue;
+    BoolNode* lt = iff->in(1)->as_Bool();
+    if (lt->_test._test != BoolTest::lt) continue;
+
+    assert(lt->in(1) != nullptr, "");
+    if (lt->in(1)->Opcode() != Op_CmpI) continue;
+    CmpNode* cmp_i = lt->in(1)->as_Cmp();
+
+    assert(cmp_i->in(1) != nullptr, "");
+    assert(cmp_i->in(2) != nullptr, "");
+
+    if (cmp_i->in(1)->Opcode() != Op_LoadI) continue;
+    LoadNode* load_offset = cmp_i->in(1)->as_Load();
+    if (!cmp_i->in(2)->is_ConI()) continue;
+    ConINode* zero_i = cmp_i->in(2)->as_ConI();
+    assert(zero_i->type()->is_int() != nullptr, "");
+    if (!zero_i->type()->is_int()->is_con(0)) continue;
+
+    assert(load_offset->in(2) != nullptr, "");
+    if (!load_offset->in(2)->is_AddP()) continue;
+    AddPNode* offset_addr_add = load_offset->in(2)->as_AddP();
+
+    assert(offset_addr_add->in(AddPNode::Base) != nullptr, "");
+    assert(offset_addr_add->in(AddPNode::Address) != nullptr, "");
+    assert(offset_addr_add->in(AddPNode::Offset) != nullptr, "");
+    if (!offset_addr_add->in(AddPNode::Base)->is_top()) continue;
+    if (offset_addr_add->in(AddPNode::Address)->Opcode() != Op_LoadP) continue;
+    LoadNode* load_members = offset_addr_add->in(AddPNode::Address)->as_Load();
+    if (!is_con_offset(offset_addr_add->in(AddPNode::Offset), InlineKlass::fast_hashcode_offset_offset())) continue;
+
+    assert(load_members->in(2) != nullptr, "");
+    if (!load_members->in(2)->is_AddP()) continue;
+    AddPNode* members_addr_add = load_members->in(2)->as_AddP();
+
+    assert(members_addr_add->in(AddPNode::Base) != nullptr, "");
+    assert(members_addr_add->in(AddPNode::Address) != nullptr, "");
+    assert(members_addr_add->in(AddPNode::Offset) != nullptr, "");
+    if (!members_addr_add->in(AddPNode::Base)->is_top()) continue;
+    if (!phase->type(members_addr_add->in(AddPNode::Address))->isa_instklassptr()) continue;
+    if (!is_con_offset(members_addr_add->in(AddPNode::Offset), InlineKlass::adr_members_offset())) continue;
+
+    return iff;
+  }
+  return nullptr;
 }
 
 //---------------------------inline_native_getClass----------------------------

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -315,6 +315,9 @@ class LibraryCallKit : public GraphKit {
   void hashcode_is_safe_to_read(Node* header, RegionNode* unsafe);
   Node* get_hashcode_from_header(Node* header, RegionNode* unset_region);
   bool inline_native_hashcode(bool is_virtual, bool is_static);
+public:
+  static IfNode* hashcode_fast_path_if_from_identity_hash_code_call(PhaseGVN* phase, CallJavaNode* call);
+private:
   bool inline_native_getClass();
 
   // Helper functions for inlining arraycopy

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -312,6 +312,8 @@ class LibraryCallKit : public GraphKit {
   bool inline_native_clone(bool is_virtual);
   bool inline_native_Reflection_getCallerClass();
   // Helper function for inlining native object hash method
+  void hashcode_is_safe_to_read(Node* header, RegionNode* unsafe);
+  Node* get_hashcode_from_header(Node* header, RegionNode* unset_region);
   bool inline_native_hashcode(bool is_virtual, bool is_static);
   bool inline_native_getClass();
 

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2332,11 +2332,10 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
     Node* offset_addr = off_heap_plus_addr(members, in_bytes(InlineKlass::fast_acmp_offset_offset()));
     Node* offset = make_load(control(), offset_addr, TypeInt::INT, T_INT, MemNode::unordered);
 
-    Node* offset_cmp = CmpI(offset, zerocon(T_INT));
-    Node* offset_bol = _gvn.transform(new BoolNode(offset_cmp, BoolTest::lt));
+    Node* offset_bol = BoolCmpI(offset, BoolTest::lt, zerocon(T_INT));
     mask_iff = create_and_map_if(control(), offset_bol, PROB_FAIR, COUNT_UNKNOWN);
-    Node* slow_path_ctl = _gvn.transform(new IfTrueNode(mask_iff));
-    Node* fast_path_ctl = _gvn.transform(new IfFalseNode(mask_iff));
+    Node* slow_path_ctl = IfTrue(mask_iff);
+    Node* fast_path_ctl = IfFalse(mask_iff);
     set_control(slow_path_ctl);
 
     {
@@ -2350,11 +2349,11 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
       // *(left + offset) & mask == *(right + offset) & mask
       Node* left_payload_addr = basic_plus_adr(not_null_left, offset_l);
       Node* left_payload = make_load(control(), left_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
-      Node* left_masked = _gvn.transform(new AndLNode(left_payload, fast_acmp_mask));
+      Node* left_masked = AndL(left_payload, fast_acmp_mask);
 
       Node* right_payload_addr = basic_plus_adr(not_null_right, offset_l);
       Node* right_payload = make_load(control(), right_payload_addr, TypeLong::LONG, T_LONG, MemNode::unordered, LoadNNode::DependsOnlyOnTest, false, true, true, true);
-      Node* right_masked = _gvn.transform(new AndLNode(right_payload, fast_acmp_mask));
+      Node* right_masked = AndL(right_payload, fast_acmp_mask);
 
       Node* masked_cmp = CmpL(left_masked, right_masked);
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3533,6 +3533,7 @@ jint Arguments::apply_ergo() {
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseNullFreeAtomicValueFlattening);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseNullableNonAtomicValueFlattening);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseAcmpFastPath);
+    DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(UseHashcodeFastPath);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(PrintInlineLayout);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(PrintFlatArrayLayout);
     DISABLE_FLAG_AND_WARN_IF_NOT_DEFAULT(IgnoreAssertUnsetFields);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2050,6 +2050,9 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, UseAcmpFastPath, true, DIAGNOSTIC,                          \
           "Use fast path for acmp.")                                        \
+                                                                            \
+  product(bool, UseHashcodeFastPath, true, DIAGNOSTIC,                      \
+          "Use fast path for identityHashCode.")                            \
 
 // end of RUNTIME_FLAGS
 

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -127,7 +127,7 @@ final class ValueObjectMethods {
         if (VERBOSE) {
             System.out.println("valueObjectHashCode: obj.getClass:" + obj.getClass().getName());
         }
-        // This method assumes a is not null and is an instance of a value class
+        // This method assumes obj is not null and is an instance of a value class
         Class<?> type = obj.getClass();
         final Unsafe U = UNSAFE;
         int[] map = U.getFieldMap(type);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestHashcodeFastPath.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestHashcodeFastPath.java
@@ -1,0 +1,575 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 0
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 1
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 2
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 3
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 4
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 5
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 6
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 7
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 8
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 9
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 10
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 11
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 12
+ */
+
+/*
+ * @test
+ * @summary Test acmp fast path with value classes
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64")
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class} 13
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import static compiler.lib.generators.Generators.G;
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+import static compiler.lib.ir_framework.IRNode.*;
+
+public class TestHashcodeFastPath {
+    public static void main(String[] args) {
+        Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
+        int idx = Integer.parseInt(args[0]);
+        Scenario scenario = scenarios[idx % 7];
+        if (idx / 7 == 1) {
+            scenario.addFlags("-XX:-UseHashcodeFastPath");
+        }
+        scenario.addFlags("-XX:CompileCommand=exclude,*::h");
+        scenario.addFlags("-XX:+UseNewCode");
+        InlineTypes.getFramework()
+                .addScenarios(scenario)
+                .start();
+    }
+
+    static abstract value class UniquelyDerivedBase {
+    }
+    static value class UniqueDerived extends UniquelyDerivedBase {
+        byte b;
+        UniqueDerived(byte b) {
+            this.b = b;
+        }
+    }
+
+    static abstract value class MultiplyDerivedBase {
+    }
+    static value class Derived extends MultiplyDerivedBase {
+        byte b;
+        Derived(byte b) {
+            this.b = b;
+        }
+    }
+    // Prevents Derived from being the only concrete class under MultiplyDerivedBase
+    static value class EvilDerived extends MultiplyDerivedBase {
+        byte b;
+        EvilDerived(byte b) {
+            this.b = b;
+        }
+    }
+
+    static value class DerivedWrapper {
+        short s;
+        Derived b;
+        DerivedWrapper(byte b, short s) {
+            this.b = new Derived(b);
+            this.s = s;
+        }
+    }
+
+    value record ShortWrapper(short s) {}
+
+    static abstract value class AbstractShort {
+        ShortWrapper s;
+        AbstractShort(int s) {
+            this.s = new ShortWrapper((short)s);
+        }
+
+        public String toString() {
+            return "AbstractShort(" + s + ")";
+        }
+    }
+
+    static value class ShortWithInt extends AbstractShort {
+        int i;
+        ShortWithInt(int s, int i) {
+            this.i = i;
+            super(s);
+        }
+        public String toString() {
+            return "ShortWithInt(s=" + s.s + ", i=" + i + ")";
+        }
+    }
+
+    static value class Empty {}
+
+
+
+    static value class LongLong {
+        long s;
+        long b;
+        LongLong(long s, long b) {
+            this.s = s;
+            this.b = b;
+        }
+    }
+    static value class WithOop {
+        String s;
+        WithOop(String s) {
+            this.s = s;
+        }
+    }
+
+    int h(Object o) {
+        return System.identityHashCode(o);
+    }
+
+    @Run(test = {
+            "h_object",
+            "h_unique_derived",
+            "h_uniquely_derived_base",
+            "h_derived",
+            "h_base",
+            "h_derived_hidden_type",
+            "h_short_with_int",
+            "h_short_with_int_hidden_type",
+            "h_with_oop",
+            "h_with_oop_hidden_type",
+    })
+    @Warmup(0)  // We want to prevent profiling
+    public void run() {
+        var wrapper = new DerivedWrapper((byte)0, (short)0xa2a1);
+        var wrapper_ = new DerivedWrapper((byte)0, (short)0xa2a1);
+
+        var derived1 = new Derived((byte)0);
+        var derived_ = new Derived((byte)0);
+        var evilDerived1 = new EvilDerived((byte)1);  // Force class loading
+
+        Asserts.assertEQ(h_object(null), h(null));
+        Asserts.assertEQ(h_object(null), 0);
+        Asserts.assertEQ(h_object(wrapper), h(wrapper_));
+
+        Asserts.assertEQ(h_derived(derived1), h(derived_));
+        Asserts.assertEQ(h_base(derived1), h(derived_));
+        Asserts.assertEQ(h_derived_hidden_type(derived1), h(derived_));
+
+        Asserts.assertEQ(h_base(evilDerived1), h(evilDerived1));
+
+        var uniqueDerived = new UniqueDerived((byte)0);
+        var uniqueDerived_ = new UniqueDerived((byte)0);
+
+        Asserts.assertEQ(h_object(uniqueDerived), h(uniqueDerived_));
+        Asserts.assertEQ(h_unique_derived(uniqueDerived), h(uniqueDerived_));
+        Asserts.assertEQ(h_uniquely_derived_base(uniqueDerived), h(uniqueDerived_));
+
+        var swi = new ShortWithInt(0, 1);
+        var swi_ = new ShortWithInt(0, 1);
+        Asserts.assertEQ(h_object(swi), h(swi_));
+        Asserts.assertEQ(h_short_with_int(swi), h(swi_));
+        Asserts.assertEQ(h_short_with_int_hidden_type(swi), h(swi_));
+
+        var empty = new Empty();
+        var empty_ = new Empty();
+        Asserts.assertEQ(h_object(empty), h(empty_));
+
+        var with_oops = new WithOop("a");
+        var with_oops_ = new WithOop("a");
+        Asserts.assertEQ(h_with_oop(with_oops), h(with_oops_));
+        Asserts.assertEQ(h_with_oop_hidden_type(with_oops), h(with_oops_));
+    }
+
+    static final String IDENTITY_HASHCODE = "identityHashCode";
+
+    static final int URSHIFT_L_COUNT_FOR_CACHE_PATH = 1;  // Shift object header
+    static final int URSHIFT_L_COUNT_FOR_FAST_PATH = 3;  // Shift class header, shift object payload, maybe shift again for long payload
+    static final String CACHE_PATH = "" + URSHIFT_L_COUNT_FOR_CACHE_PATH;
+    static final String CACHE_AND_FAST_PATH = "" + (URSHIFT_L_COUNT_FOR_CACHE_PATH + URSHIFT_L_COUNT_FOR_FAST_PATH);
+
+    // Get hashcode fast path
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "true"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "true"})
+    int h_object(Object a) {
+        return System.identityHashCode(a);
+    }
+
+    // No hashcode fast path: the type is precise, and the call will be intrinsified
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_unique_derived(UniqueDerived a) {
+        return System.identityHashCode(a);
+    }
+
+    // No hashcode fast path: single concrete derived, and the call will be intrinsified
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_uniquely_derived_base(UniquelyDerivedBase a) {
+        return System.identityHashCode(a);
+    }
+
+    // No hashcode fast path: the type is precise, and the call will be intrinsified
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_derived(Derived a) {
+        return System.identityHashCode(a);
+    }
+
+    // Hashcode fast path is generated, the type is not precise enough for intrinsifying
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "true"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"UseHashcodeFastPath", "true"})
+    int h_base(MultiplyDerivedBase a) {
+        return System.identityHashCode(a);
+    }
+
+    // Hides the type during parsing when always incrementally inlining
+    @ForceInline
+    public Object getter(Object o) {
+        return o;
+    }
+
+    // With late inlining, type is hidden at first, and a fast path is generated.
+    // Later, type becomes precise, call is intrinsified and fast path is removed.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"AlwaysIncrementalInline", "false"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "true"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_derived_hidden_type(Derived a) {
+        return System.identityHashCode(getter(a));
+    }
+
+    // No hashcode fast path: the type is precise, and the call will be intrinsified. Fast path wouldn't work anyway because it has a weird size.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_short_with_int(ShortWithInt a) {
+        return System.identityHashCode(a);
+    }
+
+    // With late inlining, type is hidden at first, and a fast path is generated.
+    // Later, type becomes precise, call is intrinsified and fast path is removed.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"AlwaysIncrementalInline", "false"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "true"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_short_with_int_hidden_type(ShortWithInt a) {
+        return System.identityHashCode(getter(a));
+    }
+
+    // No hashcode fast path: the type is precise, and the call will be intrinsified if possible. Fast path wouldn't work anyway because of the oop.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    int h_with_oop(WithOop a) {
+        return System.identityHashCode(a);
+    }
+
+    // With late inlining, type is hidden at first, and a fast path is generated.
+    // Later, type becomes precise, call would be intrinsified if possible. But it's not. Yet, we can also find out the fast path won't work, and it is removed.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"AlwaysIncrementalInline", "false"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "true"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    int h_with_oop_hidden_type(WithOop a) {
+        return System.identityHashCode(getter(a));
+    }
+
+    // Only null path should exist
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, failOn = {URSHIFT_L, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_null() {
+        return System.identityHashCode(null);
+    }
+
+    // Only null path should survive
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, failOn = {URSHIFT_L, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE}, applyIf = {"AlwaysIncrementalInline", "false"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "true"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, failOn = {URSHIFT_L, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_null_hidden_type() {
+        return System.identityHashCode(getter(null));
+    }
+
+    @Run(test = {
+            "h_byte",
+            "h_short",
+            "h_int",
+            "h_long",
+            "h_long_long",
+            "h_short_with_int2",
+            "h_short_with_int_hidden_type2",
+            "h_with_oop2",
+    })
+    public void run2() {
+        int SIZE = 100;
+        for (int i = 0; i < SIZE; ++i) {
+            Asserts.assertEQ(h_byte(new Byte((byte)i)), h(new Byte((byte)i)));
+        }
+        for (int i = 256; i < 256 + SIZE; ++i) {
+            Asserts.assertEQ(h_short(new Short((short)i)), h(new Short((short)i)));
+            Asserts.assertEQ(h_int(new Integer(i)), h(new Integer(i)));
+            Asserts.assertEQ(h_long(new Long(i)), h(new Long(i)));
+            Asserts.assertEQ(h_long_long(new LongLong(i, i)), h(new LongLong(i, i)));
+            Asserts.assertEQ(h_long_long(new LongLong((((long)i) << 32L) + i, Long.MAX_VALUE - i)), h(new LongLong((((long)i) << 32L) + i, Long.MAX_VALUE - i)));
+            Asserts.assertEQ(h_short_with_int2(new ShortWithInt(i, i)), h(new ShortWithInt(i, i)));
+            Asserts.assertEQ(h_short_with_int_hidden_type2(new ShortWithInt(i, i)), h(new ShortWithInt(i, i)));
+            String s = String.valueOf(i);
+            Asserts.assertEQ(h_with_oop2(new WithOop(s)), h(new WithOop(s)));
+
+            Long l = new Long(i);
+            int expected_hash = h(l);
+            Asserts.assertEQ(h_long(l), expected_hash);
+        }
+
+        short s = G.ints().next().shortValue();
+        Asserts.assertEQ(h_short(new Short(s)), h(new Short(s)));
+        int i = G.ints().next();
+        Asserts.assertEQ(h_int(new Integer(i)), h(new Integer(i)));
+        long l = G.longs().next();
+        Asserts.assertEQ(h_long(new Long(l)), h(new Long(l)));
+        Asserts.assertEQ(h_long_long(new LongLong(i, i)), h(new LongLong(i, i)));
+        Asserts.assertEQ(h_short_with_int2(new ShortWithInt(i, i)), h(new ShortWithInt(i, i)));
+        Asserts.assertEQ(h_short_with_int_hidden_type2(new ShortWithInt(i, i)), h(new ShortWithInt(i, i)));
+        String str = String.valueOf(i);
+        Asserts.assertEQ(h_with_oop2(new WithOop(str)), h(new WithOop(str)));
+
+        Long lon = new Long(i);
+        int expected_hash = h(lon);
+        Asserts.assertEQ(h_long(lon), expected_hash);
+    }
+
+    // TODO: complicated structure, static expansion, random values with/without late removal of fast path
+    // TODO: all the simple structures, fast path taken if enabled
+    // TODO: example with oops, no fast path taken, no expansion
+
+    // Statically expanded
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_byte(Byte a) {
+        return System.identityHashCode(a);
+    }
+    // Statically expanded
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_short(Short a) {
+        return System.identityHashCode(a);
+    }
+    // Statically expanded
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_int(Integer a) {
+        return System.identityHashCode(a);
+    }
+    // Statically expanded
+    public static final String CACHE_PATH_AND_ONE_LONG_IN_INTRINSIC = "" + (URSHIFT_L_COUNT_FOR_CACHE_PATH + 1);
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH_AND_ONE_LONG_IN_INTRINSIC}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_long(Long a) {
+        return System.identityHashCode(a);
+    }
+    // Statically expanded
+    public static final String CACHE_PATH_AND_TWO_LONG_IN_INTRINSIC = "" + (URSHIFT_L_COUNT_FOR_CACHE_PATH + 2);
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH_AND_TWO_LONG_IN_INTRINSIC}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_long_long(LongLong a) {
+        return System.identityHashCode(a);
+    }
+
+    // No hashcode fast path: the type is precise, and the call will be intrinsified. Fast path wouldn't work anyway because it has a weird size.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_short_with_int2(ShortWithInt a) {
+        return System.identityHashCode(a);
+    }
+
+    // With late inlining, type is hidden at first, and a fast path is generated.
+    // Later, type becomes precise, call is intrinsified and fast path is removed.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIf = {"AlwaysIncrementalInline", "false"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_AND_FAST_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "true"})
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"}, applyIfAnd = {"AlwaysIncrementalInline", "true", "UseHashcodeFastPath", "false"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH}, failOn = {STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE})
+    int h_short_with_int_hidden_type2(ShortWithInt a) {
+        return System.identityHashCode(getter(a));
+    }
+
+    // No hashcode fast path: the type is precise, and the call will be intrinsified if possible. Fast path wouldn't work anyway because of the oop.
+    @Test
+    @IR(phase = {CompilePhase.AFTER_PARSING}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    @IR(phase = {CompilePhase.PRINT_IDEAL}, counts = {URSHIFT_L, CACHE_PATH, STATIC_CALL_OF_METHOD, IDENTITY_HASHCODE, "1"})
+    int h_with_oop2(WithOop a) {
+        return System.identityHashCode(a);
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestHashcodeFastPath.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestHashcodeFastPath.java
@@ -192,7 +192,6 @@ public class TestHashcodeFastPath {
             scenario.addFlags("-XX:-UseHashcodeFastPath");
         }
         scenario.addFlags("-XX:CompileCommand=exclude,*::h");
-        scenario.addFlags("-XX:+UseNewCode");
         InlineTypes.getFramework()
                 .addScenarios(scenario)
                 .start();

--- a/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
+++ b/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
@@ -35,6 +35,8 @@ import java.util.concurrent.TimeUnit;
 public class FastPath {
     public static final int SIZE = 100;
 
+    // TODO try the cache path
+
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     private static int hash(Object obj) {
         return System.identityHashCode(obj);
@@ -45,72 +47,40 @@ public class FastPath {
         return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int hash_specialized(Byte[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    private static int hash_specialized(Byte obj) {
+        return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int hash_specialized(Short[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    private static int hash_specialized(Short obj) {
+        return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int hash_specialized(Integer[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    private static int hash_specialized(Integer obj) {
+        return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int hash_specialized(Long[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    private static int hash_specialized(Long obj) {
+        return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int hash_specialized(MyIntInt[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    private static int hash_specialized(MyIntInt obj) {
+        return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int hash_specialized(MyLongInt[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    private static int hash_specialized(MyLongInt obj) {
+        return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     private static int hash_specialized(MyLongLong obj) {
         return System.identityHashCode(obj);
     }
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int hash_specialized(MyByteShort[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    private static int hash_specialized(WithOop obj) {
+        return System.identityHashCode(obj);
     }
-    @CompilerControl(CompilerControl.Mode.INLINE)
-    private static int hash_inline(Object[] objects) {
-        int s = 0;
-        for (int i = 0; i < SIZE; i++) {
-            s += System.identityHashCode(objects[i]);
-        }
-        return s;
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(MyByteShort obj) {
+        return System.identityHashCode(obj);
     }
 
     // Homogeneous array of null, all go to null path
@@ -126,13 +96,17 @@ public class FastPath {
     }
 
     // Homogeneous array of empty object, all go to fast path
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public int no_hoist() {
+        return hash(new Empty());
+    }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
     public int homogeneous_empty() {
         int s = System.identityHashCode(Empty.class);
         for (int i = 0; i < SIZE; i++) {
-            s += hash(new Empty());
+            s += no_hoist();
         }
         return s;
     }
@@ -146,105 +120,171 @@ public class FastPath {
         }
         return s;
     }
-    /*
+
     // Homogeneous array of bytes, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_byte(NumericCase st) {
-        return hash(st.byte_arr);
+    public int homogeneous_byte() {
+        int s = System.identityHashCode(Byte.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new Byte((byte)i));
+        }
+        return s;
     }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_byte_static(NumericCase st) {
-        return hash_specialized((Byte[]) st.byte_arr);
+    public int homogeneous_byte_static() {
+        int s = System.identityHashCode(Byte.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new Byte((byte)i));
+        }
+        return s;
     }
 
     // Homogeneous array of shorts, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_short(NumericCase st) {
-        return hash(st.short_arr);
+    public int homogeneous_short() {
+        int s = System.identityHashCode(Short.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new Short((short)(i + 256)));
+        }
+        return s;
     }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_short_static(NumericCase st) {
-        return hash_specialized((Short[])st.short_arr);
+    public int homogeneous_short_static() {
+        int s = System.identityHashCode(Short.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new Short((short)(i + 256)));
+        }
+        return s;
     }
 
     // Homogeneous array of ints, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_int(NumericCase st) {
-        return hash(st.int_arr);
+    public int homogeneous_int() {
+        int s = System.identityHashCode(Integer.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new Integer(i + 256));
+        }
+        return s;
     }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_int_static(NumericCase st) {
-        return hash_specialized((Integer[])st.int_arr);
+    public int homogeneous_int_static() {
+        int s = System.identityHashCode(Integer.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new Integer(i + 256));
+        }
+        return s;
     }
 
     // Homogeneous array of longs, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_long(NumericCase st) {
-        return hash(st.long_arr);
+    public int homogeneous_long() {
+        int s = System.identityHashCode(Long.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new Long(i + 256));
+        }
+        return s;
     }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_long_static(NumericCase st) {
-        return hash_specialized((Long[])st.long_arr);
+    public int homogeneous_long_static() {
+        int s = System.identityHashCode(Long.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new Long(i + 256));
+        }
+        return s;
     }
 
     // Homogeneous array of pairs of ints, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_int_int(IntIntCase st) {
-        return hash(st.arr);
+    public int homogeneous_int_int() {
+        int s = System.identityHashCode(MyIntInt.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new MyIntInt(i, 2*i));
+        }
+        return s;
     }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_int_int_static(IntIntCase st) {
-        return hash_specialized((MyIntInt[])st.arr);
+    public int homogeneous_int_int_static() {
+        int s = System.identityHashCode(MyIntInt.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new MyIntInt(i, 2*i));
+        }
+        return s;
     }
 
     // Heterogeneous array, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int heterogeneous_small(AllFastPathCase st) {
-        return hash(st.arr);
+    public int heterogeneous_small() {
+        int s = System.identityHashCode(Empty.class);
+        s += System.identityHashCode(Byte.class);
+        s += System.identityHashCode(Short.class);
+        s += System.identityHashCode(Integer.class);
+        s += System.identityHashCode(Long.class);
+        s += System.identityHashCode(MyIntInt.class);
+        for (int i = 0; i < SIZE; i++) {
+            Object v = switch (i % 7) {
+                case 0 -> new Empty();
+                case 1 -> new Byte((byte) i);
+                case 2 -> new Short((short) (i + 256));
+                case 3 -> new Integer(i + 256);
+                case 4 -> new Long(i + 256);
+                case 5 -> new MyIntInt(i, 2 * i);
+                default -> null;
+            };
+            s += hash(v);
+        }
+        return s;
     }
 
     // Homogeneous array of pairs of long and int, too big for fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_too_big_long_int(LongIntCase st) {
-        return hash(st.arr);
+    public int homogeneous_too_big_long_int() {
+        int s = System.identityHashCode(MyLongInt.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new MyLongInt(i, 2*i));
+        }
+        return s;
     }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_too_big_long_int_static(LongIntCase st) {
-        return hash_specialized((MyLongInt[])st.arr);
+    public int homogeneous_too_big_long_int_static() {
+        int s = System.identityHashCode(MyLongInt.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new MyLongInt(i, 2*i));
+        }
+        return s;
     }
-*/
+
     // Homogeneous array of pairs of long, too big for fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
     public int homogeneous_too_big_long_long() {
-        int s = System.identityHashCode(Empty.class);
+        int s = System.identityHashCode(MyLongLong.class);
         for (int i = 0; i < SIZE; i++) {
             s += hash(new MyLongLong(i, 2*i));
         }
@@ -254,203 +294,145 @@ public class FastPath {
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
     public int homogeneous_too_big_long_long_static() {
-        int s = System.identityHashCode(Empty.class);
+        int s = System.identityHashCode(MyLongLong.class);
         for (int i = 0; i < SIZE; i++) {
             s += hash_specialized(new MyLongLong(i, 2*i));
         }
         return s;
     }
-/*
+
     // Heterogeneous array, too big for fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int heterogeneous_too_big(TooBigCase st) {
-        return hash(st.arr);
+    public int heterogeneous_too_big() {
+        int s = System.identityHashCode(MyLongInt.class);
+        s += System.identityHashCode(MyLongLong.class);
+        for (int i = 0; i < SIZE; i++) {
+            Object v = switch (i % 2) {
+                case 0 -> new MyLongInt(i, 2*i);
+                default -> new MyLongLong(i, 2*i);
+            };
+            s += hash(v);
+        }
+        return s;
     }
 
     // Homogeneous array, with oop, so no fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_with_oop(WithOopCase st) {
-        return hash(st.arr);
+    public int homogeneous_with_oop() {
+        int s = System.identityHashCode(WithOop.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new WithOop(i));
+        }
+        return s;
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_with_oop_static() {
+        int s = System.identityHashCode(WithOop.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new WithOop(i));
+        }
+        return s;
     }
 
     // Homogeneous array, not a nice size, so no fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_weird_size(ByteShortCase st) {
-        return hash(st.arr);
+    public int homogeneous_weird_size() {
+        int s = System.identityHashCode(MyByteShort.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new MyByteShort((byte) i, (short) (2*i)));
+        }
+        return s;
     }
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int homogeneous_weird_size_static(ByteShortCase st) {
-        return hash_specialized(st.arr);
+    public int homogeneous_weird_size_static() {
+        int s = System.identityHashCode(MyByteShort.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new MyByteShort((byte) i, (short) (2*i)));
+        }
+        return s;
     }
 
     // Heterogeneous array, identity objects, so no fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int heterogeneous_with_oop(IdentityCase st) {
-        return hash(st.arr);
+    public int heterogeneous_with_oop() {
+        int s = System.identityHashCode(String.class);
+        s += System.identityHashCode(int[].class);
+        for (int i = 0; i < SIZE; i++) {
+            Object v = switch (i % 2) {
+                case 0 -> String.valueOf(i);
+                default -> new int[]{i};
+            };
+            s += hash(v);
+        }
+        return s;
     }
 
     // Heterogeneous array, all of the above
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int big_mix(BigMixCase st) {
-        return hash(st.arr);
-    }
-*/
-    @State(Scope.Thread)
-    public static class NullCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new Object[SIZE];
+    public int big_mix() {
+        int s = System.identityHashCode(Empty.class);
+        s += System.identityHashCode(Byte.class);
+        s += System.identityHashCode(Short.class);
+        s += System.identityHashCode(Integer.class);
+        s += System.identityHashCode(Long.class);
+        s += System.identityHashCode(MyIntInt.class);
+        s += System.identityHashCode(MyLongInt.class);
+        s += System.identityHashCode(MyLongLong.class);
+        s += System.identityHashCode(WithOop.class);
+        s += System.identityHashCode(MyByteShort.class);
+        s += System.identityHashCode(String.class);
+        s += System.identityHashCode(int[].class);
+        for (int i = 0; i < SIZE; i++) {
+            Object v = switch (i % 13) {
+                    case 0 -> new Empty();
+                    case 1 -> new Byte((byte)i);
+                    case 2 -> new Short((short)(i + 256));
+                    case 3 -> new Integer((i + 256));
+                    case 4 -> new Long((i + 256));
+                    case 5 -> new MyIntInt(i, 2*i);
+                    case 6 -> new MyLongInt(i, 2*i);
+                    case 7 -> new MyLongLong(i, 2*i);
+                    case 8 -> new WithOop(i);
+                    case 9 -> new MyByteShort((byte) i, (short)(2*i));
+                    case 10 -> String.valueOf(i);
+                    case 11 -> new int[]{i};
+                    default -> null;
+            };
+            s += hash(v);
         }
+        return s;
     }
 
     static value class Empty {}
-    @State(Scope.Thread)
-    public static class EmptyCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new Empty[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                arr[i] = new Empty();
-            }
-        }
-    }
-
-    @State(Scope.Thread)
-    public static class NumericCase {
-        Object[] byte_arr;
-        Object[] short_arr;
-        Object[] int_arr;
-        Object[] long_arr;
-
-        @Setup
-        public void setup() {
-            byte_arr = new Byte[SIZE];
-            short_arr = new Short[SIZE];
-            int_arr = new Integer[SIZE];
-            long_arr = new Long[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                byte_arr[i] = new Byte((byte)i);
-                short_arr[i] = new Short((short)(i + 256));
-                int_arr[i] = new Integer(i + 256);
-                long_arr[i] = new Long(i + 256);
-            }
-        }
-    }
-
     static value class MyIntInt {
         int fst;
         int snd;
         public MyIntInt (int fst, int snd) {this.fst = fst; this.snd = snd;}
     }
-    @State(Scope.Thread)
-    public static class IntIntCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new MyIntInt[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                arr[i] = new MyIntInt(i, 2*i);
-            }
-        }
-    }
-
-    @State(Scope.Thread)
-    public static class AllFastPathCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new Object[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                switch (i % 7) {
-                    case 0: arr[i] = new Empty(); break;
-                    case 1: arr[i] = new Byte((byte)i); break;
-                    case 2: arr[i] = new Short((short)(i + 256)); break;
-                    case 3: arr[i] = new Integer(i + 256); break;
-                    case 4: arr[i] = new Long(i + 256); break;
-                    case 5: arr[i] = new MyIntInt(i, 2*i); break;
-                    case 6: arr[i] = null; break;
-                }
-            }
-        }
-    }
-
     static value class MyLongInt {
         long fst;
         int snd;
         MyLongInt(long fst, int snd) { this.fst = fst; this.snd = snd; }
     }
-    @State(Scope.Thread)
-    public static class LongIntCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new MyLongInt[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                arr[i] = new MyLongInt(i, 2*i);
-            }
-        }
-    }
-
     static value class MyLongLong {
         long fst;
         long snd;
         MyLongLong(long fst, long snd) { this.fst = fst; this.snd = snd; }
     }
-    @State(Scope.Thread)
-    public static class LongLongCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new MyLongLong[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                arr[i] = new MyLongLong(i, 2*i);
-            }
-        }
-    }
-
-    @State(Scope.Thread)
-    public static class TooBigCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new Object[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                switch (i % 6) {
-                    case 0: arr[i] = new MyLongInt(i, 2*i); break;
-                    case 1: arr[i] = new MyLongLong(i, 2*i); break;
-                }
-            }
-        }
-    }
-
     static value class WithOop {
         Integer[] s;
         WithOop(int i) {
@@ -461,80 +443,9 @@ public class FastPath {
             }
         }
     }
-    @State(Scope.Thread)
-    public static class WithOopCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new Object[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                arr[i] = new WithOop(i);
-            }
-        }
-    }
-
     static value class MyByteShort {
         byte fst;
         short snd;
         MyByteShort(byte fst, short snd) { this.fst = fst; this.snd = snd; }
-    }
-    @State(Scope.Thread)
-    public static class ByteShortCase {
-        MyByteShort[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new MyByteShort[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                arr[i] = new MyByteShort((byte) i, (short) (2*i));
-            }
-        }
-    }
-
-    @State(Scope.Thread)
-    public static class IdentityCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new Object[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                switch (i % 2) {
-                    case 0: arr[i] = String.valueOf(i); break;
-                    case 1: arr[i] = new int[]{i}; break;
-                }
-            }
-        }
-    }
-
-    @State(Scope.Thread)
-    public static class BigMixCase {
-        Object[] arr;
-
-        @Setup
-        public void setup() {
-            arr = new Object[SIZE];
-
-            for (int i = 0; i < SIZE; i++) {
-                switch (i % 12) {
-                    case 0: arr[i] = new Empty(); break;
-                    case 1: arr[i] = new Byte((byte)i); break;
-                    case 2: arr[i] = new Short((short)(i + 256)); break;
-                    case 3: arr[i] = new Integer((i + 256)); break;
-                    case 4: arr[i] = new Long((i + 256)); break;
-                    case 5: arr[i] = new MyIntInt(i, 2*i); break;
-                    case 6: arr[i] = new MyLongInt(i, 2*i); break;
-                    case 7: arr[i] = new MyLongLong(i, 2*i); break;
-                    case 8: arr[i] = new WithOop(i); break;
-                    case 9: arr[i] = new MyByteShort((byte) i, (short)(2*i)); break;
-                    case 10: arr[i] = String.valueOf(i); break;
-                    case 11: arr[i] = new int[]{i}; break;
-                }
-            }
-        }
     }
 }

--- a/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
+++ b/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
@@ -1,0 +1,540 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.valhalla.hash;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 2, jvmArgsAppend = {"--enable-preview", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseNewCode"})
+@Warmup(iterations = 1, time = 1)
+@Measurement(iterations = 3, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Thread)
+public class FastPath {
+    public static final int SIZE = 100;
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash(Object obj) {
+        return System.identityHashCode(obj);
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(Empty obj) {
+        return System.identityHashCode(obj);
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(Byte[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(Short[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(Integer[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(Long[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(MyIntInt[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(MyLongInt[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(MyLongLong obj) {
+        return System.identityHashCode(obj);
+    }
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private static int hash_specialized(MyByteShort[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    private static int hash_inline(Object[] objects) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += System.identityHashCode(objects[i]);
+        }
+        return s;
+    }
+
+    // Homogeneous array of null, all go to null path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_null() {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(null);
+        }
+        return s;
+    }
+
+    // Homogeneous array of empty object, all go to fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_empty() {
+        int s = System.identityHashCode(Empty.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new Empty());
+        }
+        return s;
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_empty_static() {
+        int s = System.identityHashCode(Empty.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new Empty());
+        }
+        return s;
+    }
+    /*
+    // Homogeneous array of bytes, all go to fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_byte(NumericCase st) {
+        return hash(st.byte_arr);
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_byte_static(NumericCase st) {
+        return hash_specialized((Byte[]) st.byte_arr);
+    }
+
+    // Homogeneous array of shorts, all go to fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_short(NumericCase st) {
+        return hash(st.short_arr);
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_short_static(NumericCase st) {
+        return hash_specialized((Short[])st.short_arr);
+    }
+
+    // Homogeneous array of ints, all go to fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_int(NumericCase st) {
+        return hash(st.int_arr);
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_int_static(NumericCase st) {
+        return hash_specialized((Integer[])st.int_arr);
+    }
+
+    // Homogeneous array of longs, all go to fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_long(NumericCase st) {
+        return hash(st.long_arr);
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_long_static(NumericCase st) {
+        return hash_specialized((Long[])st.long_arr);
+    }
+
+    // Homogeneous array of pairs of ints, all go to fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_int_int(IntIntCase st) {
+        return hash(st.arr);
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_int_int_static(IntIntCase st) {
+        return hash_specialized((MyIntInt[])st.arr);
+    }
+
+    // Heterogeneous array, all go to fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int heterogeneous_small(AllFastPathCase st) {
+        return hash(st.arr);
+    }
+
+    // Homogeneous array of pairs of long and int, too big for fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_too_big_long_int(LongIntCase st) {
+        return hash(st.arr);
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_too_big_long_int_static(LongIntCase st) {
+        return hash_specialized((MyLongInt[])st.arr);
+    }
+*/
+    // Homogeneous array of pairs of long, too big for fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_too_big_long_long() {
+        int s = System.identityHashCode(Empty.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new MyLongLong(i, 2*i));
+        }
+        return s;
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_too_big_long_long_static() {
+        int s = System.identityHashCode(Empty.class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash_specialized(new MyLongLong(i, 2*i));
+        }
+        return s;
+    }
+/*
+    // Heterogeneous array, too big for fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int heterogeneous_too_big(TooBigCase st) {
+        return hash(st.arr);
+    }
+
+    // Homogeneous array, with oop, so no fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_with_oop(WithOopCase st) {
+        return hash(st.arr);
+    }
+
+    // Homogeneous array, not a nice size, so no fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_weird_size(ByteShortCase st) {
+        return hash(st.arr);
+    }
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_weird_size_static(ByteShortCase st) {
+        return hash_specialized(st.arr);
+    }
+
+    // Heterogeneous array, identity objects, so no fast path
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int heterogeneous_with_oop(IdentityCase st) {
+        return hash(st.arr);
+    }
+
+    // Heterogeneous array, all of the above
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int big_mix(BigMixCase st) {
+        return hash(st.arr);
+    }
+*/
+    @State(Scope.Thread)
+    public static class NullCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Object[SIZE];
+        }
+    }
+
+    static value class Empty {}
+    @State(Scope.Thread)
+    public static class EmptyCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Empty[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                arr[i] = new Empty();
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class NumericCase {
+        Object[] byte_arr;
+        Object[] short_arr;
+        Object[] int_arr;
+        Object[] long_arr;
+
+        @Setup
+        public void setup() {
+            byte_arr = new Byte[SIZE];
+            short_arr = new Short[SIZE];
+            int_arr = new Integer[SIZE];
+            long_arr = new Long[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                byte_arr[i] = new Byte((byte)i);
+                short_arr[i] = new Short((short)(i + 256));
+                int_arr[i] = new Integer(i + 256);
+                long_arr[i] = new Long(i + 256);
+            }
+        }
+    }
+
+    static value class MyIntInt {
+        int fst;
+        int snd;
+        public MyIntInt (int fst, int snd) {this.fst = fst; this.snd = snd;}
+    }
+    @State(Scope.Thread)
+    public static class IntIntCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new MyIntInt[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                arr[i] = new MyIntInt(i, 2*i);
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class AllFastPathCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Object[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                switch (i % 7) {
+                    case 0: arr[i] = new Empty(); break;
+                    case 1: arr[i] = new Byte((byte)i); break;
+                    case 2: arr[i] = new Short((short)(i + 256)); break;
+                    case 3: arr[i] = new Integer(i + 256); break;
+                    case 4: arr[i] = new Long(i + 256); break;
+                    case 5: arr[i] = new MyIntInt(i, 2*i); break;
+                    case 6: arr[i] = null; break;
+                }
+            }
+        }
+    }
+
+    static value class MyLongInt {
+        long fst;
+        int snd;
+        MyLongInt(long fst, int snd) { this.fst = fst; this.snd = snd; }
+    }
+    @State(Scope.Thread)
+    public static class LongIntCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new MyLongInt[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                arr[i] = new MyLongInt(i, 2*i);
+            }
+        }
+    }
+
+    static value class MyLongLong {
+        long fst;
+        long snd;
+        MyLongLong(long fst, long snd) { this.fst = fst; this.snd = snd; }
+    }
+    @State(Scope.Thread)
+    public static class LongLongCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new MyLongLong[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                arr[i] = new MyLongLong(i, 2*i);
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class TooBigCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Object[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                switch (i % 6) {
+                    case 0: arr[i] = new MyLongInt(i, 2*i); break;
+                    case 1: arr[i] = new MyLongLong(i, 2*i); break;
+                }
+            }
+        }
+    }
+
+    static value class WithOop {
+        Integer[] s;
+        WithOop(int i) {
+            if (i % 4 == 0) {
+                this.s = null;
+            } else {
+                this.s = new Integer[]{i};
+            }
+        }
+    }
+    @State(Scope.Thread)
+    public static class WithOopCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Object[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                arr[i] = new WithOop(i);
+            }
+        }
+    }
+
+    static value class MyByteShort {
+        byte fst;
+        short snd;
+        MyByteShort(byte fst, short snd) { this.fst = fst; this.snd = snd; }
+    }
+    @State(Scope.Thread)
+    public static class ByteShortCase {
+        MyByteShort[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new MyByteShort[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                arr[i] = new MyByteShort((byte) i, (short) (2*i));
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class IdentityCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Object[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                switch (i % 2) {
+                    case 0: arr[i] = String.valueOf(i); break;
+                    case 1: arr[i] = new int[]{i}; break;
+                }
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class BigMixCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Object[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                switch (i % 12) {
+                    case 0: arr[i] = new Empty(); break;
+                    case 1: arr[i] = new Byte((byte)i); break;
+                    case 2: arr[i] = new Short((short)(i + 256)); break;
+                    case 3: arr[i] = new Integer((i + 256)); break;
+                    case 4: arr[i] = new Long((i + 256)); break;
+                    case 5: arr[i] = new MyIntInt(i, 2*i); break;
+                    case 6: arr[i] = new MyLongInt(i, 2*i); break;
+                    case 7: arr[i] = new MyLongLong(i, 2*i); break;
+                    case 8: arr[i] = new WithOop(i); break;
+                    case 9: arr[i] = new MyByteShort((byte) i, (short)(2*i)); break;
+                    case 10: arr[i] = String.valueOf(i); break;
+                    case 11: arr[i] = new int[]{i}; break;
+                }
+            }
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
+++ b/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
@@ -26,16 +26,14 @@ import org.openjdk.jmh.annotations.*;
 
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 2, jvmArgsAppend = {"--enable-preview"})
-@Warmup(iterations = 1, time = 1)
-@Measurement(iterations = 3, time = 1)
+@Fork(value = 3, jvmArgsAppend = {"--enable-preview"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.AverageTime)
 @State(Scope.Thread)
 public class FastPath {
     public static final int SIZE = 100;
-
-    // TODO try the cache path
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     private static int hash(Object obj) {

--- a/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
+++ b/test/micro/org/openjdk/bench/valhalla/hash/FastPath.java
@@ -26,7 +26,7 @@ import org.openjdk.jmh.annotations.*;
 
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 2, jvmArgsAppend = {"--enable-preview", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseNewCode"})
+@Fork(value = 2, jvmArgsAppend = {"--enable-preview"})
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 3, time = 1)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -83,7 +83,7 @@ public class FastPath {
         return System.identityHashCode(obj);
     }
 
-    // Homogeneous array of null, all go to null path
+    // Homogeneous cases of null, all go to null path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -95,7 +95,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of empty object, all go to fast path
+    // Homogeneous cases of empty object, all go to fast path
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int no_hoist() {
         return hash(new Empty());
@@ -121,7 +121,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of bytes, all go to fast path
+    // Homogeneous cases of bytes, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -143,7 +143,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of shorts, all go to fast path
+    // Homogeneous cases of shorts, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -165,7 +165,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of ints, all go to fast path
+    // Homogeneous cases of ints, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -187,7 +187,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of longs, all go to fast path
+    // Homogeneous cases of longs, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -209,7 +209,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of pairs of ints, all go to fast path
+    // Homogeneous cases of pairs of ints, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -231,7 +231,7 @@ public class FastPath {
         return s;
     }
 
-    // Heterogeneous array, all go to fast path
+    // Heterogeneous cases, all go to fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -257,7 +257,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of pairs of long and int, too big for fast path
+    // Homogeneous cases of pairs of long and int, too big for fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -279,7 +279,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array of pairs of long, too big for fast path
+    // Homogeneous cases of pairs of long, too big for fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -301,7 +301,7 @@ public class FastPath {
         return s;
     }
 
-    // Heterogeneous array, too big for fast path
+    // Heterogeneous cases, too big for fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -318,7 +318,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array, with oop, so no fast path
+    // Homogeneous cases, with oop, so no fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -340,7 +340,7 @@ public class FastPath {
         return s;
     }
 
-    // Homogeneous array, not a nice size, so no fast path
+    // Homogeneous cases, not a nice size, so no fast path
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -362,11 +362,37 @@ public class FastPath {
         return s;
     }
 
-    // Heterogeneous array, identity objects, so no fast path
+    // Homogeneous cases of String, so fast path not taken
     @Benchmark
     @OperationsPerInvocation(SIZE)
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public int heterogeneous_with_oop() {
+    public int homogeneous_with_obj_string() {
+        int s = System.identityHashCode(String.class);
+        s += System.identityHashCode(int[].class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(String.valueOf(i));
+        }
+        return s;
+    }
+
+    // Homogeneous cases of arrays, so fast path not taken
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int homogeneous_with_obj_array() {
+        int s = System.identityHashCode(String.class);
+        s += System.identityHashCode(int[].class);
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(new int[]{i});
+        }
+        return s;
+    }
+
+    // Heterogeneous array, identity objects, so fast path not taken
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int heterogeneous_with_obj() {
         int s = System.identityHashCode(String.class);
         s += System.identityHashCode(int[].class);
         for (int i = 0; i < SIZE; i++) {
@@ -417,6 +443,18 @@ public class FastPath {
         return s;
     }
 
+    // Array of pre-hashed values, should take the cache path.
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.INLINE)
+    public int pre_hashed(PreHashedCase st) {
+        int s = 0;
+        for (int i = 0; i < SIZE; i++) {
+            s += hash(st.arr[i]);
+        }
+        return s;
+    }
+
     static value class Empty {}
     static value class MyIntInt {
         int fst;
@@ -447,5 +485,20 @@ public class FastPath {
         byte fst;
         short snd;
         MyByteShort(byte fst, short snd) { this.fst = fst; this.snd = snd; }
+    }
+
+    @State(Scope.Thread)
+    public static class PreHashedCase {
+        Object[] arr;
+
+        @Setup
+        public void setup() {
+            arr = new Object[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                arr[i] = new MyLongLong(((long)i) << 32, i);
+                System.identityHashCode(arr[i]);
+            }
+        }
     }
 }


### PR DESCRIPTION
It is conceptually very similar to acmp: it has two parts.

# Static Expansion

If the operand of `identityHashCode` is known at compile-time, we can basically inline the implementation of `ValueObjectMethods.valueObjectHashCode`. There are a few points worth noting.
1. The seed of the hash is the hash of the mirror class object. That object is not a value object, but an identity class. We look in the header of the said class whether it was cached already, which is very likely. Otherwise, we give up the static expansion: it is not worth replacing a call with a call.
2. Oops are hell. We don't expand when oops are involved.
3. The runtime implementation performs some unsafe gets to get all pieces of a segment in a simple, greedy way. Which means that in the case we have a value class made of 2 `int`, the likely outcome is that it would get both at once with a single call to `getLong`. This is fine, we can do that, but we need to mark the access as mismatch and unsafe (but aligned, since the acmp maps are smartly done). But in the case we have a class made of a single `int`, it would be unfortunate to mark the `getInt` access as mismatch since it prevents some optimizations. So if we are getting exactly a field, we detect it, and we mark the load as non-mismatch (match?).

# Fast Path

This supports only objects with a simple shape: one segment of data, being 1, 2, 4 or 8-byte long, which is enough to cover many migrated classes (but not dates for instance). This feature is morally very similar to the acmp fast path. It is controlled by the diagnostic flag `UseHashcodeFastPath`. Alike acmp, we need to sabotage the fast path in case we can do a static expansion later.

I can only suggest you take a look at `inlineKlass.hpp` on how that works.

# Benchmarking

Microbenchmarking is rather unsurprising:
- haven't changed:
  - `null` was and is still fast (1-2ns)
  - hashcode cached in the header was and is still fast (2ns)
  - identity objects without cached hashcode are not too slow, and still aren't (20-25ns)
  - known at compile time (60-70ns):
    - value objects with oops
  - unknown at compile time (60-70ns):
    - value objects with sizes that are not 1, 2, 4 or 8
    - value objects with oops
- got better (60-70ns -> 2-7ns):
  - value objects with a type known at compile time, without oops
  - value objects with a type unknown at compile time, without oops, of size 1, 2, 4 or 8.


<details>
<summary>Full results of <tt>valhalla.hash.FastPath</tt></summary>

Before:
```
Benchmark                                      Mode  Cnt   Score   Error  Units
FastPath.big_mix                               avgt   15  49.680 ± 0.628  ns/op
FastPath.heterogeneous_small                   avgt   15  48.337 ± 0.865  ns/op
FastPath.heterogeneous_too_big                 avgt   15  57.891 ± 0.652  ns/op
FastPath.heterogeneous_with_obj                avgt   15  22.411 ± 0.323  ns/op
FastPath.homogeneous_byte                      avgt   15  56.707 ± 1.043  ns/op
FastPath.homogeneous_byte_static               avgt   15  57.202 ± 1.102  ns/op
FastPath.homogeneous_empty                     avgt   15  56.501 ± 1.734  ns/op
FastPath.homogeneous_empty_static              avgt   15  54.758 ± 1.700  ns/op
FastPath.homogeneous_int                       avgt   15  56.281 ± 1.197  ns/op
FastPath.homogeneous_int_int                   avgt   15  57.415 ± 1.268  ns/op
FastPath.homogeneous_int_int_static            avgt   15  56.711 ± 1.197  ns/op
FastPath.homogeneous_int_static                avgt   15  57.024 ± 1.262  ns/op
FastPath.homogeneous_long                      avgt   15  57.192 ± 1.170  ns/op
FastPath.homogeneous_long_static               avgt   15  56.798 ± 1.375  ns/op
FastPath.homogeneous_null                      avgt   15   1.371 ± 0.040  ns/op
FastPath.homogeneous_short                     avgt   15  58.196 ± 1.259  ns/op
FastPath.homogeneous_short_static              avgt   15  58.724 ± 1.449  ns/op
FastPath.homogeneous_too_big_long_int          avgt   15  61.896 ± 2.272  ns/op
FastPath.homogeneous_too_big_long_int_static   avgt   15  59.864 ± 1.394  ns/op
FastPath.homogeneous_too_big_long_long         avgt   15  59.559 ± 1.188  ns/op
FastPath.homogeneous_too_big_long_long_static  avgt   15  59.124 ± 1.078  ns/op
FastPath.homogeneous_weird_size                avgt   15  60.049 ± 1.678  ns/op
FastPath.homogeneous_weird_size_static         avgt   15  59.820 ± 1.373  ns/op
FastPath.homogeneous_with_obj_array            avgt   15  22.113 ± 0.757  ns/op
FastPath.homogeneous_with_obj_string           avgt   15  23.866 ± 0.444  ns/op
FastPath.homogeneous_with_oop                  avgt   15  71.719 ± 1.863  ns/op
FastPath.homogeneous_with_oop_static           avgt   15  71.977 ± 1.539  ns/op
FastPath.pre_hashed                            avgt   15   1.906 ± 0.054  ns/op
```

After:
```
Benchmark                                      Mode  Cnt   Score   Error  Units
FastPath.big_mix                               avgt   15  27.101 ± 0.519  ns/op
FastPath.heterogeneous_small                   avgt   15   5.175 ± 0.104  ns/op
FastPath.heterogeneous_too_big                 avgt   15  62.371 ± 1.041  ns/op
FastPath.heterogeneous_with_obj                avgt   15  23.229 ± 0.408  ns/op
FastPath.homogeneous_byte                      avgt   15   5.878 ± 0.071  ns/op
FastPath.homogeneous_byte_static               avgt   15   2.407 ± 0.054  ns/op
FastPath.homogeneous_empty                     avgt   15   3.459 ± 0.082  ns/op
FastPath.homogeneous_empty_static              avgt   15   2.156 ± 0.047  ns/op
FastPath.homogeneous_int                       avgt   15   5.916 ± 0.044  ns/op
FastPath.homogeneous_int_int                   avgt   15   7.530 ± 0.076  ns/op
FastPath.homogeneous_int_int_static            avgt   15   7.120 ± 0.109  ns/op
FastPath.homogeneous_int_static                avgt   15   2.117 ± 0.035  ns/op
FastPath.homogeneous_long                      avgt   15   3.668 ± 0.072  ns/op
FastPath.homogeneous_long_static               avgt   15   2.211 ± 0.055  ns/op
FastPath.homogeneous_null                      avgt   15   1.415 ± 0.042  ns/op
FastPath.homogeneous_short                     avgt   15   5.832 ± 0.058  ns/op
FastPath.homogeneous_short_static              avgt   15   2.099 ± 0.025  ns/op
FastPath.homogeneous_too_big_long_int          avgt   15  62.184 ± 1.775  ns/op
FastPath.homogeneous_too_big_long_int_static   avgt   15   2.536 ± 0.033  ns/op
FastPath.homogeneous_too_big_long_long         avgt   15  60.679 ± 1.968  ns/op
FastPath.homogeneous_too_big_long_long_static  avgt   15   2.894 ± 0.103  ns/op
FastPath.homogeneous_weird_size                avgt   15  60.444 ± 1.753  ns/op
FastPath.homogeneous_weird_size_static         avgt   15   2.410 ± 0.039  ns/op
FastPath.homogeneous_with_obj_array            avgt   15  22.019 ± 0.359  ns/op
FastPath.homogeneous_with_obj_string           avgt   15  24.011 ± 0.332  ns/op
FastPath.homogeneous_with_oop                  avgt   15  73.037 ± 1.287  ns/op
FastPath.homogeneous_with_oop_static           avgt   15  74.006 ± 2.115  ns/op
FastPath.pre_hashed                            avgt   15   1.888 ± 0.063  ns/op
```
</details>

On real benchmark, improvements are noticeable only on hash-intensive cases.

# Future Work

We can also add profiling and speculate on the type of the argument, as we do for acmp. That is left as an exercise for the reader.

The current implementation of both the static expansion and the fast path are not caching the result in the header. There are a few reasons for that:
1. It is not clear it is worth it.
2. It is non-trivial to do only when there is already a buffer, to avoid keeping an allocation around just for that. This will be easier in the future, with a macro-based hashcode, where the expansion would do the storing only if something else kept the buffer alive (or already exists). With that, we also would need not to remove the fast path after static expansion.
3. It is non-trivial to store something in the header while being race-safe. It probably needs cooperation of the backend to do something alike `JVM_IHashCode`.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8252185](https://bugs.openjdk.org/browse/JDK-8252185): [lworld] Improve performance of identityHashCode for value objects (**Enhancement** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2642/head:pull/2642` \
`$ git checkout pull/2642`

Update a local copy of the PR: \
`$ git checkout pull/2642` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2642`

View PR using the GUI difftool: \
`$ git pr show -t 2642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2642.diff">https://git.openjdk.org/valhalla/pull/2642.diff</a>

</details>
