### PR TITLE
8388445: [lworld] update ProblemList-Xcomp.txt entries from 8378071 to 8388438

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -62,5 +62,5 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 #############################################################################
 
 # Valhalla failures start here:
-runtime/cds/appcds/aotCache/AOTMapTest.java#valhalla 8378071 generic-all
-runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8378071 generic-all
+runtime/cds/appcds/aotCache/AOTMapTest.java#valhalla 8388438 generic-all
+runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8388438 generic-all


### PR DESCRIPTION
Trivial fix to update ProblemList-Xcomp.txt entries from 8378071 to 8388438.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388445](https://bugs.openjdk.org/browse/JDK-8388445): [lworld] update ProblemList-Xcomp.txt entries from 8378071 to 8388438 (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2654/head:pull/2654` \
`$ git checkout pull/2654`

Update a local copy of the PR: \
`$ git checkout pull/2654` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2654`

View PR using the GUI difftool: \
`$ git pr show -t 2654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2654.diff">https://git.openjdk.org/valhalla/pull/2654.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2654#issuecomment-5005468653)
</details>
