### PR TITLE
8388462: [lworld] Provide more context about wrapper class caches

### DIFF
--- a/doc/value-class-preview.html
+++ b/doc/value-class-preview.html
@@ -158,10 +158,10 @@ object is:</p>
 <li>If C2 uses scalarized calling convention, at C2 to C1/interpreter
 calls and returns</li>
 </ol>
-<p>Ideally, C2 can eliminate such allocations with scalarized calling
-convention, but this does not work if the resulting object is stored
-into references. Unfortunately, many uses of boxing conversions store
-the resulting wrapper objects as references.</p>
+<p>Ideally, C2 can eliminate such allocations, but this does not work if
+the resulting object is stored into references. Unfortunately, many uses
+of boxing conversions store the resulting wrapper objects as
+references.</p>
 <p>For the uses that store wrapper objects to references, if the boxing
 conversion is:</p>
 <ol type="1">

--- a/doc/value-class-preview.html
+++ b/doc/value-class-preview.html
@@ -107,10 +107,10 @@ directory.</p></li>
 <li><p>At run-time, jimage will pick up the preview-specific overrides
 from <code>META-INF/preview</code> only when preview features are
 enabled.</p></li>
-<li><p>The interim <code>javac</code> used by the build system cannot
-pick up the preview-specific overrides; they must be supplied explicitly
-with the following javac flag for every single module where overrides
-are significant:</p>
+<li><p>The interim javac used by the build system cannot pick up the
+preview-specific overrides; they must be supplied explicitly with the
+following javac flag for every single module where overrides are
+significant:</p>
 <pre><code>--patch-module &lt;module&gt;=$(SUPPORT_OUTPUTDIR)/preview/&lt;module&gt;</code></pre>
 <p>See <a
 href="../make/test/BuildMicrobenchmark.gmk"><code>BuildMicroBenchmarks.gmk</code></a>

--- a/doc/value-class-preview.html
+++ b/doc/value-class-preview.html
@@ -105,12 +105,12 @@ created to compile these source files into class files.</p></li>
 to the <code>META-INF/preview</code> directory of the regular output
 directory.</p></li>
 <li><p>At run-time, jimage will pick up the preview-specific overrides
-from <code>META-INF/preview</code> when preview features are
+from <code>META-INF/preview</code> only when preview features are
 enabled.</p></li>
 <li><p>The interim <code>javac</code> used by the build system cannot
-pickup the preview-specific overrides; they must be supplied explicitly
-with this javac flag for every single module where overrides are
-significant:</p>
+pick up the preview-specific overrides; they must be supplied explicitly
+with the following javac flag for every single module where overrides
+are significant:</p>
 <pre><code>--patch-module &lt;module&gt;=$(SUPPORT_OUTPUTDIR)/preview/&lt;module&gt;</code></pre>
 <p>See <a
 href="../make/test/BuildMicrobenchmark.gmk"><code>BuildMicroBenchmarks.gmk</code></a>
@@ -127,8 +127,8 @@ are:</p>
 are disabled. There's no plan to introduce completely new value
 classes.</p></li>
 </ol>
-<p>Support for other value classes require significant changes to the
-build system.</p>
+<p>Support for other value classes would require significant changes to
+the build system.</p>
 <h2 id="testing">Testing</h2>
 <p>In addition to tests that require preview features to be enabled,
 tests that do not depend on preview features wish to run with preview
@@ -147,13 +147,36 @@ the plugin.</p></li>
 </ol>
 <h2 id="wrapper-class-caches">Wrapper Class Caches</h2>
 <p>Currently, wrapper class caches are retained even when preview
-features are enabled. They are created with
-<code>ValueClass.newReferenceArray</code>, which creates a non-flat
-array storing object references, allowing a value object wrapping a
-primitive value to be available quickly without redundant allocations
-and associated performance regressions. Their existence have no semantic
-meaning, and they may be removed when the performance regressions are
-eliminated or reduced.</p>
+features are enabled to address performance losses. They have no
+semantic impact to value objects.</p>
+<p>In interpreter or C1 execution in Hotspot, allocations of value
+objects to the heap as a full object with header happens when a value
+object is:</p>
+<ol type="1">
+<li>Loaded from a flat storage (field or array)</li>
+<li>Created by a constructor</li>
+</ol>
+<p>Ideally, C2 can eliminate such allocations, but this is not the case
+if the resulting object is stored into references. Unfortunately, many
+uses of boxing conversions store the resulting wrapper objects as
+references.</p>
+<p>For the uses that store wrapper objects to references, if the boxing
+conversion is:</p>
+<ol type="1">
+<li>Returning a value object from a flat cache array</li>
+<li>Calling the value class constructor</li>
+</ol>
+<p>Then we would have heap allocation on every single use.</p>
+<p>To avoid the allocations, we fall back to returning a value object
+from a reference cache array, from which the loaded reference is
+directly storable into a destination that wants a reference without any
+allocation.</p>
+<p>Since Hotspot may create flat arrays if an array of value objects is
+requested by regular Java array creation mechanisms, we use
+<code>ValueClass.newReferenceArray</code> to ensure we always create a
+reference cache array.</p>
+<p>The cache array for value objects may be removed without notice if
+the performance losses from allocations are no longer significant.</p>
 <h2 id="editing-this-document">Editing This Document</h2>
 <p>If you want to contribute changes to this document, edit
 <code>doc/value-class-preview.md</code> and then run

--- a/doc/value-class-preview.html
+++ b/doc/value-class-preview.html
@@ -149,17 +149,19 @@ the plugin.</p></li>
 <p>Currently, wrapper class caches are retained even when preview
 features are enabled to address performance losses. They have no
 semantic impact to value objects.</p>
-<p>In interpreter or C1 execution in Hotspot, allocations of value
-objects to the heap as a full object with header happens when a value
+<p>In interpreter or C1 execution in Hotspot, allocations of a value
+object to the heap as a full object with header happen when a value
 object is:</p>
 <ol type="1">
 <li>Loaded from a flat storage (field or array)</li>
 <li>Created by a constructor</li>
+<li>If C2 uses scalarized calling convention, at C2 to C1/interpreter
+calls and returns</li>
 </ol>
-<p>Ideally, C2 can eliminate such allocations, but this is not the case
-if the resulting object is stored into references. Unfortunately, many
-uses of boxing conversions store the resulting wrapper objects as
-references.</p>
+<p>Ideally, C2 can eliminate such allocations with scalarized calling
+convention, but this does not work if the resulting object is stored
+into references. Unfortunately, many uses of boxing conversions store
+the resulting wrapper objects as references.</p>
 <p>For the uses that store wrapper objects to references, if the boxing
 conversion is:</p>
 <ol type="1">

--- a/doc/value-class-preview.md
+++ b/doc/value-class-preview.md
@@ -108,15 +108,17 @@ Currently, wrapper class caches are retained even when preview features are
 enabled to address performance losses. They have no semantic impact to value
 objects.
 
-In interpreter or C1 execution in Hotspot, allocations of value objects to the
-heap as a full object with header happens when a value object is:
+In interpreter or C1 execution in Hotspot, allocations of a value object to the
+heap as a full object with header happen when a value object is:
 
 1. Loaded from a flat storage (field or array)
 2. Created by a constructor
+3. If C2 uses scalarized calling convention, at C2 to C1/interpreter calls and returns
 
-Ideally, C2 can eliminate such allocations, but this is not the case if the
-resulting object is stored into references. Unfortunately, many uses of boxing
-conversions store the resulting wrapper objects as references.
+Ideally, C2 can eliminate such allocations with scalarized calling convention,
+but this does not work if the resulting object is stored into references.
+Unfortunately, many uses of boxing conversions store the resulting wrapper
+objects as references.
 
 For the uses that store wrapper objects to references, if the boxing
 conversion is:

--- a/doc/value-class-preview.md
+++ b/doc/value-class-preview.md
@@ -105,12 +105,37 @@ ensure compatibility:
 ## Wrapper Class Caches
 
 Currently, wrapper class caches are retained even when preview features are
-enabled. They are created with `ValueClass.newReferenceArray`, which creates
-a non-flat array storing object references, allowing a value object wrapping
-a primitive value to be available quickly without redundant allocations and
-associated performance regressions. Their existence has no semantic meaning,
-and they may be removed when the performance regressions are eliminated or
-reduced.
+enabled to address performance losses. They have no semantic impact to value
+objects.
+
+In interpreter or C1 execution in Hotspot, allocations of value objects to the
+heap as a full object with header happens when a value object is:
+
+1. Loaded from a flat storage (field or array)
+2. Created by a constructor
+
+Ideally, C2 can eliminate such allocations, but this is not the case if the
+resulting object is stored into references. Unfortunately, many uses of boxing
+conversions store the resulting wrapper objects as references.
+
+For the uses that store wrapper objects to references, if the boxing
+conversion is:
+
+1. Returning a value object from a flat cache array
+2. Calling the value class constructor
+
+Then we would have heap allocation on every single use.
+
+To avoid the allocations, we fall back to returning a value object from a
+reference cache array, from which the loaded reference is directly storable
+into a destination that wants a reference without any allocation.
+
+Since Hotspot may create flat arrays if an array of value objects is requested
+by regular Java array creation mechanisms, we use `ValueClass.newReferenceArray`
+to ensure we always create a reference cache array.
+
+The cache array for value objects may be removed without notice if the
+performance losses from allocations are no longer significant.
 
 ## Editing This Document
 

--- a/doc/value-class-preview.md
+++ b/doc/value-class-preview.md
@@ -115,10 +115,9 @@ heap as a full object with header happen when a value object is:
 2. Created by a constructor
 3. If C2 uses scalarized calling convention, at C2 to C1/interpreter calls and returns
 
-Ideally, C2 can eliminate such allocations with scalarized calling convention,
-but this does not work if the resulting object is stored into references.
-Unfortunately, many uses of boxing conversions store the resulting wrapper
-objects as references.
+Ideally, C2 can eliminate such allocations, but this does not work if the
+resulting object is stored into references. Unfortunately, many uses of boxing
+conversions store the resulting wrapper objects as references.
 
 For the uses that store wrapper objects to references, if the boxing
 conversion is:

--- a/doc/value-class-preview.md
+++ b/doc/value-class-preview.md
@@ -61,7 +61,7 @@ outcome images.
 5. At run-time, jimage will pick up the preview-specific overrides from
    `META-INF/preview` only when preview features are enabled.
 
-6. The interim `javac` used by the build system cannot pick up the
+6. The interim javac used by the build system cannot pick up the
    preview-specific overrides; they must be supplied explicitly with the
    following javac flag for every single module where overrides are significant:
 

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -116,6 +116,9 @@ public final /*value*/ class Byte extends Number
         return Optional.of(DynamicConstantDesc.ofNamed(BSM_EXPLICIT_CAST, DEFAULT_NAME, CD_byte, intValue()));
     }
 
+    // When preview features are enabled, the cache does not affect object
+    // equality == semantics, but exists for performance.
+    // See doc/value-class-preview.md "Wrapper Class Caches" section.
     @AOTSafeClassInitializer
     private static final class ByteCache {
         private ByteCache() {}

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -9429,6 +9429,9 @@ public final /*value*/ class Character
         this.value = value;
     }
 
+    // When preview features are enabled, the cache does not affect object
+    // equality == semantics, but exists for performance.
+    // See doc/value-class-preview.md "Wrapper Class Caches" section.
     @AOTSafeClassInitializer
     private static final class CharacterCache {
         private CharacterCache(){}

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -892,6 +892,10 @@ public final /*value*/ class Integer extends Number
      * Cache to support the object identity semantics of autoboxing for values between
      * -128 and 127 (inclusive) as required by JLS.
      *
+     * When preview features are enabled, the cache does not affect object
+     * equality {@code ==} semantics, but exists for performance.
+     * See doc/value-class-preview.md "Wrapper Class Caches" section.
+     *
      * The cache is initialized on first usage.  The size of the cache
      * may be controlled by the {@code -XX:AutoBoxCacheMax=<size>} option.
      * During VM initialization, java.lang.Integer.IntegerCache.high property

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -925,6 +925,9 @@ public final /*value*/ class Long extends Number
         return Long.valueOf(parseLong(s, 10));
     }
 
+    // When preview features are enabled, the cache does not affect object
+    // equality == semantics, but exists for performance.
+    // See doc/value-class-preview.md "Wrapper Class Caches" section.
     @AOTSafeClassInitializer
     private static final class LongCache {
         private LongCache() {}

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -243,6 +243,9 @@ public final /*value*/ class Short extends Number
         return Optional.of(DynamicConstantDesc.ofNamed(BSM_EXPLICIT_CAST, DEFAULT_NAME, CD_short, intValue()));
     }
 
+    // When preview features are enabled, the cache does not affect object
+    // equality == semantics, but exists for performance.
+    // See doc/value-class-preview.md "Wrapper Class Caches" section.
     @AOTSafeClassInitializer
     private static final class ShortCache {
         private ShortCache() {}


### PR DESCRIPTION
@jddarcy noted [JDK-8387875](https://bugs.openjdk.org/browse/JDK-8387875) did not provide links from wrapper class cache mechanism declarations to the overview documentation. We can add comments and also enhance that section in the design doc.

Also the value-class-preview.html is a bit out of sync.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388462](https://bugs.openjdk.org/browse/JDK-8388462): [lworld] Provide more context about wrapper class caches (**Bug** - P2)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer) ⚠️ Review applies to [2c313f32](https://git.openjdk.org/valhalla/pull/2655/files/2c313f323f728d71692de11db96ed259778986fb)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2655/head:pull/2655` \
`$ git checkout pull/2655`

Update a local copy of the PR: \
`$ git checkout pull/2655` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2655`

View PR using the GUI difftool: \
`$ git pr show -t 2655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2655.diff">https://git.openjdk.org/valhalla/pull/2655.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2655#issuecomment-5011855555)
</details>
