### PR TITLE
8388468: [lworld] TestIntrinsics intermittently fails due to unexpected substitutability

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1246,7 +1246,8 @@ public class TestIntrinsics {
 
         @ForceInline
         static SmallValue createWithFieldsInline(int x, long y) {
-            return new SmallValue((byte)x, (byte)y);
+            // Make sure it's different from the default value, some tests rely on this
+            return new SmallValue((byte)x, (byte) (y | 1));
         }
     }
 


### PR DESCRIPTION
If the stars align, both `rI` and `rL` are zero and as a result, `SmallValue` created via `createWithFieldsInline` becomes equivalent / substitutable to `SmallValue.DEFAULT` which is not expected by CAS tests 63–66. Both CAS operations then correctly perform CAS(default, default) and return true so that the second `assertFalse` will fail:
https://github.com/openjdk/valhalla/blob/a0662f990a871f23fc63dd7b58f1083e1ece9de5/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java#L1373-L1378

The fix is to simply make sure that the value created via `createWithFieldsInline` is always different from `SmallValue.DEFAULT`.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388468](https://bugs.openjdk.org/browse/JDK-8388468): [lworld] TestIntrinsics intermittently fails due to unexpected substitutability (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2656/head:pull/2656` \
`$ git checkout pull/2656`

Update a local copy of the PR: \
`$ git checkout pull/2656` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2656`

View PR using the GUI difftool: \
`$ git pr show -t 2656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2656.diff">https://git.openjdk.org/valhalla/pull/2656.diff</a>

</details>
