### PR TITLE
8388177: [lworld] Remove "statewise equivalent" terminology from APIs

### DIFF
--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -44,11 +44,10 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          When preview features are disabled, all classes are identity classes and
  *          all objects are identity objects.
  *          <p>
- *          It is not possible to synchronize on a value object. Applying a {@code
- *          synchronize} statement to a value object causes an {@link IdentityException}
- *          to be thrown.
+ *          It is not possible to synchronize on a value object. An attempt to {@code
+ *          synchronize} on a value object causes {@link IdentityException} to be thrown.
  *          <p>
- *          The {@link #finalize()} method of a value object will never be invoked by
+ *          The {@link #finalize()} method of a value class will never be invoked by
  *          the garbage collector.
  *          <p>
  *          A {@linkplain java.lang.ref.Reference Reference object} can only refer to an

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -41,16 +41,17 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          other objects, including arrays, are <em>identity objects</em>. See
  *          The Java Language Specification {@jls value-objects-8.1.1.5 Value Classes}.
  *          <p>
- *          All classes are identity classes and all objects are identity objects when
- *          preview features are disabled.
+ *          When preview features are disabled, all classes are identity classes and
+ *          all objects are identity objects.
  *          <p>
- *          It is not possible to synchronize on a value object. An attempt to {@code
- *          synchronize} on a value object causes {@link IdentityException} to be thrown.
+ *          It is not possible to synchronize on a value object. Applying a {@code
+ *          synchronize} statement to a value object causes an {@link IdentityException}
+ *          to be thrown.
  *          <p>
- *          The {@link #finalize()} method of a value class will never be invoked by
+ *          The {@link #finalize()} method of a value object will never be invoked by
  *          the garbage collector.
  *          <p>
- *          A {@linkplain java.lang.ref.Reference Reference Object} can only refer to an
+ *          A {@linkplain java.lang.ref.Reference Reference object} can only refer to an
  *          object with identity. Creating a reference object with a value object as
  *          the referent throws {@code IdentityException}.
  *      </div>
@@ -171,10 +172,10 @@ public class Object {
      * that is, for any non-null reference values {@code x} and
      * {@code y}, this method returns {@code true} if and only
      * if {@code x} and {@code y} refer to the same identity object or
-     * both refer to statewise-equivalent value objects
-     * ({@code x == y} has the value {@code true}).
-     *
-     * In other words, under the reference equality equivalence
+     * indistinguishable value objects ({@code x == y} has the value
+     * {@code true}).
+     * <p>
+     * In other words, under the object equality equivalence
      * relation, each equivalence class only has a single element.
      *
      * @apiNote
@@ -199,7 +200,7 @@ public class Object {
     /**
      * Creates and returns a copy of this object.  The precise meaning
      * of "copy" may depend on the class of the object. The general
-     * intent is that, for any identity object {@code x}, the expression:
+     * intent is that, for any object {@code x}, the expression:
      * <blockquote>
      * <pre>
      * x.clone() != x</pre></blockquote>
@@ -207,7 +208,10 @@ public class Object {
      * <blockquote>
      * <pre>
      * x.clone().getClass() == x.getClass()</pre></blockquote>
-     * will be {@code true} for any object, but these are not absolute requirements.
+     * will also be {@code true}, but these are not absolute requirements.
+     * The clone of a value object, in particular, may be indistinguishable from
+     * the original.
+     * <p>
      * While it is typically the case that:
      * <blockquote>
      * <pre>
@@ -230,10 +234,8 @@ public class Object {
      * the case that no fields in the object returned by {@code super.clone}
      * need to be modified.
      * <p>
-     * For a value object {@code x}, the expectation that {@code x.clone() != x} is not
-     * meaningful. Value classes that contain references to identity objects may override
-     * {@code clone} to perform a "deep copy" of the identity objects, returning an object
-     * with references to the copied identity objects.
+     * Value classes may similarly perform deep copies of any mutable field
+     * values before constructing a new class instance with those copies.
      *
      * @apiNote
      * It should be rare for new classes to implement the {@link Cloneable} interface.
@@ -257,8 +259,8 @@ public class Object {
      * contents of the fields are not themselves cloned. Thus, this method
      * performs a "shallow copy" of this object, not a "deep copy" operation.
      * <p>
-     * For a value object, this method returns an object that is <em>statewise
-     * equivalent</em> to this object.
+     * For a value object, this method returns an object that is indistinguishable
+     * from this object.
      * <p>
      * The class {@code Object} does not itself implement the interface
      * {@code Cloneable}, so calling the {@code clone} method on an object

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -42,14 +42,14 @@ final class ValueObjectMethods {
     }
 
     /**
-     * Return whether two value objects of the same class are statewise equivalent,
+     * Return whether two value objects of the same class are indistinguishable,
      * as used by {@code ==} operator.
      * The fields to compare are determined by Unsafe.getFieldMap.
      * This method is called by the JVM.
      *
      * @param a a value class instance, non-null
      * @param b a value class instance of the same class as {@code a}, non-null
-     * @return whether these two value objects are statewise equivalent
+     * @return whether these two value objects are indistinguishable
      */
     private static boolean isSubstitutable(Object a, Object b) {
         if (VERBOSE) {
@@ -106,7 +106,7 @@ final class ValueObjectMethods {
 
     /**
      * Return the identity hashCode of a value object.
-     * Two statewise equivalent value objects produce the same hashCode.
+     * Two indistinguishable value objects produce the same hashCode.
      * This method is called by the JVM.
      *
      * The generated identity hash must be invariantly immutable.

--- a/src/java.base/share/classes/java/util/IdentityHashMap.java
+++ b/src/java.base/share/classes/java/util/IdentityHashMap.java
@@ -35,7 +35,7 @@ import jdk.internal.access.SharedSecrets;
 
 /**
  * This class implements the {@code Map} interface with a hash table, using
- * {@code == } in place of {@code .equals()} equality when comparing keys (and values).
+ * {@code ==} in place of {@code .equals()} equality when comparing keys (and values).
  * In other words, in an {@code IdentityHashMap}, two keys
  * {@code k1} and {@code k2} are considered equal if and only if
  * {@code (k1==k2)}.  (In normal {@code Map} implementations (like
@@ -46,18 +46,18 @@ import jdk.internal.access.SharedSecrets;
  * implementation!  While this class implements the {@code Map} interface, it
  * intentionally violates {@code Map's} general contract, which mandates the
  * use of the {@code equals} method when comparing objects.  This class is
- * designed for use only in the rare cases wherein {@code == } semantics are required.
+ * designed for use only in the rare cases wherein {@code ==} semantics are required.
  * </b>
  * <div class="preview-block">
  *      <div class="preview-comment">
  *          When preview features are enabled, keys and values may be
  *          {@linkplain java.util.Objects#hasIdentity value objects}.
- *          Two value object keys are {@code == } if they are instances
+ *          Two value object keys are {@code ==} if they are instances
  *          of the same class and the values of their instance fields are the same.
  *      </div>
  * </div>
  *
- * <p>The view collections of this map also have {@code == } equality semantics
+ * <p>The view collections of this map also have {@code ==} equality semantics
  * for their elements. See the {@link #keySet() keySet}, {@link #values() values},
  * and {@link #entrySet() entrySet} methods for further information.
  *

--- a/src/java.base/share/classes/java/util/IdentityHashMap.java
+++ b/src/java.base/share/classes/java/util/IdentityHashMap.java
@@ -50,9 +50,9 @@ import jdk.internal.access.SharedSecrets;
  * </b>
  * <div class="preview-block">
  *      <div class="preview-comment">
- *          When preview features are enabled, keys and values may be identity objects,
- *          value objects or null.
- *          For value classes, two value objects are state-wise equivalent if they are instances
+ *          When preview features are enabled, keys and values may be
+ *          {@linkplain java.util.Objects#hasIdentity value objects}.
+ *          Two value object keys are {@code == } if they are instances
  *          of the same class and the values of their instance fields are the same.
  *      </div>
  * </div>


### PR DESCRIPTION
Some final polishing to align javadocs with the JEP.

- Main goal is to remove usage of "statewise equivalent", as noted in the title
- A little bit of general editing in the Object intro, `equals` method, and `clone` method
- Corrected "the finalize method of a value ~class~ _object_ will never be invoked"

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388177](https://bugs.openjdk.org/browse/JDK-8388177): [lworld] Remove "statewise equivalent" terminology from APIs (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2651/head:pull/2651` \
`$ git checkout pull/2651`

Update a local copy of the PR: \
`$ git checkout pull/2651` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2651`

View PR using the GUI difftool: \
`$ git pr show -t 2651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2651.diff">https://git.openjdk.org/valhalla/pull/2651.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2651#issuecomment-4998502037)
</details>
