### PR TITLE
8388318: [lworld] jdk.internal.value.Deserializer annotation should not be honored on application classes

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1362,6 +1362,10 @@ public final class ObjectStreamClass implements Serializable {
      */
     private static Executable findDeserializer(Class<?> clazz,
                                                ObjectStreamField[] fields) {
+        if (clazz.getClassLoader() != null) {
+            // Only for boot loader classes
+            return null;
+        }
         return Stream.concat(
                 Arrays.stream(clazz.getDeclaredMethods()).filter(m -> Modifier.isStatic(m.getModifiers())),
                 Arrays.stream(clazz.getDeclaredConstructors()))

--- a/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
+++ b/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
@@ -28,7 +28,7 @@
  * @enablePreview
  * @modules java.base/jdk.internal
  * @modules java.base/jdk.internal.value
- * @run junit/othervm SimpleValueGraphs
+ * @run junit/bootclasspath/othervm SimpleValueGraphs
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/valueObjects/ValueSerializationTest.java
+++ b/test/jdk/java/io/Serializable/valueObjects/ValueSerializationTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8388318
  * @summary Test serialization of value classes
  * @enablePreview
  * @modules java.base/jdk.internal.value
@@ -33,7 +34,8 @@
  *          generate classfiles with STRICT_INIT access flags for its annotated fields
  * @run driver jdk.test.lib.helpers.StrictProcessor
  *             ValueSerializationTest$IdentityStrictPoint
- * @run junit ${test.main.class}
+ * @run junit/othervm -DdeserializerOnBootclasspath=false ${test.main.class}
+ * @run junit/bootclasspath/othervm -DdeserializerOnBootclasspath=true ${test.main.class}
  */
 
 import java.io.ByteArrayInputStream;
@@ -56,6 +58,7 @@ import java.util.stream.Stream;
 
 import jdk.internal.value.Deserializer;
 import jdk.test.lib.helpers.StrictInit;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -74,10 +77,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ValueSerializationTest {
 
+    private static final boolean DESERIALIZER_ON_BOOTCLASSPATH = Boolean.getBoolean("deserializerOnBootclasspath");
     private static final Class<NotSerializableException> NSE = NotSerializableException.class;
     private static final Class<InvalidClassException> ICE = InvalidClassException.class;
 
+    @BeforeAll
+    static void setup() {
+        System.out.println("deserializerOnBootclasspath: " + DESERIALIZER_ON_BOOTCLASSPATH);
+    }
+
     static Stream<Arguments> serializationFailingInstances() {
+        return DESERIALIZER_ON_BOOTCLASSPATH ? serializationAlwaysFailingInstances()
+                : Stream.concat(serializationAlwaysFailingInstances(),
+                                // Unrecognized deserializer leads to ICE
+                                deserializerInstances().map(a -> Arguments.of(a, ICE)));
+    }
+
+    static Stream<Arguments> serializationAlwaysFailingInstances() {
         return Stream.of(
                 Arguments.of(
                         new NonSerializableValue(10, 100),
@@ -161,7 +177,7 @@ public class ValueSerializationTest {
         }
     }
 
-    static Stream<Object> serializingInstances() {
+    static Stream<Object> deserializerInstances() {
         return Stream.of(
                 new ValueWithDeserializer(11, 101),
 
@@ -173,8 +189,17 @@ public class ValueSerializationTest {
                 new Object[]{
                         new ValueWithDeserializer(3, 7),
                         new ValueWithDeserializer(4, 8)
-                },
+                }
+        );
+    }
 
+    static Stream<Object> serializingInstances() {
+        return DESERIALIZER_ON_BOOTCLASSPATH ? Stream.concat(deserializerInstances(), alwaysSerializingInstances())
+                : alwaysSerializingInstances();
+    }
+
+    static Stream<Object> alwaysSerializingInstances() {
+        return Stream.of(
                 new ValueWriteReplaceWithIdentity(45),
 
                 new ValueWriteReplaceWithIdentity[]{
@@ -271,7 +296,7 @@ public class ValueSerializationTest {
                 Arguments.of(
                         ValueWithDeserializer.class,
                         SC_SERIALIZABLE,
-                        null
+                        DESERIALIZER_ON_BOOTCLASSPATH ? null : ICE
                 ),
 
                 Arguments.of(
@@ -431,6 +456,7 @@ public class ValueSerializationTest {
     /**
      * A concrete value class which implements java.io.Serializable and has a
      * jdk.internal.value.Deserializer associated with its constructor.
+     * It may be serialized only if it is on the boot class path.
      */
     static value class ValueWithDeserializer implements Serializable {
         public int x;


### PR DESCRIPTION
The Deserializer documentation states that it only applies to the boot class path:

https://github.com/openjdk/valhalla/blob/1c3301cb96d779d06bb6e2391c35ce729bc28189/src/java.base/share/classes/jdk/internal/value/Deserializer.java#L58-L59


There is an implementation defect right now that this annotation is scanned from all sources.

Updated `ValueSerializationTest` to add positive and negative tests for a value class with `@Deserializer` both on and off the boot class path.

In the test updates I noticed `SerializedObjectCombo` is broken that it never generates value classes somehow; tracked in [JDK-8388597](https://bugs.openjdk.org/browse/JDK-8388597).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388318](https://bugs.openjdk.org/browse/JDK-8388318): [lworld] jdk.internal.value.Deserializer annotation should not be honored on application classes (**Bug** - P2)


### Reviewers
 * [Dan Smith](https://openjdk.org/census#dlsmith) (@dansmithcode - Committer)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - no project role)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2661/head:pull/2661` \
`$ git checkout pull/2661`

Update a local copy of the PR: \
`$ git checkout pull/2661` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2661`

View PR using the GUI difftool: \
`$ git pr show -t 2661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2661.diff">https://git.openjdk.org/valhalla/pull/2661.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2661#issuecomment-5036778644)
</details>
