### PR TITLE
8388256: [lworld] Clone of reference array is broken in C2

### DIFF
--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -237,14 +237,18 @@ ObjArrayKlass* ObjArrayKlass::allocate_klass_from_description(ArrayDescription a
 }
 
 objArrayOop ObjArrayKlass::allocate_instance(int length, ArrayProperties props, TRAPS) {
-  check_array_allocation_length(length, arrayOopDesc::max_array_length(T_OBJECT), CHECK_NULL);
   ObjArrayKlass* ak = klass_with_properties(props, CHECK_NULL);
-  switch (ak->kind()) {
+  return ak->allocate_instance(length, CHECK_NULL);
+}
+
+objArrayOop ObjArrayKlass::allocate_instance(int length, TRAPS) {
+  check_array_allocation_length(length, arrayOopDesc::max_array_length(T_OBJECT), CHECK_NULL);
+  switch (kind()) {
     case Klass::RefArrayKlassKind:
-      return RefArrayKlass::cast(ak)->allocate_instance(length, CHECK_NULL);
+      return RefArrayKlass::cast(this)->allocate_instance(length, CHECK_NULL);
 
     case Klass::FlatArrayKlassKind:
-      return FlatArrayKlass::cast(ak)->allocate_instance(length, CHECK_NULL);
+      return FlatArrayKlass::cast(this)->allocate_instance(length, CHECK_NULL);
 
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -100,6 +100,7 @@ class ObjArrayKlass : public ArrayKlass {
                                                 int n, Klass* element_klass, TRAPS);
 
   oop multi_allocate(int rank, jint* sizes, TRAPS) override;
+  objArrayOop allocate_instance(int length, TRAPS);
 
   // Copying
   void copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos, int length, TRAPS) override;

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -363,8 +363,8 @@ JRT_BLOCK_ENTRY(void, OptoRuntime::new_array_C(Klass* array_type, int len, oopDe
     result = oopFactory::new_typeArray(elem_type, len, THREAD);
   } else {
     Handle holder(current, array_type->klass_holder()); // keep the array klass alive
-    ObjArrayKlass* oak = ObjArrayKlass::cast(array_type);
-    result = oopFactory::new_objArray(oak->element_klass(), len, oak->properties(), THREAD);
+    result = ObjArrayKlass::cast(array_type)->allocate_instance(len, THREAD);
+    assert(HAS_PENDING_EXCEPTION || result->klass() == array_type, "array klass must be preserved");
     if (!HAS_PENDING_EXCEPTION && array_type->is_null_free_array_klass() && !h_init_val.is_null()) {
       // Null-free arrays need to be initialized
 #ifdef ASSERT

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestReferenceArrayClone.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestReferenceArrayClone.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify that clone preserves the layout of reference arrays.
+ * @bug 8388256
+ * @requires vm.compiler2.enabled
+ * @library /test/lib /
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @run main ${test.main.class}
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:-UseTLAB
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::testClone
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+import jdk.test.lib.Asserts;
+
+public class TestReferenceArrayClone {
+    static Integer[] testClone(Integer[] a) {
+        return a.clone();
+    }
+
+    public static void main(String[] args) {
+        Integer[] array = (Integer[])ValueClass.newReferenceArray(Integer.class, 1);
+        array[0] = 42;
+        array = testClone(array);
+        Asserts.assertEQ(array[0], 42, "unexpected element");
+        Asserts.assertFalse(ValueClass.isFlatArray(array), "should not be flat");
+        Asserts.assertFalse(ValueClass.isNullRestrictedArray(array), "should not be null-restricted");
+        Asserts.assertTrue(ValueClass.isAtomicArray(array), "should be atomic");
+    }
+}


### PR DESCRIPTION
The slow path of C2's clone intrinsic calls `OptoRuntime::new_array_C` which reconstructs the array klass from its element klass and properties through this path:

https://github.com/openjdk/valhalla/blob/0b66ce5e7725fc4c120532694a764c8195f91361/src/hotspot/share/memory/oopFactory.cpp#L113-L116

->

https://github.com/openjdk/valhalla/blob/0b66ce5e7725fc4c120532694a764c8195f91361/src/hotspot/share/oops/objArrayKlass.cpp#L239-L241

For the array klass of a reference array, created through `ValueClass.newReferenceArray`, with nullable + atomic properties, a `FlatArrayKlass` is selected. As a result, we clone from a reference array into a flat array and things are going south.

The fix is to select based on the klass, not the properties. In the test, I use `-XX:-UseTLAB` to trigger the slow path reliably.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388256](https://bugs.openjdk.org/browse/JDK-8388256): [lworld] Clone of reference array is broken in C2 (**Bug** - P3)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2644/head:pull/2644` \
`$ git checkout pull/2644`

Update a local copy of the PR: \
`$ git checkout pull/2644` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2644`

View PR using the GUI difftool: \
`$ git pr show -t 2644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2644.diff">https://git.openjdk.org/valhalla/pull/2644.diff</a>

</details>
