### PR TITLE
8388400: [lworld] Incorrect null check in jdk.internal.jrtfs.ExplodedImage$PathNode constructor

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
@@ -120,9 +120,9 @@ class ExplodedImage extends SystemImage {
          * Used for each module-named directory that are leafs of /packages/...
          */
         private PathNode(String name, PathNode link) {
-            super(name, link.getFileAttributes());
+            super(name, Objects.requireNonNull(link).getFileAttributes());
             this.file = null;
-            this.link = Objects.requireNonNull(link);
+            this.link = link;
             this.directories = null;
             this.childNames = null;
         }

--- a/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
@@ -120,7 +120,7 @@ class ExplodedImage extends SystemImage {
          * Used for each module-named directory that are leafs of /packages/...
          */
         private PathNode(String name, PathNode link) {
-            super(name, Objects.requireNonNull(link).getFileAttributes());
+            super(name, link.getFileAttributes());
             this.file = null;
             this.link = link;
             this.directories = null;

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -78,7 +78,7 @@ class JrtFileSystem extends FileSystem {
     private final JrtFileSystemProvider provider;
     private final JrtPath rootPath = new JrtPath(this, "/");
     private volatile boolean isOpen;
-    private volatile boolean isClosable;
+    private final boolean isClosable;
     private SystemImage image;
 
     /**


### PR DESCRIPTION
Can I please get a review of this change which reorders a null check in `ExplodedImage`? While at it, the `isClosable` is made `final` in `JrtFileSystem` too.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8388400](https://bugs.openjdk.org/browse/JDK-8388400)

### Issue
 * [JDK-8388400](https://bugs.openjdk.org/browse/JDK-8388400): Incorrect null check in jdk.internal.jrtfs.ExplodedImage$PathNode constructor (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2649/head:pull/2649` \
`$ git checkout pull/2649`

Update a local copy of the PR: \
`$ git checkout pull/2649` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2649`

View PR using the GUI difftool: \
`$ git pr show -t 2649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2649.diff">https://git.openjdk.org/valhalla/pull/2649.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2649#issuecomment-4993813290)
</details>
