### PR TITLE
8389130: [lworld] Compiled frame walking is slow due to scalarized calling convention handling

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -793,52 +793,6 @@ frame::frame(void* sp, void* fp, void* pc) {
 
 #endif
 
-// Check for a method with scalarized inline type arguments that needs
-// a stack repair and return the repaired sender stack pointer.
-intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const {
-  nmethod* nm = _cb->as_nmethod_or_null();
-  if (nm != nullptr && nm->needs_stack_repair()) {
-    // The stack increment resides just below the saved FP on the stack and
-    // records the total frame size excluding the two words for saving FP and LR
-    // (see MacroAssembler::remove_frame).
-    intptr_t* sp_inc_addr = (intptr_t*) (saved_fp_addr - 1);
-    assert(*sp_inc_addr % StackAlignmentInBytes == 0, "sp_inc not aligned");
-    int real_frame_size = (*sp_inc_addr / wordSize) + metadata_words_at_bottom;
-    assert(real_frame_size >= _cb->frame_size() && real_frame_size <= 1000000, "invalid frame size");
-    sender_sp = unextended_sp() + real_frame_size;
-  }
-  return sender_sp;
-}
-
-// See comment in MacroAssembler::remove_frame
-frame::CompiledFramePointers frame::compiled_frame_details() const {
-  // we cannot rely upon the last fp having been saved to the thread
-  // in C2 code but it will have been pushed onto the stack. so we
-  // have to find it relative to the unextended sp
-
-  assert(_cb->frame_size() > 0, "must have non-zero frame size");
-
-  // if need stack repair: the bottom of the fake frame, under LR #2
-  // else the bottom of the frame
-  intptr_t* l_sender_sp = (!PreserveFramePointer || _sp_is_trusted)
-      ? unextended_sp() + _cb->frame_size()
-      : sender_sp();
-
-  assert(!_sp_is_trusted || l_sender_sp == real_fp(), "");
-
-  // the actual bottom of the frame. This actually changes something if the frame needs stack repair
-  l_sender_sp = repair_sender_sp(l_sender_sp, (intptr_t**)(l_sender_sp - frame::sender_sp_offset));
-
-  // From the sender's sp, we can locate the real saved lr (x30) and rfp (x29): they are
-  // immediately above, no matter if the stack was extended or not
-  CompiledFramePointers cfp;
-  cfp.sender_sp = l_sender_sp;
-  cfp.saved_fp_addr = (intptr_t**)(l_sender_sp - frame::sender_sp_offset);
-  cfp.sender_pc_addr = (address*)(l_sender_sp - frame::return_addr_offset);
-
-  return cfp;
-}
-
 intptr_t* frame::repair_sender_sp(nmethod* nm, intptr_t* sp, intptr_t** saved_fp_addr) {
   assert(nm != nullptr && nm->needs_stack_repair(), "");
   // The stack increment resides just below the saved FP on the stack and

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -408,7 +408,7 @@ inline int frame::sender_sp_ret_address_offset() {
 
 //------------------------------------------------------------------------------
 // frame::sender
-inline frame frame::sender(RegisterMap* map) const {
+ALWAYSINLINE frame frame::sender(RegisterMap* map) const {
   frame result = sender_raw(map);
 
   if (map->process_frames() && !map->in_cont()) {
@@ -421,7 +421,7 @@ inline frame frame::sender(RegisterMap* map) const {
   return result;
 }
 
-inline frame frame::sender_raw(RegisterMap* map) const {
+ALWAYSINLINE frame frame::sender_raw(RegisterMap* map) const {
   // Default is we done have to follow them. The sender_for_xxx will
   // update it accordingly
   map->set_include_argument_oops(false);
@@ -446,7 +446,53 @@ inline frame frame::sender_raw(RegisterMap* map) const {
   return frame(sender_sp(), link(), sender_pc());
 }
 
-inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
+// Check for a method with scalarized inline type arguments that needs
+// a stack repair and return the repaired sender stack pointer.
+ALWAYSINLINE intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const {
+  nmethod* nm = _cb->as_nmethod_or_null();
+  if (nm != nullptr && nm->needs_stack_repair()) {
+    // The stack increment resides just below the saved FP on the stack and
+    // records the total frame size excluding the two words for saving FP and LR
+    // (see MacroAssembler::remove_frame).
+    intptr_t* sp_inc_addr = (intptr_t*) (saved_fp_addr - 1);
+    assert(*sp_inc_addr % StackAlignmentInBytes == 0, "sp_inc not aligned");
+    int real_frame_size = (*sp_inc_addr / wordSize) + metadata_words_at_bottom;
+    assert(real_frame_size >= _cb->frame_size() && real_frame_size <= 1000000, "invalid frame size");
+    sender_sp = unextended_sp() + real_frame_size;
+  }
+  return sender_sp;
+}
+
+// See comment in MacroAssembler::remove_frame
+ALWAYSINLINE frame::CompiledFramePointers frame::compiled_frame_details() const {
+  // we cannot rely upon the last fp having been saved to the thread
+  // in C2 code but it will have been pushed onto the stack. so we
+  // have to find it relative to the unextended sp
+
+  assert(_cb->frame_size() > 0, "must have non-zero frame size");
+
+  // if need stack repair: the bottom of the fake frame, under LR #2
+  // else the bottom of the frame
+  intptr_t* l_sender_sp = (!PreserveFramePointer || _sp_is_trusted)
+      ? unextended_sp() + _cb->frame_size()
+      : sender_sp();
+
+  assert(!_sp_is_trusted || l_sender_sp == real_fp(), "");
+
+  // the actual bottom of the frame. This actually changes something if the frame needs stack repair
+  l_sender_sp = repair_sender_sp(l_sender_sp, (intptr_t**)(l_sender_sp - frame::sender_sp_offset));
+
+  // From the sender's sp, we can locate the real saved lr (x30) and rfp (x29): they are
+  // immediately above, no matter if the stack was extended or not
+  CompiledFramePointers cfp;
+  cfp.sender_sp = l_sender_sp;
+  cfp.saved_fp_addr = (intptr_t**)(l_sender_sp - frame::sender_sp_offset);
+  cfp.sender_pc_addr = (address*)(l_sender_sp - frame::return_addr_offset);
+
+  return cfp;
+}
+
+ALWAYSINLINE frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   CompiledFramePointers cfp = compiled_frame_details();
 
   // The return_address is always the word on the stack.

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -406,8 +406,10 @@ inline int frame::sender_sp_ret_address_offset() {
   return frame::sender_sp_offset - frame::return_addr_offset;
 }
 
-//------------------------------------------------------------------------------
-// frame::sender
+// This method can be on a hot path. Since Valhalla made it a bit bigger, compilers are
+// not as eager to inline it, but in some cases, it makes a significant difference.
+// Let's encourage the compiler to inline sender all the way to frame::repair_sender_sp.
+// through frame::sender_for_compiled_frame.
 ALWAYSINLINE frame frame::sender(RegisterMap* map) const {
   frame result = sender_raw(map);
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -649,41 +649,6 @@ frame::frame(void* sp, void* fp, void* pc) {
 
 #endif
 
-// Check for a method with scalarized inline type arguments that needs
-// a stack repair and return the repaired sender stack pointer.
-intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const {
-  nmethod* nm = _cb->as_nmethod_or_null();
-  if (nm != nullptr && nm->needs_stack_repair()) {
-    // The stack increment resides just below the saved rbp on the stack
-    // and does not account for the return address and rbp (see MacroAssembler::remove_frame).
-    intptr_t* real_frame_size_addr = (intptr_t*) (saved_fp_addr - 1);
-    int real_frame_size = (*real_frame_size_addr / wordSize) + metadata_words_at_bottom;
-    assert(real_frame_size >= _cb->frame_size() && real_frame_size <= 1000000, "invalid frame size");
-    sender_sp = unextended_sp() + real_frame_size;
-  }
-  return sender_sp;
-}
-
-
-// See comment in MacroAssembler::remove_frame
-frame::CompiledFramePointers frame::compiled_frame_details() const {
-  // frame owned by optimizing compiler
-  assert(_cb->frame_size() > 0, "must have non-zero frame size");
-  intptr_t* sender_sp = unextended_sp() + _cb->frame_size();
-  assert(sender_sp == real_fp(), "");
-
-  // Repair the sender sp if the frame has been extended
-  sender_sp = repair_sender_sp(sender_sp, (intptr_t**)(sender_sp - frame::sender_sp_offset));
-
-  CompiledFramePointers cfp;
-  cfp.sender_sp = sender_sp;
-  cfp.saved_fp_addr = (intptr_t**)(sender_sp - frame::sender_sp_offset);
-  // On Intel the return_address is always the word on the stack
-  cfp.sender_pc_addr = (address*)(sender_sp - frame::return_addr_offset);
-
-  return cfp;
-}
-
 intptr_t* frame::repair_sender_sp(nmethod* nm, intptr_t* sp, intptr_t** saved_fp_addr) {
   assert(nm != nullptr && nm->needs_stack_repair(), "");
   // The stack increment resides just below the saved rbp on the stack

--- a/src/hotspot/cpu/x86/frame_x86.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.hpp
@@ -138,13 +138,13 @@
 
  public:
   // Support for scalarized inline type calling convention
-  intptr_t* repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const;
+  ALWAYSINLINE intptr_t* repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const;
   struct CompiledFramePointers {
     intptr_t* sender_sp;       // The top of the stack of the sender
     intptr_t** saved_fp_addr;  // Where RBP is saved on the stack
     address* sender_pc_addr;   // Where return address (copy #1 in remove_frame's comment) is saved on the stack
   };
-  CompiledFramePointers compiled_frame_details() const;
+  ALWAYSINLINE CompiledFramePointers compiled_frame_details() const;
   static intptr_t* repair_sender_sp(nmethod* nm, intptr_t* sp, intptr_t** saved_fp_addr);
   bool was_augmented_on_entry(int& real_size) const;
 
@@ -182,6 +182,6 @@
   void interpreter_frame_set_last_sp(intptr_t* sp);
 
   // returns the sending frame, without applying any barriers
-  inline frame sender_raw(RegisterMap* map) const;
+  ALWAYSINLINE frame sender_raw(RegisterMap* map) const;
 
 #endif // CPU_X86_FRAME_X86_HPP

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -390,9 +390,10 @@ inline int frame::sender_sp_ret_address_offset() {
   return frame::sender_sp_offset - frame::return_addr_offset;
 }
 
-//------------------------------------------------------------------------------
-// frame::sender
-
+// This method can be on a hot path. Since Valhalla made it a bit bigger, compilers are
+// not as eager to inline it, but in some cases, it makes a significant difference.
+// Let's encourage the compiler to inline sender all the way to frame::repair_sender_sp.
+// through frame::sender_for_compiled_frame.
 ALWAYSINLINE frame frame::sender(RegisterMap* map) const {
   frame result = sender_raw(map);
 

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -393,7 +393,7 @@ inline int frame::sender_sp_ret_address_offset() {
 //------------------------------------------------------------------------------
 // frame::sender
 
-inline frame frame::sender(RegisterMap* map) const {
+ALWAYSINLINE frame frame::sender(RegisterMap* map) const {
   frame result = sender_raw(map);
 
   if (map->process_frames() && !map->in_cont()) {
@@ -406,7 +406,7 @@ inline frame frame::sender(RegisterMap* map) const {
   return result;
 }
 
-inline frame frame::sender_raw(RegisterMap* map) const {
+ALWAYSINLINE frame frame::sender_raw(RegisterMap* map) const {
   // Default is we done have to follow them. The sender_for_xxx will
   // update it accordingly
   map->set_include_argument_oops(false);
@@ -427,7 +427,42 @@ inline frame frame::sender_raw(RegisterMap* map) const {
   return frame(sender_sp(), link(), sender_pc());
 }
 
-inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
+// Check for a method with scalarized inline type arguments that needs
+// a stack repair and return the repaired sender stack pointer.
+ALWAYSINLINE intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const {
+  nmethod* nm = _cb->as_nmethod_or_null();
+  if (nm != nullptr && nm->needs_stack_repair()) {
+    // The stack increment resides just below the saved rbp on the stack
+    // and does not account for the return address and rbp (see MacroAssembler::remove_frame).
+    intptr_t* real_frame_size_addr = (intptr_t*) (saved_fp_addr - 1);
+    int real_frame_size = (*real_frame_size_addr / wordSize) + metadata_words_at_bottom;
+    assert(real_frame_size >= _cb->frame_size() && real_frame_size <= 1000000, "invalid frame size");
+    sender_sp = unextended_sp() + real_frame_size;
+  }
+  return sender_sp;
+}
+
+
+// See comment in MacroAssembler::remove_frame
+ALWAYSINLINE frame::CompiledFramePointers frame::compiled_frame_details() const {
+  // frame owned by optimizing compiler
+  assert(_cb->frame_size() > 0, "must have non-zero frame size");
+  intptr_t* sender_sp = unextended_sp() + _cb->frame_size();
+  assert(sender_sp == real_fp(), "");
+
+  // Repair the sender sp if the frame has been extended
+  sender_sp = repair_sender_sp(sender_sp, (intptr_t**)(sender_sp - frame::sender_sp_offset));
+
+  CompiledFramePointers cfp;
+  cfp.sender_sp = sender_sp;
+  cfp.saved_fp_addr = (intptr_t**)(sender_sp - frame::sender_sp_offset);
+  // On Intel the return_address is always the word on the stack
+  cfp.sender_pc_addr = (address*)(sender_sp - frame::return_addr_offset);
+
+  return cfp;
+}
+
+ALWAYSINLINE frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   assert(map != nullptr, "map must be set");
   CompiledFramePointers cfp = compiled_frame_details();
 

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1062,6 +1062,10 @@ void ciEnv::register_method(ciMethod* target,
     assert(compiler->type() == compiler_c2 ||
            offsets->value(CodeOffsets::Exceptions) != -1, "must have exception entry");
 
+    bool needs_stack_repair =
+        (compiler->is_c1() && method()->c1_needs_stack_repair()) ||
+        (compiler->is_c2() && method()->c2_needs_stack_repair());
+
     nm =  nmethod::new_nmethod(method,
                                compile_id(),
                                entry_bci,
@@ -1071,7 +1075,7 @@ void ciEnv::register_method(ciMethod* target,
                                frame_words, oop_map_set,
                                handler_table, inc_table,
                                compiler, CompLevel(task()->comp_level()),
-                               nmethod::Flags(has_unsafe_access, has_wide_vectors, has_monitors, has_scoped_access));
+                               nmethod::Flags(has_unsafe_access, has_wide_vectors, has_monitors, has_scoped_access, needs_stack_repair));
 
     // Free codeBlobs
     code_buffer->free_blob();

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -259,17 +259,19 @@ public:
 
     enum : uint8_t {
       UNSAFE_ACCESS = 1 << 0,
-      WIDE_VECTORS  = 1 << 1,
-      MONITORS      = 1 << 2,
-      SCOPED_ACCESS = 1 << 3
+      WIDE_VECTORS = 1 << 1,
+      MONITORS = 1 << 2,
+      SCOPED_ACCESS = 1 << 3,
+      NEEDS_STACK_REPAIR = 1 << 4,
     };
 
     Flags() : _bits(0) {}
-    Flags(bool has_unsafe_access, bool has_wide_vectors, bool has_monitors, bool has_scoped_access) :
+    Flags(bool has_unsafe_access, bool has_wide_vectors, bool has_monitors, bool has_scoped_access, bool needs_stack_repair) :
       _bits((has_unsafe_access ? UNSAFE_ACCESS : 0) |
-            (has_wide_vectors  ? WIDE_VECTORS  : 0) |
-            (has_monitors      ? MONITORS      : 0) |
-            (has_scoped_access ? SCOPED_ACCESS : 0))
+            (has_wide_vectors ? WIDE_VECTORS : 0) |
+            (has_monitors ? MONITORS : 0) |
+            (has_scoped_access ? SCOPED_ACCESS : 0) |
+            (needs_stack_repair ? NEEDS_STACK_REPAIR : 0))
     {}
 
     // May fault due to unsafe access
@@ -283,6 +285,9 @@ public:
 
     // Used by shared scope closure (scopedMemoryAccess.cpp)
     bool has_scoped_access() const { return (_bits & SCOPED_ACCESS) != 0; }
+
+    // Used by shared scope closure (scopedMemoryAccess.cpp)
+    bool needs_stack_repair() const { return (_bits & NEEDS_STACK_REPAIR) != 0; }
   };
 
 private:
@@ -739,16 +744,7 @@ public:
   bool  has_monitors() const                      { return _flags.has_monitors(); }
   bool  has_scoped_access() const                 { return _flags.has_scoped_access(); }
   bool  has_wide_vectors() const                  { return _flags.has_wide_vectors(); }
-
-  bool  needs_stack_repair() const {
-    if (is_compiled_by_c1()) {
-      return method()->c1_needs_stack_repair();
-    } else if (is_compiled_by_c2()) {
-      return method()->c2_needs_stack_repair();
-    } else {
-      return false;
-    }
-  }
+  bool  needs_stack_repair() const                { return _flags.needs_stack_repair(); }
 
   bool  has_flushed_dependencies() const          { return _has_flushed_dependencies; }
   void  set_has_flushed_dependencies(bool z)      {

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -286,7 +286,7 @@ public:
     // Used by shared scope closure (scopedMemoryAccess.cpp)
     bool has_scoped_access() const { return (_bits & SCOPED_ACCESS) != 0; }
 
-    // Used by shared scope closure (scopedMemoryAccess.cpp)
+    // Stack has been extended and needs reair. See comment in MacroAssembler::remove_frame
     bool needs_stack_repair() const { return (_bits & NEEDS_STACK_REPAIR) != 0; }
   };
 

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -286,7 +286,7 @@ public:
     // Used by shared scope closure (scopedMemoryAccess.cpp)
     bool has_scoped_access() const { return (_bits & SCOPED_ACCESS) != 0; }
 
-    // Stack has been extended and needs reair. See comment in MacroAssembler::remove_frame
+    // Stack has been extended and needs repair. See comment in MacroAssembler::remove_frame
     bool needs_stack_repair() const { return (_bits & NEEDS_STACK_REPAIR) != 0; }
   };
 

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -226,7 +226,7 @@ class frame {
   inline void interpreted_frame_oop_map(InterpreterOopMap* mask) const;
 
   // returns the sending frame
-  inline frame sender(RegisterMap* map) const;
+  ALWAYSINLINE frame sender(RegisterMap* map) const;
 
   bool safe_for_sender(JavaThread *thread);
 
@@ -239,7 +239,7 @@ class frame {
 
  private:
   // Helper methods for better factored code in frame::sender
-  inline frame sender_for_compiled_frame(RegisterMap* map) const;
+  ALWAYSINLINE frame sender_for_compiled_frame(RegisterMap* map) const;
   frame sender_for_entry_frame(RegisterMap* map) const;
   frame sender_for_interpreter_frame(RegisterMap* map) const;
   frame sender_for_upcall_stub_frame(RegisterMap* map) const;

--- a/test/hotspot/jtreg/compiler/exceptions/TestStackWalkPerf.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestStackWalkPerf.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8389130
+ * @summary With Valhalla, frame::sender became a bit too big and is not as spontaneously inlined as before.
+ *          This causes some measurable performance regressions in cases where walking the stack is frequent.
+ * @run main/othervm -Xbatch
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::fillInStackTrace
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+package compiler.exceptions;
+
+public class TestStackWalkPerf extends Throwable {
+    private static final TestStackWalkPerf PROBE = new TestStackWalkPerf();
+
+    private static void fillInStackTrace(int depth, int fills) {
+        if (depth == 0) {
+            for (int i = 0; i < fills; i++) {
+                PROBE.fillInStackTrace();
+            }
+            return;
+        }
+        fillInStackTrace(depth - 1, fills);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            fillInStackTrace(512, 1);
+        }
+        fillInStackTrace(512, 1_000_000);
+    }
+}


### PR DESCRIPTION
The problem is that Valhalla made `frame::sender` a tiny bit bigger, but it is enough for gcc to decide not to inline it anymore. And then, functions such as `void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHandle& method, TRAPS)` have a call, instead of having it inlined all the way to `intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const`. While there are a lot of paths, and its job is a bit subtle `frame frame::sender_for_compiled_frame(RegisterMap* map) const` is mostly doing rather basic arithmetic: a call can easily create some slowdown, Especially in cases where walking the stack is on a hot path.

So, to address this, I propose a 2-part solution: trying to shrink the size of `sender`, and marking it as `ALWAYS_INLINE`. To shrink the size, I cache whether the method needs stack repairs in its flags rather than recomputing it, since it is a constant. It doesn't seem to make it as small as the mainline version, but quite closer. This change is not satisfactory by itself because, even if it were enough to reenable inlining (which it is not), we are so clone from the inlining threshold that the least change in the future could make it bad again. Since we know we are not far from inlining, force inlining the method cannot be too bad.

It is to note that because it is about codesize and inlining problem, the performance issue appear without `--enable-preview`. Trying to branch on that just makes the code bigger and the problem worse.

Valhalla:
```
Time (mean ± σ):      9.429 s ±  0.098 s    [User: 9.274 s, System: 0.171 s]
Range (min … max):    9.246 s …  9.548 s    10 runs
```
Mainline:
```
Time (mean ± σ):      7.957 s ±  0.082 s    [User: 7.817 s, System: 0.152 s]
Range (min … max):    7.778 s …  8.051 s    10 runs
```
This PR:
```
Time (mean ± σ):      8.107 s ±  0.077 s    [User: 7.943 s, System: 0.183 s]
Range (min … max):    7.967 s …  8.218 s    10 runs
```
We can see the changes for the performances of mainline and this PR overlap. There is still a gap, but of 0.15s, that is about 2% instead of 18.5%. It seems the rest of the slowdown is mostly happening during startup.

For comparison, here are the timing for the given test, with only the flag fix, without forcing inlining:
```
Time (mean ± σ):      9.326 s ±  0.075 s    [User: 9.164 s, System: 0.179 s]
Range (min … max):    9.188 s …  9.422 s    10 runs
```
That is only marginally (but consistently) better than Valhalla's current state, but clearly not good enough.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8389130](https://bugs.openjdk.org/browse/JDK-8389130): [lworld] Compiled frame walking is slow due to scalarized calling convention handling (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [838c5283](https://git.openjdk.org/valhalla/pull/2687/files/838c5283bb904fdb0ae033df79bcfff56cc4c2ef)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/2687/head:pull/2687` \
`$ git checkout pull/2687`

Update a local copy of the PR: \
`$ git checkout pull/2687` \
`$ git pull https://git.openjdk.org/valhalla.git pull/2687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2687`

View PR using the GUI difftool: \
`$ git pr show -t 2687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/2687.diff">https://git.openjdk.org/valhalla/pull/2687.diff</a>

</details>
