### PR TITLE
8389341: [lworld] C2 Class.isAssignableFrom intrinsic returns false for identical array Class arguments

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4686,6 +4686,7 @@ bool LibraryCallKit::inline_native_subtype_check() {
                                 // {P,P} & superc!=subc => false
     _prim_same_path,            // {P,P} & superc==subc => true
     _prim_1_path,               // {N,P} => false
+    _ref_same_path,             // {N,N} & superk==subk => true
     _ref_subtype_path,          // {N,N} & subtype check wins => true
     _both_ref_path,             // {N,N} & subtype check loses => false
     PATH_LIMIT
@@ -4733,6 +4734,16 @@ bool LibraryCallKit::inline_native_subtype_check() {
     // now we have two reference types, in klasses[0..1]
     Node* subk   = klasses[1];  // the argument to isAssignableFrom
     Node* superk = klasses[0];  // the receiver
+
+    // gen_subtype_check() refines exact array superklasses for comparison with
+    // (refined) klasses loaded from the header. Since both operands here are unrefined
+    // klasses, handle equality first. Unequal types then use the regular hierarchy check.
+    Node* cmp = _gvn.transform(new CmpPNode(subk, superk));
+    Node* bol = _gvn.transform(new BoolNode(cmp, BoolTest::eq));
+    IfNode* iff = create_and_xform_if(control(), bol, PROB_STATIC_FREQUENT, COUNT_UNKNOWN);
+    region->set_req(_ref_same_path, _gvn.transform(new IfTrueNode(iff)));
+    set_control(_gvn.transform(new IfFalseNode(iff)));
+
     region->set_req(_both_ref_path, gen_subtype_check(subk, superk));
     region->set_req(_ref_subtype_path, control());
   }
@@ -4757,6 +4768,7 @@ bool LibraryCallKit::inline_native_subtype_check() {
 
   // these are the only paths that produce 'true':
   phi->set_req(_prim_same_path,   intcon(1));
+  phi->set_req(_ref_same_path,    intcon(1));
   phi->set_req(_ref_subtype_path, intcon(1));
 
   // pull together the cases:

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIsAssignableFrom.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIsAssignableFrom.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389341
+ * @summary Test that Class.isAssignableFrom returns true for two identical arguments.
+ * @library /test/lib
+ * @run main ${test.main.class}
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   -XX:CompileCommand=delayinline,${test.main.class}::helperDelayed
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.test.lib.Asserts;
+
+public final class TestIsAssignableFrom {
+    static boolean test(Class<?> c) {
+        return TestIsAssignableFrom[].class.isAssignableFrom(c);
+    }
+
+    static Class<?> helperDelayed() {
+        return TestIsAssignableFrom[].class;
+    }
+
+    static boolean testLate(Class<?> c) {
+        return helperDelayed().isAssignableFrom(c);
+    }
+
+    public static void main(String[] args) {
+        Asserts.assertEQ(test(TestIsAssignableFrom[].class), true);
+        Asserts.assertEQ(testLate(TestIsAssignableFrom[].class), true);
+    }
+}
+


### PR DESCRIPTION
Since [JDK-8366705](https://bugs.openjdk.org/browse/JDK-8366705), an object array Java type is represented by an **_unrefined_** array Klass. Actual array objects use a **_refined_** array Klass describing their concrete layout/properties. All refined variants share the same Java Class mirror, which refers to the unrefined Klass.

C2’s `SubTypeCheckNode` normally compares a refined sub-Klass loaded from an object header against an unrefined Java-level super-Klass. For fast pointer comparisons, it converts an exact array superclass to its refined form. This is correct for callers such as instanceof, casts, and arraycopy:
https://github.com/openjdk/valhalla/blob/f181286389fad995be1e71de60f30d14eb1c9122/src/hotspot/share/opto/graphKit.cpp#L3052-L3057

The `Class.isAssignableFrom` intrinsic is different though: both klasses are loaded from Class mirrors and are therefore unrefined. Above code then nevertheless refines the super-klass for the direct comparison while leaving the sub-klass unrefined. The pointers differed even when both represented the same Java array type, causing the intrinsic to incorrectly return false.

The intrinsic now compares the two unrefined klasses loaded from the mirror before invoking the general subtype helper. Identical Java types return true directly, while unequal types continue through the existing hierarchy-based subtype check.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389341](https://bugs.openjdk.org/browse/JDK-8389341): [lworld] C2 Class.isAssignableFrom intrinsic returns false for identical array Class arguments (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2680/head:pull/2680` \
`$ git checkout pull/2680`

Update a local copy of the PR: \
`$ git checkout pull/2680` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2680`

View PR using the GUI difftool: \
`$ git pr show -t 2680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2680.diff">https://git.openjdk.org/valhalla/pull/2680.diff</a>

</details>
