### PR TITLE
8389085: [lworld] C2: assert(field_value != nullptr) failed in PhaseMacroExpand::inline_type_from_mem

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -760,8 +760,11 @@ Node* PhaseMacroExpand::inline_type_from_mem(ciInlineKlass* vk, const TypeAryPtr
         }
       }
     }
-    assert(field_value != nullptr, "");
-    vt->set_field_value(i, field_value);
+    if (field_value != nullptr) {
+      vt->set_field_value(i, field_value);
+    } else {
+      return nullptr;
+    }
   }
   return vt;
 }


### PR DESCRIPTION
This is a regression from the recent merge which changed an if into an assert:
https://github.com/openjdk/valhalla/blame/828c729cdd5f937547f4a9034ce8d8f7aa119b6b/src/hotspot/share/opto/macro.cpp#L763

While building scalarized debug info, `create_scalarized_object_description()` calls `add_array_elems_to_safepoint()`, which recursively reconstructs flattened fields through `inline_type_from_mem()` -> `value_from_mem()` -> `value_from_alloc()`.

That method cannot decompose an arbitrary oop initializer into scalar fields and deliberately returns `nullptr` which must propagate outward to abort scalar replacement:
https://github.com/openjdk/valhalla/blob/828c729cdd5f937547f4a9034ce8d8f7aa119b6b/src/hotspot/share/opto/macro.cpp#L548-L550

The fix is to revert the code back to what it was before the merge. I can reliably reproduce this with `serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java` and therefore did not add a targeted regression test.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389085](https://bugs.openjdk.org/browse/JDK-8389085): [lworld] C2: assert(field_value != nullptr) failed in PhaseMacroExpand::inline_type_from_mem (**Bug** - P2)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2669/head:pull/2669` \
`$ git checkout pull/2669`

Update a local copy of the PR: \
`$ git checkout pull/2669` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2669`

View PR using the GUI difftool: \
`$ git pr show -t 2669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2669.diff">https://git.openjdk.org/valhalla/pull/2669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2669#issuecomment-5088994296)
</details>
