### PR TITLE
8389365: [lworld] Fix ProblemList marker comments and misc cleanups

### DIFF
--- a/test/docs/ProblemList.txt
+++ b/test/docs/ProblemList.txt
@@ -56,4 +56,4 @@
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/hotspot/jtreg/ProblemList-AotJdk.txt
+++ b/test/hotspot/jtreg/ProblemList-AotJdk.txt
@@ -73,4 +73,4 @@ compiler/arraycopy/TestCloneWithStressReflectiveCode.java 8323727 generic-all
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/hotspot/jtreg/ProblemList-StaticJdk.txt
+++ b/test/hotspot/jtreg/ProblemList-StaticJdk.txt
@@ -52,4 +52,4 @@ gtest/NMTGtests.java#nmt-summary                        8356201 generic-all
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -98,4 +98,4 @@ vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.ja
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -61,6 +61,6 @@ gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:
 runtime/cds/appcds/aotCache/AOTMapTest.java#valhalla 8388438 generic-all
 runtime/cds/appcds/cacheObject/ArchivedFlatArrayTest.java 8388438 generic-all

--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -33,7 +33,7 @@
 #
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:
 
 # Compiler:
 

--- a/test/hotspot/jtreg/ProblemList-jvmti-stress-agent.txt
+++ b/test/hotspot/jtreg/ProblemList-jvmti-stress-agent.txt
@@ -107,4 +107,4 @@ serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorVMEventsTest.java#id1     
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -46,5 +46,5 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -196,7 +196,7 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:
 applications/ctw/modules/java_base.java 8375645 generic-all
 applications/ctw/modules/java_base_2.java 8375645 generic-all
 
@@ -208,6 +208,7 @@ serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compil
 
 vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all
 
-# The following test failures DID NOT reproduce during Tier[1-8] testing
-# done for 8377828. Further analysis is being done with 8376235:
+# The following test failure(s) DID NOT reproduce during Tier[1-8] testing
+# done for 8377828. Further analysis was done with 8376235 and just one
+# sub-test needed to remain on the ProblemList via 8361089.
 compiler/codegen/TestRedundantLea.java#RegexFind          8361089 generic-all

--- a/test/jaxp/ProblemList.txt
+++ b/test/jaxp/ProblemList.txt
@@ -39,4 +39,4 @@
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-AotJdk.txt
+++ b/test/jdk/ProblemList-AotJdk.txt
@@ -60,4 +60,4 @@ java/util/Locale/UseOldISOCodesTest.java                       0000000 generic-a
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-StaticJdk.txt
+++ b/test/jdk/ProblemList-StaticJdk.txt
@@ -41,4 +41,4 @@
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -50,4 +50,4 @@ java/lang/ScopedValue/StressStackOverflow.java#TieredStopAtLevel1 8309646 generi
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -46,4 +46,4 @@ java/lang/reflect/callerCache/ReflectionCallerCacheTest.java    8332028 generic-
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-enable-preview.txt
+++ b/test/jdk/ProblemList-enable-preview.txt
@@ -33,4 +33,4 @@
 #
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-jvmti-stress-agent.txt
+++ b/test/jdk/ProblemList-jvmti-stress-agent.txt
@@ -46,4 +46,4 @@ java/lang/ref/ReachabilityFenceTest.java                                    0000
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-shenandoah.txt
+++ b/test/jdk/ProblemList-shenandoah.txt
@@ -74,4 +74,4 @@ jdk/jfr/startupargs/TestOldObjectQueueSize.java         8342951     generic-all
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -45,4 +45,4 @@ com/sun/jdi/ThreadMemoryLeakTest.java              8307402   generic-all
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -695,7 +695,7 @@ tools/sincechecker/modules/jdk.management.jfr/JdkManagementJfrCheckSince.java 83
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:
 
 java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java 8375778 macosx-aarch64
 

--- a/test/langtools/ProblemList-StaticJdk.txt
+++ b/test/langtools/ProblemList-StaticJdk.txt
@@ -41,4 +41,4 @@
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/langtools/ProblemList-enable-preview.txt
+++ b/test/langtools/ProblemList-enable-preview.txt
@@ -33,5 +33,5 @@
 #
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:
 

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -88,4 +88,4 @@ tools/javap/output/RepeatingTypeAnnotations.java                                
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/lib-test/ProblemList-StaticJdk.txt
+++ b/test/lib-test/ProblemList-StaticJdk.txt
@@ -41,4 +41,4 @@
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:

--- a/test/lib-test/ProblemList.txt
+++ b/test/lib-test/ProblemList.txt
@@ -54,4 +54,4 @@
 
 #############################################################################
 
-# Valhalla failures start here:
+# Value Objects failures start here:


### PR DESCRIPTION
Trivial changeset to fix ProblemList marker comments and misc cleanups.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389365](https://bugs.openjdk.org/browse/JDK-8389365): [lworld] Fix ProblemList marker comments and misc cleanups (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2683/head:pull/2683` \
`$ git checkout pull/2683`

Update a local copy of the PR: \
`$ git checkout pull/2683` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2683`

View PR using the GUI difftool: \
`$ git pr show -t 2683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2683.diff">https://git.openjdk.org/valhalla/pull/2683.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/2683#issuecomment-5121277134)
</details>
