### PR TITLE
8389235: [lworld] Wrong reason for too_many_traps_or_recompiles check in Parse::speculate_non_flat_array

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4926,6 +4926,7 @@ bool Compile::final_graph_reshaping() {
 bool Compile::too_many_traps(ciMethod* method,
                              int bci,
                              Deoptimization::DeoptReason reason) {
+  assert(reason > Deoptimization::Reason_none && reason <= Deoptimization::Reason_LIMIT, "invalid reason");
   ciMethodData* md = method->method_data();
   if (md->is_empty()) {
     // Assume the trap has not occurred, or that it occurred only
@@ -4951,6 +4952,7 @@ bool Compile::too_many_traps(ciMethod* method,
 // Less-accurate variant which does not require a method and bci.
 bool Compile::too_many_traps(Deoptimization::DeoptReason reason,
                              ciMethodData* logmd) {
+  assert(reason > Deoptimization::Reason_none && reason <= Deoptimization::Reason_LIMIT, "invalid reason");
   if (trap_count(reason) >= Deoptimization::per_method_trap_limit(reason)) {
     // Too many traps globally.
     // Note that we use cumulative trap_count, not just md->trap_count.
@@ -4975,6 +4977,7 @@ bool Compile::too_many_traps(Deoptimization::DeoptReason reason,
 bool Compile::too_many_recompiles(ciMethod* method,
                                   int bci,
                                   Deoptimization::DeoptReason reason) {
+  assert(reason > Deoptimization::Reason_none && reason <= Deoptimization::Reason_LIMIT, "invalid reason");
   ciMethodData* md = method->method_data();
   if (md->is_empty()) {
     // Assume the trap has not occurred, or that it occurred only

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -772,7 +772,7 @@ class GraphKit : public Phase {
   }
 
   bool too_many_traps_or_recompiles(Deoptimization::DeoptReason reason) {
-      return C->too_many_traps_or_recompiles(method(), bci(), reason);
+    return C->too_many_traps_or_recompiles(method(), bci(), reason);
   }
 
   // Returns the object (if any) which was created the moment before.

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -581,7 +581,7 @@ Node* Parse::speculate_non_flat_array(Node* const array, const TypeAryPtr* const
       !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
     flat_array = false;
     reason = Deoptimization::Reason_speculate_class_check;
-  } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(reason)) {
+  } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(Deoptimization::Reason_class_check)) {
     ciKlass* profiled_array_type = nullptr;
     ciKlass* profiled_element_type = nullptr;
     ProfilePtrKind element_ptr = ProfileMaybeNull;


### PR DESCRIPTION
`Parse::speculate_non_flat_array` checks `Reason_none` instead of `Reason_class_check` before using array profile data. This can lead to unnecessary deoptimization and recompilation cycles.

I tried to come up with a regression test for this but it's too brittle and not worth the effort here.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389235](https://bugs.openjdk.org/browse/JDK-8389235): [lworld] Wrong reason for too_many_traps_or_recompiles check in Parse::speculate_non_flat_array (**Bug** - P5)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer) ⚠️ Review applies to [b559b539](https://git.openjdk.org/valhalla/pull/2674/files/b559b5394452deb88f7abdb8f93e71ebb1becd2f)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer) ⚠️ Review applies to [b559b539](https://git.openjdk.org/valhalla/pull/2674/files/b559b5394452deb88f7abdb8f93e71ebb1becd2f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2674/head:pull/2674` \
`$ git checkout pull/2674`

Update a local copy of the PR: \
`$ git checkout pull/2674` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2674`

View PR using the GUI difftool: \
`$ git pr show -t 2674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2674.diff">https://git.openjdk.org/valhalla/pull/2674.diff</a>

</details>
