### PR TITLE
8389139: [lworld] C1 should not reuse CodeEmitInfo for G1 pre-barriers of atomic flat fields

### DIFF
--- a/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
@@ -50,7 +50,7 @@ void CardTableBarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) 
       ciField* field = vk->nonstatic_field_at(i);
       if (!field->type()->is_primitive_type()) {
         int off = access.offset().opr().as_jint() + field->offset_in_bytes() - vk->payload_offset();
-        // Each pre-barrier is a different LIR instruction and needs its own CodeEmitInfo.
+        // Each pre-barrier needs its own CodeEmitInfo
         CodeEmitInfo* info = access.patch_emit_info();
         if (info != nullptr) {
           info = new CodeEmitInfo(info);

--- a/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "c1/c1_IR.hpp"
 #include "ci/ciInlineKlass.hpp"
 #include "code/aotCodeCache.hpp"
 #include "gc/shared/c1/cardTableBarrierSetC1.hpp"
@@ -49,7 +50,12 @@ void CardTableBarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) 
       ciField* field = vk->nonstatic_field_at(i);
       if (!field->type()->is_primitive_type()) {
         int off = access.offset().opr().as_jint() + field->offset_in_bytes() - vk->payload_offset();
-        LIRAccess inner_access(access.gen(), decorators, access.base(), LIR_OprFact::intConst(off), field->type()->basic_type(), access.patch_emit_info(), access.access_emit_info());
+        // Each pre-barrier is a different LIR instruction and needs its own CodeEmitInfo.
+        CodeEmitInfo* info = access.patch_emit_info();
+        if (info != nullptr) {
+          info = new CodeEmitInfo(info);
+        }
+        LIRAccess inner_access(access.gen(), decorators, access.base(), LIR_OprFact::intConst(off), field->type()->basic_type(), info, access.access_emit_info());
         pre_barrier(inner_access, resolve_address(inner_access, false),
                     LIR_OprFact::illegalOpr /* pre_val */, inner_access.patch_emit_info());
       }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatTwoOopField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatTwoOopField.java
@@ -21,10 +21,10 @@
  * questions.
  */
 
-// TODO  * @bug 8389089
 
 /*
  * @test
+ * @bug 8389139
  * @summary Test atomic flat field stores with two embedded oops
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatTwoOopField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatTwoOopField.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// TODO  * @bug 8389089
+
+/*
+ * @test
+ * @summary Test atomic flat field stores with two embedded oops
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.vm.annotation.NullRestricted;
+
+public class TestFlatTwoOopField {
+    static value class TwoOopValue {
+        Object x;
+        Object y;
+
+        TwoOopValue(Object x, Object y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    @NullRestricted
+    TwoOopValue field;
+
+    TestFlatTwoOopField() {
+        field = new TwoOopValue(null, null);
+        super();
+    }
+
+    static void test(TestFlatTwoOopField holder, TwoOopValue value) {
+        holder.field = value;
+    }
+
+    public static void main(String[] args) {
+        TestFlatTwoOopField holder = new TestFlatTwoOopField();
+        TwoOopValue value = new TwoOopValue(null, null);
+        for (int i = 0; i < 20_000; i++) {
+            test(holder, value);
+        }
+    }
+}


### PR DESCRIPTION
Storing a flat value with two oop fields makes C1 emit two G1 pre-barriers sharing one `CodeEmitInfo`. LinearScan then asserts while computing per-instruction oop maps. The fix is to clone the `CodeEmitInfo` so that each barrier gets its own.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389139](https://bugs.openjdk.org/browse/JDK-8389139): [lworld] C1 should not reuse CodeEmitInfo for G1 pre-barriers of atomic flat fields (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2671/head:pull/2671` \
`$ git checkout pull/2671`

Update a local copy of the PR: \
`$ git checkout pull/2671` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2671`

View PR using the GUI difftool: \
`$ git pr show -t 2671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2671.diff">https://git.openjdk.org/valhalla/pull/2671.diff</a>

</details>
