### PR TITLE
8388438: [lworld] RuntimeStub::resolve_virtual_call_blob hits "receiver_klass must be initialized" assert

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -1396,7 +1396,7 @@ void HeapShared::resolve_classes_for_subgraph_of(JavaThread* current, Klass* k) 
   JavaThread* THREAD = current;
   ExceptionMark em(THREAD);
   const ArchivedKlassSubGraphInfoRecord* record =
-   resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/false, THREAD);
+   resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/false, /*init_subgraph_first*/false, THREAD);
   if (HAS_PENDING_EXCEPTION) {
    CLEAR_PENDING_EXCEPTION;
   }
@@ -1484,7 +1484,7 @@ void HeapShared::initialize_from_archived_subgraph(JavaThread* current, Klass* k
 
   ExceptionMark em(THREAD);
   const ArchivedKlassSubGraphInfoRecord* record =
-    resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/true, THREAD);
+    resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/true, /*init_subgraph_first=*/false, THREAD);
 
   if (HAS_PENDING_EXCEPTION) {
     CLEAR_PENDING_EXCEPTION;
@@ -1500,7 +1500,7 @@ void HeapShared::initialize_from_archived_subgraph(JavaThread* current, Klass* k
 }
 
 const ArchivedKlassSubGraphInfoRecord*
-HeapShared::resolve_or_init_classes_for_subgraph_of(Klass* k, bool do_init, TRAPS) {
+HeapShared::resolve_or_init_classes_for_subgraph_of(Klass* k, bool do_init, bool init_subgraph_first, TRAPS) {
   assert(!CDSConfig::is_dumping_heap(), "Should not be called when dumping heap");
 
   if (!k->in_aot_cache()) {
@@ -1545,7 +1545,9 @@ HeapShared::resolve_or_init_classes_for_subgraph_of(Klass* k, bool do_init, TRAP
       }
     }
 
-    resolve_or_init(k, do_init, CHECK_NULL);
+    if (!init_subgraph_first) {
+      resolve_or_init(k, do_init, CHECK_NULL);
+    }
 
     // Load/link/initialize the klasses of the objects in the subgraph.
     // nullptr class loader is used.
@@ -1557,6 +1559,10 @@ HeapShared::resolve_or_init_classes_for_subgraph_of(Klass* k, bool do_init, TRAP
         }
         resolve_or_init(klass, do_init, CHECK_NULL);
       }
+    }
+
+    if (init_subgraph_first) {
+      resolve_or_init(k, do_init, CHECK_NULL);
     }
   }
 
@@ -2288,16 +2294,19 @@ void HeapShared::initialize_test_class_from_archive(JavaThread* current) {
     JavaThread* THREAD = current;
     ExceptionMark em(THREAD);
     const ArchivedKlassSubGraphInfoRecord* record =
-      resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/false, THREAD);
+      resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/false, /*init_subgraph_first*/false, THREAD);
 
     // The _test_class is in the unnamed module, so it can't call CDS.initializeFromArchive()
     // from its <clinit> method. So we set up its "archivedObjects" field first, before
-    // calling its <clinit>. This is not strictly clean, but it's a convenient way to write unit
-    // test cases (see test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchiveHeapTestClass.java).
+    // calling its <clinit>.
     if (record != nullptr) {
       init_archived_fields_for(k, record);
     }
-    resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/true, THREAD);
+
+    // This is a convenient way to write unit test cases, but the order of initialization needs
+    // to initialize the subclasses first in this case.
+    // (see test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchiveHeapTestClass.java).
+    resolve_or_init_classes_for_subgraph_of(k, /*do_init=*/true, /*init_subgraph_first*/true, THREAD);
   }
 }
 #endif

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -337,7 +337,7 @@ private:
   static void resolve_classes_for_subgraph_of(JavaThread* current, Klass* k);
   static void clear_archived_roots_of(Klass* k);
   static const ArchivedKlassSubGraphInfoRecord*
-               resolve_or_init_classes_for_subgraph_of(Klass* k, bool do_init, TRAPS);
+               resolve_or_init_classes_for_subgraph_of(Klass* k, bool do_init, bool init_subgraph_first, TRAPS);
   static void resolve_or_init(const char* klass_name, bool do_init, TRAPS);
   static void resolve_or_init(Klass* k, bool do_init, TRAPS);
   static void init_archived_fields_for(Klass* k, const ArchivedKlassSubGraphInfoRecord* record);

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1430,6 +1430,11 @@ void LinkResolver::runtime_resolve_virtual_method(CallInfo& result,
     THROW(vmSymbols::java_lang_NullPointerException());
   }
 
+  // Check that receiver class for an actual receiver-based virtual dispatch is initialized.
+  assert(!check_null_and_abstract || !recv->klass()->is_instance_klass() ||
+         !InstanceKlass::cast(recv->klass())->is_not_initialized(),
+         "must be initialized");
+
   // Virtual methods cannot be resolved before its klass has been linked, for otherwise the Method*'s
   // has not been rewritten, and the vtable initialized. Make sure to do this after the nullcheck, since
   // a missing receiver might result in a bogus lookup.

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1430,11 +1430,6 @@ void LinkResolver::runtime_resolve_virtual_method(CallInfo& result,
     THROW(vmSymbols::java_lang_NullPointerException());
   }
 
-  // Check that receiver class for an actual receiver-based virtual dispatch is initialized.
-  assert(!check_null_and_abstract || !recv->klass()->is_instance_klass() ||
-         !InstanceKlass::cast(recv->klass())->is_not_initialized(),
-         "must be initialized");
-
   // Virtual methods cannot be resolved before its klass has been linked, for otherwise the Method*'s
   // has not been rewritten, and the vtable initialized. Make sure to do this after the nullcheck, since
   // a missing receiver might result in a bogus lookup.

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -61,6 +61,3 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 
 #############################################################################
 
-# Valhalla failures start here:
-runtime/cds/appcds/aotCache/AOTMapTest.java#valhalla 8388438 generic-all
-runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8388438 generic-all


### PR DESCRIPTION
For this CDS test in ArchiveHeapTestClass path, the subgraph types are manually initialized, but they need to be called before the main class's `<clinit>`. This is only for the test, so added a conditional.  Normal control flow already runs subgraph type `<clinit>` before the main class.

The valhalla case triggers this because the class has a value class called wrapperWrapper that it adds to archivedObjects.

Added an assert in the interpreter to find the uninitialized receiver class before Xcomp reresolve_call_site finds it.

Tested with tier1-4 in progress.  cds/appcds tests manually.

This checkin will be delayed and rebased for mainline when Valhalla is integrated.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8388438](https://bugs.openjdk.org/browse/JDK-8388438): [lworld] RuntimeStub::resolve_virtual_call_blob hits "receiver_klass must be initialized" assert (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2672/head:pull/2672` \
`$ git checkout pull/2672`

Update a local copy of the PR: \
`$ git checkout pull/2672` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2672`

View PR using the GUI difftool: \
`$ git pr show -t 2672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2672.diff">https://git.openjdk.org/valhalla/pull/2672.diff</a>

</details>
