### PR TITLE
8389391: [lworld] Return buffer allocation for late-inlined MH calls should not initialize the class

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -27,6 +27,7 @@
 #include "ci/ciMemberName.hpp"
 #include "ci/ciMethodHandle.hpp"
 #include "ci/ciObjArray.hpp"
+#include "ci/ciStreams.hpp"
 #include "classfile/javaClasses.hpp"
 #include "compiler/compileLog.hpp"
 #include "oops/accessDecorators.hpp"
@@ -772,13 +773,19 @@ void CallGenerator::do_late_inline_helper() {
     Node* buffer_oop = nullptr;
     ciMethod* inline_method = inline_cg()->method();
     ciType* return_type = inline_method->return_type();
-    if (!call->tf()->returns_inline_type_as_fields() &&
-        return_type->is_inlinetype() && return_type->as_inline_klass()->can_be_returned_as_fields()) {
-      assert(is_mh_late_inline(), "Unexpected return type");
+    // Allocate a buffer for the inline type returned as fields because the caller expects an oop return.
+    // Moving this after the call would require distinct JVM states: a next-BCI state with the result for
+    // deoptimization at an allocation safepoint and an invoke-BCI state for exceptions like OOME. The
+    // pre-call state can safely execute the call if allocation deoptimizes.
+    bool needs_return_buffer = !call->tf()->returns_inline_type_as_fields() &&
+                               return_type->is_inlinetype() &&
+                               return_type->as_inline_klass()->can_be_returned_as_fields();
+    // A non-null scalarized return would require a buffer. Since allocating that buffer could
+    // initialize the value class, speculate that the result is null and deoptimize otherwise.
+    bool assert_null_return = needs_return_buffer && !return_type->as_inline_klass()->is_initialized();
+    assert(!needs_return_buffer || is_mh_late_inline(), "Unexpected return type");
 
-      // Allocate a buffer for the inline type returned as fields because the caller expects an oop return.
-      // Do this before the method handle call in case the buffer allocation triggers deoptimization and
-      // we need to "re-execute" the call in the interpreter (to make sure the call is only executed once).
+    if (needs_return_buffer && !assert_null_return) {
       GraphKit arg_kit(jvms, &gvn);
       {
         PreserveReexecuteState preexecs(&arg_kit);
@@ -840,6 +847,20 @@ void CallGenerator::do_late_inline_helper() {
         if (vt != nullptr) {
           if (call->tf()->returns_inline_type_as_fields()) {
             vt->replace_call_results(&kit, call, C);
+          } else if (assert_null_return && !vt->is_allocated(&kit.gvn())) {
+            // Deoptimize if the result is non-null.
+            // Put the trap at the next bytecode to avoid re-executing the method handle call.
+            ciBytecodeStream iter(kit.method());
+            iter.force_bci(kit.bci());
+            assert(Bytecodes::is_invoke(iter.cur_bc()), "unexpected bytecode: %s", Bytecodes::name(iter.cur_bc()));
+            int bci = kit.bci();
+            kit.push(vt);
+            kit.set_bci(iter.next_bci());
+            result = kit.null_assert(vt);
+            kit.set_bci(bci);
+            if (!kit.stopped()) {
+              result = kit.pop();
+            }
           } else {
             // Result might still be allocated (for example, if it has been stored to a non-flat field)
             if (!vt->is_allocated(&kit.gvn())) {
@@ -899,6 +920,7 @@ void CallGenerator::do_late_inline_helper() {
       }
     }
 
+    C->set_do_cleanup(kit.stopped()); // path is dead; needs cleanup
     kit.replace_call(call, result, true, do_asserts);
   }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestReturnBufferClassInitialization.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestReturnBufferClassInitialization.java
@@ -78,7 +78,7 @@ public class TestReturnBufferClassInitialization {
     }
 
     static Object test() throws Throwable {
-        // Late inlining exposes target's scalarized UninitializedValue return at this Object-returning call site.
+        // Late inlining 'target' through the MH requires buffering because the caller expects an oop return.
         // C2 must not initialize UninitializedValue by allocating an unused buffer when the result is null.
         return (Object) HANDLE.invokeExact();
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestReturnBufferClassInitialization.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestReturnBufferClassInitialization.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8389391
+ * @key stress randomness
+ * @summary Return buffer allocation for late-inlined MH calls should not initialize the class.
+ * @requires vm.compiler2.enabled
+ * @library /test/lib
+ * @enablePreview
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+StressIncrementalInlining -XX:StressSeed=1
+ *                   -XX:CompileCommand=exclude,${test.main.class}::target
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import jdk.test.lib.Asserts;
+
+public class TestReturnBufferClassInitialization {
+    static boolean initialized;
+    static boolean returnNonNull;
+    static int invocations;
+
+    static value class UninitializedValue {
+        final int value;
+
+        UninitializedValue(int value) {
+            this.value = value;
+        }
+
+        static {
+            initialized = true;
+        }
+    }
+
+    static UninitializedValue target() {
+        invocations++;
+        return returnNonNull ? new UninitializedValue(42) : null;
+    }
+
+    static final MethodHandle HANDLE;
+    static {
+        try {
+            MethodType exact = MethodType.methodType(UninitializedValue.class);
+            MethodHandle target = MethodHandles.lookup().findStatic(TestReturnBufferClassInitialization.class, "target", exact);
+            HANDLE = target.asType(exact.changeReturnType(Object.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    static Object test() throws Throwable {
+        // Late inlining exposes target's scalarized UninitializedValue return at this Object-returning call site.
+        // C2 must not initialize UninitializedValue by allocating an unused buffer when the result is null.
+        return (Object) HANDLE.invokeExact();
+    }
+
+    public static void main(String[] args) throws Throwable {
+        Asserts.assertFalse(initialized, "Should not be initialized");
+        Object result = null;
+        for (int i = 0; i < 10_000; i++) {
+            result = test();
+        }
+        Asserts.assertNull(result, "Unexpected result");
+        Asserts.assertFalse(initialized, "Should not be initialized");
+        Asserts.assertEQ(invocations, 10_000, "Unexpected invocation count");
+
+        // Test that a non-null scalarized return deoptimizes at the next BCI without re-executing target
+        returnNonNull = true;
+        result = test();
+        Asserts.assertEQ(invocations, 10_001, "Unexpected invocation count - target re-executed?");
+        Asserts.assertEQ(result, new UninitializedValue(42), "Unexpected result");
+        Asserts.assertTrue(initialized, "Should now be initialized");
+    }
+}
+


### PR DESCRIPTION
During late MethodHandle inlining, C2 preallocates a return buffer when the inlined target returns a scalarized value object but the caller expects an oop. This allocation can initialize the value class even when the target only returns null and the buffer is never used.

Similar to https://github.com/openjdk/valhalla/pull/2670, let's just assert that the result is null if the value class is uninitialized and deopt if we observe a non-null return value.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389391](https://bugs.openjdk.org/browse/JDK-8389391): [lworld] Return buffer allocation for late-inlined MH calls should not initialize the class (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2685/head:pull/2685` \
`$ git checkout pull/2685`

Update a local copy of the PR: \
`$ git checkout pull/2685` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2685`

View PR using the GUI difftool: \
`$ git pr show -t 2685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2685.diff">https://git.openjdk.org/valhalla/pull/2685.diff</a>

</details>
