### PR TITLE
8389354: [lworld] PhaseIdealLoop::move_flat_array_check_out_of_loop creates anti-dependence cycle

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1133,7 +1133,7 @@ void PhaseIdealLoop::move_flat_array_check_out_of_loop(Node* n) {
     return;
   }
   Node* mem = n->in(FlatArrayCheckNode::Memory);
-  Node* array = n->in(FlatArrayCheckNode::ArrayOrKlass)->uncast();
+  Node* array = n->in(FlatArrayCheckNode::ArrayOrKlass);
   IdealLoopTree* check_loop = get_loop(get_ctrl(n));
   IdealLoopTree* ary_loop = get_loop(get_ctrl(array));
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayCheckHoisting.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayCheckHoisting.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8389354
+ * @summary Test that moving a flat array check does not create an anti-dependence cycle
+ * @enablePreview
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:-UseArrayLoadStoreProfile
+ *                   -XX:+StressGCM -XX:StressSeed=0
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestFlatArrayCheckHoisting {
+    // A and C arrays are flat, B is too large to flatten and I has identity
+    static value class A { final int x; A(int x) { this.x = x; } }
+    static value class B { final long x, y; B(long x, long y) { this.x = x; this.y = y; } }
+    static value class C { final int x; C(int x) { this.x = x; } }
+    static final class I { final int x; I(int x) { this.x = x; } }
+
+    static long helper(Object v) {
+        if (v instanceof A x) return x.x;
+        if (v instanceof B x) return x.x * 3 + x.y;
+        if (v instanceof C x) return x.x * 3;
+        return ((I)v).x * 3;
+    }
+
+    static long test(Object[] a, int kind) {
+        long sum = 0;
+        for (int i = 0; i < 150_000; i++) {
+            Object v = switch (kind) {
+                case 0 -> new A(i);
+                case 1 -> new B(i, i ^ 1);
+                case 2 -> new I(i);
+                default -> new C(i);
+            };
+            int index = i & 1;
+            // The FlatArrayCheck for below access is incorrectly moved out of the loop
+            a[index] = v;
+            Object loaded = a[index];
+            if (helper(loaded) != helper(v)) {
+                throw new AssertionError();
+            }
+            if (kind == 3) {
+                C copy = new C(((C)v).x);
+                if (v != copy) {
+                    throw new AssertionError();
+                }
+            }
+            sum += helper(a[index]);
+        }
+        return sum;
+    }
+
+    public static void main(String[] args) {
+        // Alternate non-flat and flat layouts until C2 uses a generic flat-array check
+        test(new I[2], 2);
+        test(new A[2], 0);
+        test(new B[2], 1);
+        test(new C[2], 3);
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3087,9 +3087,11 @@ public class TestLWorld {
     @IR(applyIf = {"UseArrayFlattening", "true"},
         failOn = {STORE_UNKNOWN_INLINE, INLINE_ARRAY_NULL_GUARD},
         counts = {COUNTED_LOOP, "= 2", LOAD_UNKNOWN_INLINE, "= 2"},
-         // Match on CCP since we are removing one of the unswitched loop versions later due to being empty
+        // Match on CCP since we are removing one of the unswitched loop versions later due to being empty
         phase = {CompilePhase.CCP1})
     public void test107(Object[] src1, Object[] src2) {
+        // Null check both arrays before the loop to allow both flat array checks to be hoisted.
+        src2 = Objects.requireNonNull(src2);
         for (int i = 0; i < src1.length; i++) {
             oFld1 = src1[i];
             oFld2 = src2[i];


### PR DESCRIPTION
`FlatArrayCheckNode` reads the array mark word using raw memory. `PhaseIdealLoop::move_flat_array_check_out_of_loop()` attempts to move it out of loops to enable optimizations such as loop unswitching:
https://github.com/openjdk/valhalla/blob/3f00d9dc481dfcc529f3a214fed35615582557f8/src/hotspot/share/opto/loopopts.cpp#L1126-L1130

The code determines if the **uncasted** array is loop-invariant:
https://github.com/openjdk/valhalla/blob/3f00d9dc481dfcc529f3a214fed35615582557f8/src/hotspot/share/opto/loopopts.cpp#L1137-L1141

In the failing test, the `FlatArrayCheck` comes from the `a[index] = v store`, i.e. the uncasted value is `a`, but the actual input is a non-null `CastPP` of `a` with control inside the loop, below the `MemBarStoreStore` for a value-object allocation in one of the switch cases.

C2 therefore considered the array loop invariant and moved the check's raw-memory input above the barrier. Its control could not move because it still depended on the in-loop cast.
https://github.com/openjdk/valhalla/blob/3f00d9dc481dfcc529f3a214fed35615582557f8/src/hotspot/share/opto/loopopts.cpp#L1166-L1168

After macro expansion, the mark-word load consequently had a memory dependency placing it **above** the barrier and a control dependency placing it **below** the same barrier -> :boom: 

The fix is to not do the uncast. I first thought about replacing the node's `ArrayOrKlass` input with the uncast value but that would not be safe: it would discard the cast’s null/type-guard dependency and could allow the mark-word load to execute above that guard.

The test is a simplified version of a generated test. Unfortunately, I could not simplify it further - believe me, I tried.

I also had to adjust `TestLWorld::test107` because there is a loop-local non-null cast of `src2`, preventing its flat-array check from hoisting and causing unswitching to clone the `LOAD_UNKNOWN_INLINE`. Pre-null-checking`src2` makes the cast loop-invariant and enables hoisting. An alternative would be to retry `FlatArrayCheck` hoisting after loop predication but before `iteration_split`. I leave this to future work though because it's quite invasive.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389354](https://bugs.openjdk.org/browse/JDK-8389354): [lworld] PhaseIdealLoop::move_flat_array_check_out_of_loop creates anti-dependence cycle (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2682/head:pull/2682` \
`$ git checkout pull/2682`

Update a local copy of the PR: \
`$ git checkout pull/2682` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2682`

View PR using the GUI difftool: \
`$ git pr show -t 2682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2682.diff">https://git.openjdk.org/valhalla/pull/2682.diff</a>

</details>
