### PR TITLE
8388524: [lworld] JVMTI cleanup

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3397,7 +3397,7 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
         of <code>void</code>.
         A constructor is a special method named <code>&lt;init&gt;</code> with
         a return type of <code>void</code>. A class initializer is a special
-        method named named <code>&lt;clinit&gt;</code> with a return type of
+        method named <code>&lt;clinit&gt;</code> with a return type of
         <code>void</code>.
         <p/>
         When preview features are enabled, this function can not be used to return
@@ -10766,7 +10766,7 @@ myInit() {
           <eventlink id="SampledObjectAlloc"></eventlink>.
           <b> can_support_value_objects is a preview API of the Java platform. </b>
           <i>Preview features may be removed in a future release, or upgraded to
-          permanent features of the Java platform.</i> 
+          permanent features of the Java platform.</i>
         </description>
       </capabilityfield>
     </capabilitiestypedef>

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -3282,7 +3282,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
     stackmap_p++;
 
    if (frame_type == StackMapReader::EARLY_LARVAL) {
-     // rewrite_cp_refs in  unset fields and fall through.
+     // rewrite_cp_refs in unset fields and fall through.
      rewrite_cp_refs_in_early_larval_stackmaps(stackmap_p, stackmap_end, calc_number_of_entries, frame_type);
      // The larval frames point to the next frame, so advance to the next frame and fall through.
      frame_type = *stackmap_p;

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -440,7 +440,7 @@ class CallbackWrapper : public StackObj {
     } else {
       // flat value object, we know its InstanceKlass
       assert(_o.inline_klass() != nullptr, "must be");
-      _obj_size = _o.inline_klass()->size() * wordSize;;
+      _obj_size = _o.inline_klass()->size() * wordSize;
     }
 
     // get object tag
@@ -2846,9 +2846,9 @@ VM_HeapWalkOperation::VM_HeapWalkOperation(JvmtiTagMap* tag_map,
   _tag_map = tag_map;
   _initial_object = initial_object;
   _following_object_refs = true;
-  _reporting_primitive_fields = (callbacks.primitive_field_callback() != nullptr);;
-  _reporting_primitive_array_values = (callbacks.array_primitive_value_callback() != nullptr);;
-  _reporting_string_values = (callbacks.string_primitive_value_callback() != nullptr);;
+  _reporting_primitive_fields = (callbacks.primitive_field_callback() != nullptr);
+  _reporting_primitive_array_values = (callbacks.array_primitive_value_callback() != nullptr);
+  _reporting_string_values = (callbacks.string_primitive_value_callback() != nullptr);
   _dead_objects = objects;
   CallbackInvoker::initialize_for_advanced_heap_walk(tag_map, user_data, callbacks, &_visit_stack);
 }
@@ -2884,7 +2884,7 @@ inline bool VM_HeapWalkOperation::iterate_over_array(const JvmtiHeapwalkObject& 
   return true;
 }
 
-// similar to iterate_over_array(), but itrates over flat array
+// similar to iterate_over_array(), but iterates over flat array
 inline bool VM_HeapWalkOperation::iterate_over_flat_array(const JvmtiHeapwalkObject& o) {
   assert(!o.is_flat(), "Array object cannot be flattened");
   flatArrayOop array = flatArrayOop(o.obj());

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/FieldAccessModify.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/FieldAccessModify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,16 +92,16 @@ public class FieldAccessModify {
         TestHolder testHolder = new TestHolder();
 
         if (!initWatchers(ValueClass.class, ValueClass.class.getDeclaredField("valueClass_fld1"))) {
-            throw new RuntimeException("Watchers initializations error (valueClass_fld1)");
+            throw new RuntimeException("Watcher initialization error (valueClass_fld1)");
         }
         if (!initWatchers(ValueClass.class, ValueClass.class.getDeclaredField("valueClass_fld2"))) {
-            throw new RuntimeException("Watchers initializations error (valueClass_fld2)");
+            throw new RuntimeException("Watcher initialization error (valueClass_fld2)");
         }
         if (!initWatchers(InstanceHolder.class, InstanceHolder.class.getDeclaredField("instanceHolder_fld1"))) {
-            throw new RuntimeException("Watchers initializations error (instanceHolder_fld1)");
+            throw new RuntimeException("Watcher initialization error (instanceHolder_fld1)");
         }
         if (!initWatchers(ValueHolder.class, ValueHolder.class.getDeclaredField("valueHolder_fld1"))) {
-            throw new RuntimeException("Watchers initializations error (valueHolder_fld1)");
+            throw new RuntimeException("Watcher initialization error (valueHolder_fld1)");
         }
 
         test("ValueClass (access)", () -> {

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java
@@ -52,7 +52,7 @@ public value class VMObjectAllocValueTest {
         int actual = getNumberOfAllocation();
 
         if (actual != expected) {
-            throw new Exception("Number of allocation: expected: " + expected + ", got: " + actual);
+            throw new Exception("Number of allocations: expected: " + expected + ", got: " + actual);
         }
     }
 }


### PR DESCRIPTION
This fix is for Valhalla pre-integration.
This trivial update fixes minor typos like double semicolons and a trailing whitespace in the `jvmti.xml`.

Testing: N/A

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388524](https://bugs.openjdk.org/browse/JDK-8388524): [lworld] JVMTI cleanup (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2657/head:pull/2657` \
`$ git checkout pull/2657`

Update a local copy of the PR: \
`$ git checkout pull/2657` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2657`

View PR using the GUI difftool: \
`$ git pr show -t 2657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2657.diff">https://git.openjdk.org/valhalla/pull/2657.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2657#issuecomment-5029487634)
</details>
