### PR TITLE
8388380: [lworld] Improve the documentation of jdk.internal.value.Deserializer annotation

### DIFF
--- a/src/java.base/share/classes/jdk/internal/value/Deserializer.java
+++ b/src/java.base/share/classes/jdk/internal/value/Deserializer.java
@@ -38,7 +38,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * <p>
  * Non-record value classes, unless they implement the {@code writeReplace()}
  * and {@code readObject()} methods, cannot be serialized or deserialized. Certain pre-existing
- * {@code Serializable} identity classes within the JDK are migrated to value classes. Such a value
+ * {@code Serializable} identity classes within the JDK are value classes in preview-mode, and must remain compatible. Such a value
  * class may choose to annotate a constructor or a static method in that class with the
  * {@code Deserializer} annotation. During serialization and deserialization of value objects
  * of those classes, the {@code java.io.ObjectOutputStream} and {@code java.io.ObjectInputStream}

--- a/src/java.base/share/classes/jdk/internal/value/Deserializer.java
+++ b/src/java.base/share/classes/jdk/internal/value/Deserializer.java
@@ -32,19 +32,41 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
 
 /**
- * Indicates the constructor or static factory to
- * construct a value object during deserialization.
- * The annotation is used by java.io.ObjectStreamClass to select the constructor
- * or factory method to create objects from a stream.
- * This is a temporary measure for legacy serialization migration compatibility;
- * future value object persistence would be handled by other mechanisms.
+ * A JDK internal annotation that facilitates serialization and deserialization of non-record
+ * value classes without requiring those value classes to implement the {@code writeReplace()}
+ * and {@code readObject()} methods.
+ * <p>
+ * Non-record value classes, unless they implement the {@code writeReplace()}
+ * and {@code readObject()} methods, cannot be serialized or deserialized. Certain pre-existing
+ * {@code Serializable} identity classes within the JDK are migrated to value classes. Such a value
+ * class may choose to annotate a constructor or a static method in that class with the
+ * {@code Deserializer} annotation. During serialization and deserialization of value objects
+ * of those classes, the {@code java.io.ObjectOutputStream} and {@code java.io.ObjectInputStream}
+ * will check for the presence of this annotation and when present, will relax the requirement of
+ * {@code writeReplace()} and {@code readObject()} methods in that class.
+ * <p>
+ * During deserialization, the constructor or the method annotated with the {@code Deserializer}
+ * will be invoked to create the value object instance from the stream.
+ * <p>
+ * {@code Deserializer} is a temporary measure for legacy serialization migration compatibility;
+ * future value object persistence would be handled by other mechanisms. The {@code Deserializer}
+ * annotation isn't for general purpose usage, even in the classes that belong to the JDK; it is
+ * meant to be used by a very select few classes and the legacy serialization places several
+ * unspecified restrictions on its usage.
+ * <p>
+ * This annotation only takes effect for classes loaded by the boot loader. The presence of this
+ * annotation in classes loaded outside of the boot loader is ignored.
  *
  * @since 28
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value={CONSTRUCTOR, METHOD})
+@Target(value = {CONSTRUCTOR, METHOD})
 public @interface Deserializer {
-    /// Identifies the serial field names for the method parameters.
-    /// The serial field type are the corresponding parameter types.
+    /**
+     * The names of the serial fields that the constructor or static method,
+     * annotated with {@code Deserializer}, expects to be passed when invoked during
+     * deserialization of the value object from the stream. The serial field types are
+     * the corresponding parameter types.
+     */
     String[] value();
 }

--- a/src/java.base/share/classes/jdk/internal/value/Deserializer.java
+++ b/src/java.base/share/classes/jdk/internal/value/Deserializer.java
@@ -38,12 +38,13 @@ import static java.lang.annotation.ElementType.METHOD;
  * <p>
  * Non-record value classes, unless they implement the {@code writeReplace()}
  * and {@code readObject()} methods, cannot be serialized or deserialized. Certain pre-existing
- * {@code Serializable} identity classes within the JDK are value classes in preview-mode, and must remain compatible. Such a value
- * class may choose to annotate a constructor or a static method in that class with the
- * {@code Deserializer} annotation. During serialization and deserialization of value objects
- * of those classes, the {@code java.io.ObjectOutputStream} and {@code java.io.ObjectInputStream}
- * will check for the presence of this annotation and when present, will relax the requirement of
- * {@code writeReplace()} and {@code readObject()} methods in that class.
+ * {@code Serializable} identity classes within the JDK are value classes in preview-mode, and
+ * must remain compatible. Such a value class may choose to annotate a constructor or a static
+ * method in that class with the {@code Deserializer} annotation. During serialization and
+ * deserialization of value objects of those classes, the {@code java.io.ObjectOutputStream} and
+ * {@code java.io.ObjectInputStream} will check for the presence of this annotation and when
+ * present, will relax the requirement of {@code writeReplace()} and {@code readObject()}
+ * methods in that class.
  * <p>
  * During deserialization, the constructor or the method annotated with the {@code Deserializer}
  * will be invoked to create the value object instance from the stream.

--- a/src/java.base/share/classes/jdk/internal/value/Deserializer.java
+++ b/src/java.base/share/classes/jdk/internal/value/Deserializer.java
@@ -51,7 +51,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * {@code Deserializer} is a temporary measure for legacy serialization migration compatibility;
  * future value object persistence would be handled by other mechanisms. The {@code Deserializer}
  * annotation isn't for general purpose usage, even in the classes that belong to the JDK; it is
- * meant to be used by a very select few classes and the legacy serialization places several
+ * meant to be used only by a very select few classes and the legacy serialization places several
  * unspecified restrictions on its usage.
  * <p>
  * This annotation only takes effect for classes loaded by the boot loader. The presence of this


### PR DESCRIPTION
Can I please get a review of this doc-only change which documents the purpose of the `jdk.internal.value.Deserializer` annotation?




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388380](https://bugs.openjdk.org/browse/JDK-8388380): [lworld] Improve the documentation of jdk.internal.value.Deserializer annotation (**Bug** - P4)


### Reviewers
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - no project role)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Dan Smith](https://openjdk.org/census#dlsmith) (@dansmithcode - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2647/head:pull/2647` \
`$ git checkout pull/2647`

Update a local copy of the PR: \
`$ git checkout pull/2647` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2647`

View PR using the GUI difftool: \
`$ git pr show -t 2647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2647.diff">https://git.openjdk.org/valhalla/pull/2647.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2647#issuecomment-4991003874)
</details>
