### PR TITLE
8389322: [lworld] Disable TestNullableInlineTypes::test103() until JDK-8389088 is fixed

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -3018,6 +3018,7 @@ public class TestNullableInlineTypes {
     }
 
     // Test that the ConstraintCastNode::Ideal transformation propagates null-free information
+    /* TODO 8389088: Re-enable once fixed.
     @Test
     public MyValue1 test103() {
         Object obj = hide(null);
@@ -3028,6 +3029,7 @@ public class TestNullableInlineTypes {
     public void test103_verifier() {
         Asserts.assertEQ(test103(), null);
     }
+     */
 
     // Test null restricted fields
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -3029,7 +3029,7 @@ public class TestNullableInlineTypes {
     public void test103_verifier() {
         Asserts.assertEQ(test103(), null);
     }
-     */
+    */
 
     // Test null restricted fields
 


### PR DESCRIPTION
Instead of problemlisting the entire test, we should disable TestNullableInlineTypes::test103() in order to reduce the noise in the CI in tier6.

Testing `TestNullableInlineTypes` in all possible flag combos (also includes more configs than normally seen in the CI):
- tier1-6
- hs-comp-stress + valhalla-comp-stress

Only found a different crash which should be fixed by [JDK-8388435](https://bugs.openjdk.org/browse/JDK-8388435) (currently open mainline issue). This failure was with a flag combination that we do not see in standard CI runs (`-DIgnoreCompilerControls=true -XX:CompileThreshold=100 -DVerifyIR=false`).

Note that JDK-8389322 will be fixed after Valhalla integration: https://github.com/openjdk/valhalla/pull/2678

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389322](https://bugs.openjdk.org/browse/JDK-8389322): [lworld] Disable TestNullableInlineTypes::test103() until JDK-8389088 is fixed (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2679/head:pull/2679` \
`$ git checkout pull/2679`

Update a local copy of the PR: \
`$ git checkout pull/2679` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2679`

View PR using the GUI difftool: \
`$ git pr show -t 2679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2679.diff">https://git.openjdk.org/valhalla/pull/2679.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2679#issuecomment-5117712429)
</details>
