### PR TITLE
8388419: [lworld] cherry-pick JDK-8388347 Remove enablePreview from TestEnableNativeAccessJarManifest

### DIFF
--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  * @requires jdk.foreign.linker != "UNSUPPORTED"
  * @requires !vm.musl
  *
- * @enablePreview
  * @build TestEnableNativeAccessJarManifest
  *        panama_module/*
  *        org.openjdk.foreigntest.unnamed.PanamaMainUnnamedModule


### PR DESCRIPTION
This P2 fix:

- [JDK-8388261](https://bugs.openjdk.org/browse/JDK-8388261) [lworld] javac creates early_larval_frame and ACC_STRICT_INIT in record non-preview class files

depends on this fix from main-line:

- [JDK-8388347](https://bugs.openjdk.org/browse/JDK-8388347) Remove enablePreview from TestEnableNativeAccessJarManifest

so I'm using this sub-task to cherry-pick [JDK-8388347](https://bugs.openjdk.org/browse/JDK-8388347) from main-line to repo-valhalla.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388419](https://bugs.openjdk.org/browse/JDK-8388419): [lworld] cherry-pick JDK-8388347 Remove enablePreview from TestEnableNativeAccessJarManifest (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2650/head:pull/2650` \
`$ git checkout pull/2650`

Update a local copy of the PR: \
`$ git checkout pull/2650` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2650`

View PR using the GUI difftool: \
`$ git pr show -t 2650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2650.diff">https://git.openjdk.org/valhalla/pull/2650.diff</a>

</details>
