### PR TITLE
8388343: [lworld] Reevaluate the enable-preview in memory compilation from VM arguments

### DIFF
--- a/test/lib/jdk/test/lib/compiler/InMemoryJavaCompiler.java
+++ b/test/lib/jdk/test/lib/compiler/InMemoryJavaCompiler.java
@@ -258,22 +258,6 @@ public class InMemoryJavaCompiler {
                 opts.add(opt);
             }
         }
-
-        // Add in preview mode if -Dtest.java.opts
-        String testOpts = System.getProperty("test.java.opts", "");
-        if (testOpts.contains("--enable-preview")) {
-            opts.add("--enable-preview");
-            opts.add("-source");
-            opts.add(Integer.toString(Runtime.version().feature()));
-        } else {
-            String preview = System.getProperty("test.enable.preview", "");
-            if (preview.equals("true")) {
-                opts.add("--enable-preview");
-                opts.add("-source");
-                opts.add(Integer.toString(Runtime.version().feature()));
-            }
-        }
-
         try (FileManagerWrapper fileManager = new FileManagerWrapper(file, moduleOverride)) {
             CompilationTask task = getCompiler().getTask(null, fileManager, null, opts, null, Arrays.asList(file));
             if (!task.call()) {


### PR DESCRIPTION
When the JVM of javac runs with -J--enable-preview, javac should still compile against the non-preview class path when it is not passed --enable-preview. We have this hack within InMemoryJavaCompiler that turns out breaks things when we try to fix some javac issues (#2643), because we expect the output bytecode to be stable for transformations.

Turns out now this change is redundant. Tier 1-6 is clear so far except the known CreateCoreDumpOnCrash.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388343](https://bugs.openjdk.org/browse/JDK-8388343): [lworld] Reevaluate the enable-preview in memory compilation from VM arguments (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2645/head:pull/2645` \
`$ git checkout pull/2645`

Update a local copy of the PR: \
`$ git checkout pull/2645` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2645`

View PR using the GUI difftool: \
`$ git pr show -t 2645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2645.diff">https://git.openjdk.org/valhalla/pull/2645.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2645#issuecomment-4985016523)
</details>
