### PR TITLE
8389088: [lworld] C2: assert(false) failed: empty program detected during loop optimization

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -3115,6 +3115,7 @@ private:
     _clones.map(phi->_idx, vt);
     Node_List casts;
     for (uint i = 1; i < phi->req(); ++i) {
+      assert(casts.size() == 0, "must be cleared");
       Node* n = phi->in(i);
       if (n == nullptr) {
         continue;
@@ -3142,6 +3143,10 @@ private:
         n->as_InlineType()->set_oop(*_phase, _phase->transform(cast));
         n = _phase->transform(n);
         if (n->is_top()) {
+          if (casts.size() > 0) {
+            // We could be skipping some unprocessed casts that are also dead. Clear the list for the next phi input.
+            casts.clear();
+          }
           break;
         }
       }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushInlineTypeDownDeadBranch.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushInlineTypeDownDeadBranch.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389088
+ * @summary Test that PushInlineTypeDown correctly handles dying branches in do_transform().
+ * @library /test/lib
+ * @enablePreview
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:+DeoptimizeALot -XX:+AlwaysIncrementalInline -XX:CompileOnly=${test.main.class}::test
+ *                   ${test.main.class}
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -Xcomp -XX:+StressIGVN -XX:+AlwaysIncrementalInline -XX:CompileOnly=${test.main.class}::test
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.test.lib.Asserts;
+
+public class TestPushInlineTypeDownDeadBranch {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            Asserts.assertEQ(test(), null);
+        }
+    }
+
+    static V test() {
+        //                                                                                         null
+        //                                                                                           |
+        //                                                                                           v
+        // Before Incremental Inlining: CallStaticJava   -> OpaqueParse -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        // After  Incremental Inlining: InlineType(null) -> OpaqueParse -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        // During IGVN:                 InlineType(null)                -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        //                              InlineType(null)                -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        //                              InlineType(null)                                                -> InlineType -> Return
+        // Before Patch:                InlineType(TOP /* wrong! */)                                    -> InlineType -> Return
+        //                              <empty>
+        // After Patch:                 InlineType(null)                                                -> InlineType -> Return
+        Object obj = foo(null);
+        return (V)obj;
+    }
+
+    static Object foo(Object obj) {
+        return (V)obj;
+    }
+
+    static value class V {
+        int i = 34;
+    }
+}


### PR DESCRIPTION
The test case fails with an empty program assertion due to wrongly folding an `InlineType` away which also removes the `Return` node, leaving us with an empty program which is unexpected.

### Graph before Incremental Inlining of `foo()`
The issue can only be observed when incrementally inlining a method that returns an `InlineType`. Before incremental inline, the graph looks like this:

<img width="536" height="551" alt="image" src="https://github.com/user-attachments/assets/8d0003ba-01b1-4cba-8f02-4b8e6b2ccfd9" />

### Graph after Incremental Inlining of `foo()`
We now late inline `foo()` and replace the `CallStaticJava` with the return value of `foo()` which is `117 InlineType`:

<img width="424" height="631" alt="image" src="https://github.com/user-attachments/assets/8d673211-3c73-446a-b975-fedb4953dec6" />

Note that we still guard it with an `OpaqueParse` that was recently introduced in mainline with [JDK-8374783](https://bugs.openjdk.org/browse/JDK-8374783).

We now discover that we have a null `117 InlineType` (i.e. with inputs representing `null`).

### Push null `117 InlineType` down through `42 Phi` during IGVN
When processing `42 Phi` during IGVN, we discover that `117 InlineType` is suitable to push down through it (we look through cast nodes).

We apply `PushInlineTypeDown` in order to get an `InlineType` that has phi inputs instead of the other way round (helps scalarization later). So far so good.

### Dead Cast Nodes not Removed from `casts` List
Depending on the IGVN order, we face an issue (note that `-XX:+DeoptimizeALot` gives us a reliable trigger vs. `-XX:+StressIGVN`). When processing `42 Phi`, we have the following graph which already removed the `118 OpaqueParse`:

<img width="426" height="546" alt="image" src="https://github.com/user-attachments/assets/d078dcb8-2ab6-40f5-b619-e06ef163c776" />

We apply `PushInlineTypeDown::do_transform()` by creating a new null `125 InlineType` with phis merging top inputs:

<img width="619" height="144" alt="image" src="https://github.com/user-attachments/assets/47271aeb-2838-4897-9815-e330b0e632e5" />

 We are now filling these. We visit the first input of `42 Phi` which is `59 CheckCastPP`. We first add all casts recursively to the `casts` LIFO list ( `59 CheckCastPP` and `48 CastPP`):

https://github.com/openjdk/valhalla/blob/f181286389fad995be1e71de60f30d14eb1c9122/src/hotspot/share/opto/cfgnode.cpp#L3122-L3125

We then pop `48 CastPP` and try to push it down through `42 Phi`. We clone it and set the oop input of `117 InlineType` as new input which is `null`. When we then call `transform()` on it, we see in `Value()` that the input type is `null`  while the cast's `_type` is `NotNull` and the join returns top. As a result, we have an `InlineType` with a top oop input. We then transform this `InlineType`:

https://github.com/openjdk/valhalla/blob/f181286389fad995be1e71de60f30d14eb1c9122/src/hotspot/share/opto/cfgnode.cpp#L3142-L3143

and get top as well. We break the loop because we discovered that the path is dead:

https://github.com/openjdk/valhalla/blob/f181286389fad995be1e71de60f30d14eb1c9122/src/hotspot/share/opto/cfgnode.cpp#L3144-L3146

We do not need to update `125 InlineType` because the path is dead.

The problem now is: The `casts` list still contains the unprocessed `59 CheckCastPP` which is also dead.

### Wrongly Assuming `59 CheckCastPP` Is Part of `42 Phi`'s Second Input
We now continue processing the second input of `42 Phi` which is null. Since we have not cleared the `casts` list, we wrongly assume that we have `42 Phi` <- `59 CheckCastPP` <- `null` which is wrong. We pop `59 CheckCastPP`, find that it is also top, feed it as oop into the newly created `InlineType` for this branch, then transform it and find that this input path of `42 Phi` is also dead which is wrong.

We return `125 InlineType` unmodified with phis merging top and eventually IGVN will remove that node as well together with the `Return` following below. We are left with an empty program and crash.

### Solution
The solution is straight forward: Clear the `casts` list when we've processed a dead cast node to avoid propagating them to the next phi input.

### Follow-Up RFE
With this fix, I've noticed that we end up with a null-`InlineType` that is fed as oop input into another null-`InlineType`:

<img width="402" height="188" alt="image" src="https://github.com/user-attachments/assets/36b998ce-a74d-4cb2-bba1-3fa43e9610f7" />

I think we could follow up with an RFE to also clean this up. We already optimize `InlineType` oop inputs but only if they are known to be non-null:
https://github.com/openjdk/valhalla/blob/f181286389fad995be1e71de60f30d14eb1c9122/src/hotspot/share/opto/inlinetypenode.cpp#L1196

We could extend this and set the oop input of `this` to null if we know that the `NullMarker` of the `this` is 0.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389088](https://bugs.openjdk.org/browse/JDK-8389088): [lworld] C2: assert(false) failed: empty program detected during loop optimization (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2678/head:pull/2678` \
`$ git checkout pull/2678`

Update a local copy of the PR: \
`$ git checkout pull/2678` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2678`

View PR using the GUI difftool: \
`$ git pr show -t 2678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2678.diff">https://git.openjdk.org/valhalla/pull/2678.diff</a>

</details>
