### PR TITLE
8388928: [lworld] ProblemList compiler/vectorapi/TestVectorReassociations.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -200,6 +200,8 @@ applications/ctw/modules/java_base_2.java 8375645 generic-all
 
 compiler/codegen/TestRedundantLea.java#Spill                            8361089 generic-all
 
+compiler/vectorapi/TestVectorReassociations.java 8388927 generic-all
+
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8386674 linux-aarch64
 
 vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all


### PR DESCRIPTION
A trivial fix to ProblemList compiler/vectorapi/TestVectorReassociations.java on all configs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388928](https://bugs.openjdk.org/browse/JDK-8388928): [lworld] ProblemList compiler/vectorapi/TestVectorReassociations.java (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2667/head:pull/2667` \
`$ git checkout pull/2667`

Update a local copy of the PR: \
`$ git checkout pull/2667` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2667`

View PR using the GUI difftool: \
`$ git pr show -t 2667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2667.diff">https://git.openjdk.org/valhalla/pull/2667.diff</a>

</details>
